### PR TITLE
CS-4607: Use locally mounted directories instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,16 @@ The Code Health insights augment the AI prompts with rich content around code qu
 To connect with CodeScene Cloud:
 
 ```sh
-claude mcp add codescene --env CS_ACCESS_TOKEN=<token> -- docker run -i --rm -e CS_ACCESS_TOKEN codescene/codescene-mcp
+claude mcp add codescene --env CS_ACCESS_TOKEN=<token> -- docker run -i --rm -e CS_ACCESS_TOKEN -e CS_MOUNT_PATH=<PATH_TO_CODE> --mount type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro codescene/codescene-mcp
 ```
 
 To connect with CodeScene On-prem:
 
 ```sh
-claude mcp add codescene --env CS_ACCESS_TOKEN=<token> --env CS_ONPREM_URL=<url> -- docker run -i --rm -e CS_ACCESS_TOKEN -e CS_ONPREM_URL codescene/codescene-mcp
+claude mcp add codescene --env CS_ACCESS_TOKEN=<token> --env CS_ONPREM_URL=<url> -- docker run -i --rm -e CS_ACCESS_TOKEN -e CS_ONPREM_URL -e CS_MOUNT_PATH=<PATH_TO_CODE> --mount type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro codescene/codescene-mcp
 ```
+
+Make sure to replace the `<PATH_TO_CODE>` with the absolute path to the directory whose read-only access you want the CodeScene MCP server to have.
 
 </details>
 
@@ -43,7 +45,7 @@ CodeScene Cloud:
 ```toml
 [mcp_servers.codescene]
 command = "docker"
-args = ["run", "--rm", "-i", "-e", "CS_ACCESS_TOKEN", "codescene/codescene-mcp"]
+args = ["run", "--rm", "-i", "-e", "CS_ACCESS_TOKEN", "-e", "CS_MOUNT_PATH=<PATH_TO_CODE>", "--mount", "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro", "codescene/codescene-mcp"]
 env = { "CS_ACCESS_TOKEN" = "<YOUR_ACCESS_TOKEN>" }
 ```
 
@@ -52,9 +54,11 @@ CodeScene On-prem:
 ```toml
 [mcp_servers.codescene]
 command = "docker"
-args = ["run", "--rm", "-i", "-e", "CS_ACCESS_TOKEN", "-e", "CS_ONPREM_URL", "codescene/codescene-mcp"]
+args = ["run", "--rm", "-i", "-e", "CS_ACCESS_TOKEN", "-e", "CS_ONPREM_URL", "-e", "CS_MOUNT_PATH=<PATH_TO_CODE>", "--mount", "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro", "codescene/codescene-mcp"]
 env = { "CS_ACCESS_TOKEN" = "<YOUR_ACCESS_TOKEN>", "CS_ONPREM_URL" = "<URL>" }
 ```
+
+Make sure to replace the `<PATH_TO_CODE>` with the absolute path to the directory whose read-only access you want the CodeScene MCP server to have.
 
 </details>
 
@@ -75,14 +79,16 @@ CodeScene Cloud:
 - Server Name: `codescene`
 - Server Type: `Local (Press 1)`
 - Command: `docker`
-- Arguments: `run, --rm, -i, -e, CS_ACCESS_TOKEN, codescene/codescene-mcp`
+- Arguments: `run, --rm, -i, -e, CS_ACCESS_TOKEN, -e, CS_MOUNT_PATH=<PATH_TO_CODE>, --mount, "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro", codescene/codescene-mcp`
 
 CodeScene On-prem:
 
 - Server Name: `codescene`
 - Server Type: `Local (Press 1)`
 - Command: `docker`
-- Arguments: `run, --rm, -i, -e, CS_ACCESS_TOKEN, -e, CS_ONPREM_URL, codescene/codescene-mcp`
+- Arguments: `run, --rm, -i, -e, CS_ACCESS_TOKEN, -e, CS_ONPREM_URL, -e, CS_MOUNT_PATH=<PATH_TO_CODE>, --mount, "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro", codescene/codescene-mcp`
+
+Make sure to replace the `<PATH_TO_CODE>` with the absolute path to the directory whose read-only access you want the CodeScene MCP server to have.
 
 </details>
 
@@ -110,10 +116,15 @@ CodeScene Cloud:
         "-i",
         "-e",
         "CS_ACCESS_TOKEN=$CS_ACCESS_TOKEN",
+        "-e",
+        "CS_MOUNT_PATH=$CS_MOUNT_PATH",
+        "--mount",
+				"type=bind,src=$CS_MOUNT_PATH,dst=/mount/,ro",
         "codescene/codescene-mcp"
       ],
       "env": {
-        "CS_ACCESS_TOKEN": "COPILOT_MCP_CS_ACCESS_TOKEN"
+        "CS_ACCESS_TOKEN": "COPILOT_MCP_CS_ACCESS_TOKEN",
+        "CS_MOUNT_PATH": "COPILOT_MCP_CS_MOUNT_PATH"
       },
       "tools": ["*"]
     }
@@ -137,11 +148,16 @@ CodeScene On-prem:
         "CS_ACCESS_TOKEN=$CS_ACCESS_TOKEN",
         "-e",
         "CS_ONPREM_URL=$CS_ONPREM_URL",
+        "-e",
+        "CS_MOUNT_PATH=$CS_MOUNT_PATH",
+        "--mount",
+				"type=bind,src=$CS_MOUNT_PATH,dst=/mount/,ro",
         "codescene/codescene-mcp"
       ],
       "env": {
         "CS_ACCESS_TOKEN": "COPILOT_MCP_CS_ACCESS_TOKEN",
-        "CS_ONPREM_URL": "COPILOT_MCP_CS_ONPREM_URL"
+        "CS_ONPREM_URL": "COPILOT_MCP_CS_ONPREM_URL",
+        "CS_MOUNT_PATH": "COPILOT_MCP_CS_MOUNT_PATH"
       },
       "tools": ["*"]
     }
@@ -170,10 +186,14 @@ CodeScene Cloud:
         "--rm",
         "-e", 
         "CS_ACCESS_TOKEN",
+        "-e",
+        "CS_MOUNT_PATH=<PATH_TO_CODE>",
+        "--mount",
+				"type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro",
         "codescene/codescene-mcp"
       ],
       "env": {
-        "CS_ACCESS_TOKEEN": "<YOUR_TOKEN>",
+        "CS_ACCESS_TOKEN": "<YOUR_TOKEN>",
       },
       "disabled": false,
       "autoApprove": []
@@ -197,10 +217,14 @@ CodeScene On-prem:
         "CS_ACCESS_TOKEN",
         "-e",
         "CS_ONPREM_URL",
+        "-e",
+        "CS_MOUNT_PATH=<PATH_TO_CODE>",
+        "--mount",
+				"type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro",
         "codescene/codescene-mcp"
       ],
       "env": {
-        "CS_ACCESS_TOKEEN": "<YOUR_TOKEN>",
+        "CS_ACCESS_TOKEN": "<YOUR_TOKEN>",
         "CS_ONPREM_URL": "<URL>"
       },
       "disabled": false,
@@ -210,15 +234,17 @@ CodeScene On-prem:
 }
 ```
 
+Make sure to replace the `<PATH_TO_CODE>` with the absolute path to the directory whose read-only access you want the CodeScene MCP server to have.
+
 </details>
 
 <details>
 
 **<summary>VS Code</summary>**
 
-[![Install CodeScene MCP for Cloud](https://img.shields.io/badge/VS_Code-Install_CodeScene_MCP_for_Cloud-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=codescene&inputs=[{%22id%22:%22CS_ACCESS_TOKEN%22,%22type%22:%22promptString%22,%22description%22:%22CodeScene%20Access%20Token%22,%22password%22:true}]&config={%22command%22:%22docker%22,%22args%22:[%22run%22,%22-i%22,%22--rm%22,%22-e%22,%22CS_ACCESS_TOKEN%22,%22codescene/codescene-mcp%22],%22env%22:{%22CS_ACCESS_TOKEN%22:%22${input:CS_ACCESS_TOKEN}%22}})
+[![Install CodeScene MCP for Cloud](https://img.shields.io/badge/VS_Code-Install_CodeScene_MCP_for_Cloud-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=codescene&inputs=[%7B%22id%22%3A%22CS_MOUNT_PATH%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Path%20of%20the%20directory%20that%20CodeScene%20should%20be%20able%20to%20see.%22%2C%22password%22%3Afalse%7D%2C%7B%22id%22%3A%22CS_ACCESS_TOKEN%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22CodeScene%20Access%20Token%22%2C%22password%22%3Atrue%7D]&config={%22command%22%3A%22docker%22%2C%22args%22%3A[%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22CS_ACCESS_TOKEN%22%2C%22-e%22%2C%22CS_MOUNT_PATH%3D%24%7Binput%3ACS_MOUNT_PATH%7D%22%2C%22--mount%22%2C%22type%3Dbind%2Csrc%3D%24%7Binput%3ACS_MOUNT_PATH%7D%2Cdst%3D/mount/%2Cro%22%2C%22codescene/codescene-mcp%22]%2C%22env%22%3A%7B%22CS_ACCESS_TOKEN%22%3A%22%24%7Binput%3ACS_ACCESS_TOKEN%7D%22%7D%2C%22type%22%3A%22stdio%22})
 
-[![Install CodeScene MCP for On-prem](https://img.shields.io/badge/VS_Code-Install_CodeScene_MCP_for_Onprem-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=codescene&inputs=[{%22id%22:%22CS_ACCESS_TOKEN%22,%22type%22:%22promptString%22,%22description%22:%22CodeScene%20Access%20Token%22,%22password%22:true},%20{%22id%22:%22CS_ONPREM_URL%22,%22type%22:%22promptString%22,%22description%22:%22CodeScene%20On-prem%20URL%22,%22password%22:false}]&config={%22command%22:%22docker%22,%22args%22:[%22run%22,%22-i%22,%22--rm%22,%22-e%22,%22CS_ACCESS_TOKEN%22,%20%22-e%22,%20%22CS_ONPREM_URL%22,%22codescene/codescene-mcp%22],%22env%22:{%22CS_ACCESS_TOKEN%22:%22${input:CS_ACCESS_TOKEN}%22,%20%22CS_ONPREM_URL%22:%22${input:CS_ONPREM_URL}%22}})
+[![Install CodeScene MCP for On-prem](https://img.shields.io/badge/VS_Code-Install_CodeScene_MCP_for_Onprem-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=codescene&inputs=[%7B%22id%22%3A%22CS_MOUNT_PATH%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22Path%20of%20the%20directory%20that%20CodeScene%20should%20be%20able%20to%20see.%22%2C%22password%22%3Afalse%7D%2C%7B%22id%22%3A%22CS_ACCESS_TOKEN%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22CodeScene%20Access%20Token%22%2C%22password%22%3Atrue%7D%2C%7B%22id%22%3A%22CS_ONPREM_URL%22%2C%22type%22%3A%22promptString%22%2C%22description%22%3A%22CodeScene%20On-prem%20URL%22%2C%22password%22%3Afalse%7D]&config={%22command%22%3A%22docker%22%2C%22args%22%3A[%22run%22%2C%22-i%22%2C%22--rm%22%2C%22-e%22%2C%22CS_ACCESS_TOKEN%22%2C%22-e%22%2C%22CS_ONPREM_URL%22%2C%22-e%22%2C%22CS_MOUNT_PATH%3D%24%7Binput%3ACS_MOUNT_PATH%7D%22%2C%22--mount%22%2C%22type%3Dbind%2Csrc%3D%24%7Binput%3ACS_MOUNT_PATH%7D%2Cdst%3D/mount/%2Cro%22%2C%22codescene/codescene-mcp%22]%2C%22env%22%3A%7B%22CS_ACCESS_TOKEN%22%3A%22%24%7Binput%3ACS_ACCESS_TOKEN%7D%22%2C%22CS_ONPREM_URL%22%3A%22%24%7Binput%3ACS_ONPREM_URL%7D%22%7D%2C%22type%22%3A%22stdio%22})
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ docker run -i --rm -e CS_ACCESS_TOKEN=token-goes-here codescene-mcp
 
 <details>
 
+**<summary>I have multiple repos — how do I configure the MCP?</summary>**
+
+Since you have to provide a mount path for Docker, you can either have a MCP configuration per project (in VS Code that would be a `.vscode/mcp.json` file per project, for example) or you can mount a root directory within which all your projects are and then just use that one configuration instead.
+
+<details>
+
 **<summary>Why are we mounting a directory in the Docker?</summary>**
 
 Previously we had the MCP client pass the entire file contents to us in a JSON object, but with this we ran into a problem where if the file contents exceed your AI model's input or output token limit, we'd either get no data or incorrect data. 

--- a/README.md
+++ b/README.md
@@ -323,3 +323,29 @@ docker run -i --rm -e CS_ACCESS_TOKEN=token-goes-here codescene-mcp
 ```
 
 **Note:** if you want to use CodeScene On-prem, you need to additionally pass the `CS_ONPREM_URL` environment variable to it.
+
+## Frequently Asked Questions
+
+<details>
+
+**<summary>Why are we mounting a directory in the Docker?</summary>**
+
+Previously we had the MCP client pass the entire file contents to us in a JSON object, but with this we ran into a problem where if the file contents exceed your AI model's input or output token limit, we'd either get no data or incorrect data. 
+
+While this might work for small files and code snippets, we want to provide a solution that works on any file, no matter the size, and we achieve this by having the MCP client return a file path to us which we then read ourselves, thus bypassing the AI token limit issue entirely.
+
+To make this safe, we have you, the user, specify which path our MCP server should have access to. In addition, all the configuration examples provided in this README feature a mounting command that only gives read-only access to the mounted path, so we can't do anything to those files other than read them.
+
+In addition this now saves your AI budget by not spending precious tokens on file reading, which can add up pretty quickly.
+
+</details>
+
+<details>
+
+**<summary>Why do we specify `CS_MOUNT_PATH` twice?</summary>**
+
+Due to the limitation of not knowing the relative path to the file from within Docker, in order to read the correct file we need to know the full absolute path to your mounted directory, so that we could deduce a relative path to the internally mounted file by simply taking the absolute path to the file, the absolute path to the mounted directory, and replacing the mounted directory part with our internal mounted directory. 
+
+We pass the absolute path to the mounted directory to us via a environment variable `-e CS_MOUNT_PATH=<PATH>` so that we would know the absolute path, jand then we need to pass that path again the second time via `--mount type=bind,src=<PATH>,dst=/mount/,ro` which then instructs Docker to actually mount `<PATH>` to our internal `/mount/` directory.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Previously we had the MCP client pass the entire file contents to us in a JSON o
 
 While this might work for small files and code snippets, we want to provide a solution that works on any file, no matter the size, and we achieve this by having the MCP client return a file path to us which we then read ourselves, thus bypassing the AI token limit issue entirely.
 
-To make this safe, we have you, the user, specify which path our MCP server should have access to. In addition, all the configuration examples provided in this README feature a mounting command that only gives read-only access to the mounted path, so we can't do anything to those files other than read them.
+To make this safe, we have you, the user, specify which path our MCP server should have access to. In addition, all the configuration examples provided in this README feature a mounting command that gives only read-only access to the mounted path, so we can't do anything to those files other than read them.
 
 In addition this now saves your AI budget by not spending precious tokens on file reading, which can add up pretty quickly.
 
@@ -346,6 +346,6 @@ In addition this now saves your AI budget by not spending precious tokens on fil
 
 Due to the limitation of not knowing the relative path to the file from within Docker, in order to read the correct file we need to know the full absolute path to your mounted directory, so that we could deduce a relative path to the internally mounted file by simply taking the absolute path to the file, the absolute path to the mounted directory, and replacing the mounted directory part with our internal mounted directory. 
 
-We pass the absolute path to the mounted directory to us via a environment variable `-e CS_MOUNT_PATH=<PATH>` so that we would know the absolute path, jand then we need to pass that path again the second time via `--mount type=bind,src=<PATH>,dst=/mount/,ro` which then instructs Docker to actually mount `<PATH>` to our internal `/mount/` directory.
+We pass the absolute path to the mounted directory to us via a environment variable `-e CS_MOUNT_PATH=<PATH>` so that we would know the absolute path, and then we need to pass that path again the second time via `--mount type=bind,src=<PATH>,dst=/mount/,ro` which then instructs Docker to actually mount `<PATH>` to our internal `/mount/` directory.
 
 </details>


### PR DESCRIPTION
We want to use local files instead so we are not capped by AI token limits, and we do so by mounting `CS_MOUNT_PATH` to our Docker container. This way the user always specifies exactly what files to share with the MCP server, and we'll update the documentation to demonstrate MCP configurations where Docker only gets read-only access to the files so that in addition to specifying a directory you can be rest assured we can't do anything malicious to those files.

Example VS code config using the new docker image:

```json
{
	"servers": {
		"codescene": {
			"command": "docker",
			"args": [
				"run",
				"-i",
				"--rm",
				"-e",
				"CS_ACCESS_TOKEN",
				"-e",
				"CS_MOUNT_PATH=${input:CS_MOUNT_PATH}",
				"--mount",
				"type=bind,src=${input:CS_MOUNT_PATH},dst=/mount/,ro",
				"codescene/codescene-mcp"
			],
			"env": {
				"CS_ACCESS_TOKEN": "${input:CS_ACCESS_TOKEN}"
			},
			"type": "stdio"
		}
	},
	"inputs": [
		{
			"id": "CS_MOUNT_PATH",
			"type": "promptString",
			"description": "Path of the directory that CodeScene should be able to see.",
			"password": false
		},
		{ 
			"id": "CS_ACCESS_TOKEN",
			"type": "promptString",
			"description": "CodeScene Access Token",
			"password": true
		}
	]
}
```