### PR TITLE
Document how to get access to the CS_ACCESS_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Create a `.kiro/settings/mcp.json` file in your workspace directory (or edit if 
 
 </details>
 
+### Get a CS_ACCESS_TOKEN for the MCP Server
+
+The MCP server configuration requires a `CS_ACCESS_TOKEN` which you get via your CodeScene instance. (The token grants access to the code health analysis capability).
+* For CodeScene Cloud you create the token [here](https://codescene.io/users/me/pat).
+* In CodeScene on-prem, you get the token via `https://<your-cs-host><:port>/configuration/user/token`.
+
 ## Use Cases
 
 > [!TIP]


### PR DESCRIPTION
While the MCP server is free to download, you do need a CodeScene account to use it. The CS_ACCESS_TOKEN controls that, and is a mandatory config input to the MCP.