### PR TITLE
CS-4607: Dockerize and get file contents from the MCP client as text instead of reading files on disk

### DIFF
--- a/.github/actions/docker-setup/action.yml
+++ b/.github/actions/docker-setup/action.yml
@@ -1,0 +1,27 @@
+name: 'Docker Setup'
+description: 'Used to perform common setup steps for docker builds'
+inputs:
+  DOCKER_USERNAME:
+    description: 'DOCKER_USERNAME'
+    required: false
+  DOCKER_PASSWORD:
+    description: 'DOCKER_PASSWORD'
+    required: false
+runs:
+  using: "composite"
+  steps:
+    # Configure credentials
+    # It seems like this must be done before the setup-buildx-action in order to not mess up the config for buildx
+    - uses: docker/login-action@v3
+      if: "${{ inputs.DOCKER_USERNAME != '' }}"
+      with:
+        username: ${{ inputs.DOCKER_USERNAME }}
+        password: ${{ inputs.DOCKER_PASSWORD }}
+    # This step is required in order to use buildx provided by Docker. More on this here: https://github.com/docker/setup-buildx-action
+    # and here: https://betterprogramming.pub/build-and-deploy-multi-architecture-graviton-container-images-for-spring-boot-microservices-f220d66cb3e3
+    - name: Set up QEMU dependency
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: arm64, amd64 # By default QEMU will create almost a dozen vm’s. Limit it to just the architectures we care about.
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,7 @@ env:
   DOCKERHUB_CACHE_REPO: codescene/codescene-unstable
   
 jobs:
-build-docker:
+  build-docker:
     strategy:
       matrix:
         runner: [ubuntu-24.04-4core, arm64-ubuntu-24.04-4core]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,53 @@
+name: Build and Publish Release
+
+on: 
+  push:
+    tags:
+      - 'MCP-[0-9]+.[0-9]+.[0-9]+'
+      - 'MCP-[0-9]+.[0-9]+.[0-9]+-*'
+
+# permissions needed for assuming the IAM role below: https://github.com/aws-actions/configure-aws-credentials/issues/271#issuecomment-931012696
+permissions:
+  contents: read # This is required for actions/checkout
+  id-token: write # This is required for requesting the JWT
+
+env:
+  DOCKERHUB_REPO: codescene/codescene
+  DOCKERHUB_CACHE_REPO: codescene/codescene-unstable
+  
+jobs:
+build-docker:
+    strategy:
+      matrix:
+        runner: [ubuntu-24.04-4core, arm64-ubuntu-24.04-4core]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      # Checkout source code and setup
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Docker setup
+        uses: ./.github/actions/docker-setup
+        with:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Build steps
+      - name: Prepare
+        run: |
+          if [ "aarch64" == $(uname -m) ]; then
+            platform=linux/arm64
+          else
+            platform=linux/amd64
+          fi
+          echo "PLATFORM=${platform}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Build and push by digest
+        id: docker-build
+        uses: docker/build-push-action@v6
+        with:
+          context: codescene-mcp
+          platforms: ${{ env.PLATFORM }}
+          cache-from: type=registry,ref=${{ env.DOCKERHUB_CACHE_REPO }}:cache-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,"name=${{ env.DOCKERHUB_REPO }}",push-by-digest=true,name-canonical=true,push=true

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,13 +13,12 @@ permissions:
 
 env:
   DOCKERHUB_REPO: codescene/codescene
-  DOCKERHUB_CACHE_REPO: codescene/codescene-unstable
   
 jobs:
   build-docker:
     strategy:
       matrix:
-        runner: [ubuntu-24.04-4core, arm64-ubuntu-24.04-4core]
+        runner: [ubuntu-24.04, arm64-ubuntu-24.04]
     runs-on: ${{ matrix.runner }}
     steps:
       # Checkout source code and setup
@@ -49,5 +48,4 @@ jobs:
         with:
           context: codescene-mcp
           platforms: ${{ env.PLATFORM }}
-          cache-from: type=registry,ref=${{ env.DOCKERHUB_CACHE_REPO }}:cache-${{ env.PLATFORM_PAIR }}
           outputs: type=image,"name=${{ env.DOCKERHUB_REPO }}",push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.13
+WORKDIR /app
+COPY src/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+RUN curl https://downloads.codescene.io/enterprise/cli/install-cs-tool.sh | bash -s -- -y
+COPY . .
+ENV PATH="/root/.local/bin:${PATH}"
+CMD [ "python", "src/cs_mcp_server.py" ]

--- a/README.md
+++ b/README.md
@@ -22,3 +22,27 @@ The Code Health tools solve this by giving AI assistants precise insight into de
 ### Understand Existing Code Before Acting
 Use Code Health reviews to inform AI-driven summaries, diagnostics, or code transformations based on **real-world cognitive and design challenges**, not just syntax.
 
+## Running the docker instance
+
+You can run the dockerized CodeScene MCP server by first cloning the repo and then building the Docker image:
+
+```sh
+docker build -t codescene-mcp .
+```
+
+And then configuring the MCP in your editor, for example in VS Code:
+
+```json
+"codescene-mcp": {
+    "type": "stdio",
+    "command": "docker",
+    "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "CS_ACCESS_TOKEN",
+        "codescene-mcp"
+    ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -46,3 +46,29 @@ And then configuring the MCP in your editor, for example in VS Code:
     ]
 }
 ```
+
+This configuration will automatically pick up the `CS_ACCESS_TOKEN` environment variable, but if you can't create a system-wide one then you can manually specify it like this:
+
+```json
+"codescene-mcp": {
+    "type": "stdio",
+    "command": "docker",
+    "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "CS_ACCESS_TOKEN",
+        "codescene-mcp"
+    ],
+    "env": {
+		"CS_ACCESS_TOKEN": "token-goes-here",
+    }
+}
+```
+
+Or when running it from the CLI, like this:
+
+```sh
+docker run -i --rm -e CS_ACCESS_TOKEN=token-goes-here codescene-mcp
+```

--- a/src/cs_mcp_server.py
+++ b/src/cs_mcp_server.py
@@ -31,11 +31,11 @@ def code_health_from(cli_output) -> float:
     r = json.loads(cli_output)
     return r['score']
 
-def analyze_code(file_content: str, file_type: str) -> str:
+def analyze_code(file_content: str, file_ext: str) -> str:
     local_file = None
 
     try:
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=file_type, encoding='utf-8') as tmp:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=file_ext, encoding='utf-8') as tmp:
             tmp.write(file_content)
             local_file = tmp.name
 
@@ -62,65 +62,42 @@ def run_cs_cli(cli_fn) -> str:
         return f"Error: {e.stderr}"
     except Exception as e:
         return f"Error: {e}"
-    
-def file_type_from(file_path: str) -> str:
-    _, file_extension = os.path.splitext(file_path)
-
-    return file_extension
 
 @mcp.tool()
-def code_health_score(opts: dict) -> str:
+def code_health_score(file_content: str, file_ext: str) -> str:
     """
     Calculates the code quality of the given file using the Code Health metric.
     Returns a score from 10.0 (best) down to 1.0 (worst).
     Args:
-        opts: A dictionary containing "file_content" and "file_path".
-            - file_content: The content of the source code file to be analyzed.
-            - file_path: The absolute path to the source code file to be reviewed.
+        file_content: The content of the source code file to be analyzed.
+        file_ext: The file extension of the source code file to be reviewed (e.g. .py, .java).
     Returns:
         A string representing the Code Health score, 10.0->1.0
     """
-    file_content = opts.get("file_content")
-    file_path = opts.get("file_path")
-
-    if not file_content or not file_path:
-        return "Error: Missing required arguments 'file_content' and 'file_path'."
-    
-    file_type = file_type_from(file_path)
-    
-    def calculate_code_health_of(file_content: str, file_type: str) -> float:
-        result = analyze_code(file_content, file_type)
+    def calculate_code_health_of(file_content: str, file_ext: str) -> float:
+        result = analyze_code(file_content, file_ext)
         return code_health_from(result)
     
-    return run_cs_cli(lambda: f"Code Health score: {calculate_code_health_of(file_content, file_type)}")
+    return run_cs_cli(lambda: f"Code Health score: {calculate_code_health_of(file_content, file_ext)}")
 
 @mcp.tool()
-def code_health_review(opts: dict) -> str:
+def code_health_review(file_content: str, file_ext: str) -> str:
     """
     Performs a Code Health review of the given file_path and returns 
     a JSON object specifying all potential code smells that contribute 
     to a lower Code Health.
     Args:
-        opts: A dictionary containing "file_content" and "file_path".
-            - file_content: The content of the source code file to be analyzed.
-            - file_path: The absolute path to the source code file to be reviewed.
+        file_content: The content of the source code file to be analyzed.
+        file_ext: The file extension of the source code file to be reviewed (e.g. .py, .java).
     Returns:
         A JSON object containing score and review:
          - score: this is the Code Health score. 10.0 is best, 1.0 is worst health.
          - review: an array of category and description for each code smell.
     """
-    file_content = opts.get("file_content")
-    file_path = opts.get("file_path")
-
-    if not file_content or not file_path:
-        return "Error: Missing required arguments 'file_content' and 'file_path'."
+    def review_code_health_of(file_content: str, file_ext: str) -> float:
+        return analyze_code(file_content, file_ext)
     
-    file_type = file_type_from(file_path)
-    
-    def review_code_health_of(file_content: str, file_type: str) -> float:
-        return analyze_code(file_content, file_type)
-    
-    return run_cs_cli(lambda: review_code_health_of(file_content, file_type))
+    return run_cs_cli(lambda: review_code_health_of(file_content, file_ext))
     
 if __name__ == "__main__":
     mcp.run()

--- a/src/cs_mcp_server.py
+++ b/src/cs_mcp_server.py
@@ -1,6 +1,8 @@
 import subprocess
 from fastmcp import FastMCP
 import json
+import tempfile
+import os
 
 mcp = FastMCP("CodeScene")
 
@@ -29,7 +31,21 @@ def code_health_from(cli_output) -> float:
     r = json.loads(cli_output)
     return r['score']
 
-def cs_cli_review_command_for(local_file):
+def analyze_code(file_content: str, file_type: str) -> str:
+    local_file = None
+
+    try:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix=file_type, encoding='utf-8') as tmp:
+            tmp.write(file_content)
+            local_file = tmp.name
+
+        return run_local_tool(cs_cli_review_command_for(local_file))
+    
+    finally:
+        if local_file and os.path.exists(local_file):
+            os.remove(local_file)
+
+def cs_cli_review_command_for(local_file: str):
     cs_cli = 'cs' # needs to be installed locally
     return [cs_cli, "review", local_file, "--output-format=json"]
 
@@ -46,40 +62,65 @@ def run_cs_cli(cli_fn) -> str:
         return f"Error: {e.stderr}"
     except Exception as e:
         return f"Error: {e}"
+    
+def file_type_from(file_path: str) -> str:
+    _, file_extension = os.path.splitext(file_path)
+
+    return file_extension
 
 @mcp.tool()
-def code_health_score(file_path: str) -> str:
+def code_health_score(opts: dict) -> str:
     """
     Calculates the code quality of the given file using the Code Health metric.
     Returns a score from 10.0 (best) down to 1.0 (worst).
     Args:
-        file_path: The absolute path to the source code file to be reviewed.
+        opts: A dictionary containing "file_content" and "file_path".
+            - file_content: The content of the source code file to be analyzed.
+            - file_path: The absolute path to the source code file to be reviewed.
     Returns:
         A string representing the Code Health score, 10.0->1.0
     """
-    def calculate_code_health_of(local_file: str) -> float:
-        result = run_local_tool(cs_cli_review_command_for(local_file))
+    file_content = opts.get("file_content")
+    file_path = opts.get("file_path")
+
+    if not file_content or not file_path:
+        return "Error: Missing required arguments 'file_content' and 'file_path'."
+    
+    file_type = file_type_from(file_path)
+    
+    def calculate_code_health_of(file_content: str, file_type: str) -> float:
+        result = analyze_code(file_content, file_type)
         return code_health_from(result)
     
-    return run_cs_cli(lambda: f"Code Health score: {calculate_code_health_of(file_path)}")
+    return run_cs_cli(lambda: f"Code Health score: {calculate_code_health_of(file_content, file_type)}")
 
 @mcp.tool()
-def code_health_review(file_path: str) -> str:
+def code_health_review(opts: dict) -> str:
     """
     Performs a Code Health review of the given file_path and returns 
     a JSON object specifying all potential code smells that contribute 
     to a lower Code Health.
     Args:
-        file_path: The absolute path to the source code file to be reviewed.
+        opts: A dictionary containing "file_content" and "file_path".
+            - file_content: The content of the source code file to be analyzed.
+            - file_path: The absolute path to the source code file to be reviewed.
     Returns:
         A JSON object containing score and review:
          - score: this is the Code Health score. 10.0 is best, 1.0 is worst health.
          - review: an array of category and description for each code smell.
     """
-    def review_code_health_of(local_file: str) -> float:
-        return run_local_tool(cs_cli_review_command_for(local_file))
+    file_content = opts.get("file_content")
+    file_path = opts.get("file_path")
+
+    if not file_content or not file_path:
+        return "Error: Missing required arguments 'file_content' and 'file_path'."
     
-    return run_cs_cli(lambda: review_code_health_of(file_path))
+    file_type = file_type_from(file_path)
+    
+    def review_code_health_of(file_content: str, file_type: str) -> float:
+        return analyze_code(file_content, file_type)
+    
+    return run_cs_cli(lambda: review_code_health_of(file_content, file_type))
     
 if __name__ == "__main__":
     mcp.run()

--- a/src/test_cs_mcp_server.py
+++ b/src/test_cs_mcp_server.py
@@ -27,6 +27,10 @@ class TestCodeSceneMCP(unittest.IsolatedAsyncioTestCase):
     def setUpClass(cls):
         cls.file_to_review = "./src/test_data/OrderProcessor.java"
 
+        with open(cls.file_to_review, 'r') as f:
+            cls.file_content = f.read()
+            cls.file_ext = '.java'
+
     async def test_ping(self):
         async with mcp_client() as c:
             ponged = await c.ping()
@@ -41,7 +45,8 @@ class TestCodeSceneMCP(unittest.IsolatedAsyncioTestCase):
     async def test_code_health_score(self):
         async with mcp_client() as c:
             result = await c.call_tool("code_health_score", {
-                "file_path": self.file_to_review
+                "file_content": self.file_content,
+                "file_ext": self.file_ext
             })
             code_health_response = result.data
             self.assertIn('Code Health score: 8.65', code_health_response)
@@ -49,7 +54,8 @@ class TestCodeSceneMCP(unittest.IsolatedAsyncioTestCase):
     async def test_code_health_review(self):
         async with mcp_client() as c:
             result = await c.call_tool("code_health_review", {
-                "file_path": self.file_to_review
+                "file_content": self.file_content,
+                "file_ext": self.file_ext
             })
             review = json.loads(result.data)
             


### PR DESCRIPTION
This adds a `Dockerfile` which makes the MCP server run as a self-contained instance, as well as changes the MCP server implementation in such a way that we no longer rely on files on disk, but rather get the file contents and related required information as JSON directly from the MCP client.