### PR TITLE
Update the e2e tests to read from (mounted) file paths, not receiving content directly

### DIFF
--- a/src/test_cs_mcp_server.py
+++ b/src/test_cs_mcp_server.py
@@ -5,20 +5,22 @@ from contextlib import asynccontextmanager
 from fastmcp import Client
 from fastmcp.client.transports import StdioTransport
 
-def include_cs_pat_token():
+def cs_access_token():
     """ The MCP server runs in an isolated environment => communicate the 
         token needed to access the CS CLI tool."""
     token = os.getenv("CS_ACCESS_TOKEN")
     if not token:
         raise EnvironmentError("Missing CS_ACCESS_TOKEN environment variable")
-    return {"CS_ACCESS_TOKEN": token}
+    return token
 
 @asynccontextmanager
 async def mcp_client():
     use_stdio_for_transport = StdioTransport(
         command="python",
         args=["./src/cs_mcp_server.py"],
-        env=include_cs_pat_token())
+        env={"CS_ACCESS_TOKEN": cs_access_token(),
+             "CS_MCP_RUNS_TEST_CONTEXT": "True",
+             "CS_CLI_PATH": "cs"}) # ensure 'cs' is exposed for the MCP
     async with Client(use_stdio_for_transport) as client:
         yield client
 
@@ -26,10 +28,6 @@ class TestCodeSceneMCP(unittest.IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.file_to_review = "./src/test_data/OrderProcessor.java"
-
-        with open(cls.file_to_review, 'r') as f:
-            cls.file_content = f.read()
-            cls.file_ext = '.java'
 
     async def test_ping(self):
         async with mcp_client() as c:
@@ -45,18 +43,17 @@ class TestCodeSceneMCP(unittest.IsolatedAsyncioTestCase):
     async def test_code_health_score(self):
         async with mcp_client() as c:
             result = await c.call_tool("code_health_score", {
-                "file_content": self.file_content,
-                "file_ext": self.file_ext
-            })
+                "file_path": self.file_to_review
+                })
             code_health_response = result.data
             self.assertIn('Code Health score: 8.65', code_health_response)
 
     async def test_code_health_review(self):
         async with mcp_client() as c:
             result = await c.call_tool("code_health_review", {
-                "file_content": self.file_content,
-                "file_ext": self.file_ext
-            })
+                "file_path": self.file_to_review
+                })
+            print(result)
             review = json.loads(result.data)
             
             self.assertEqual(8.65, review['score'])

--- a/src/test_cs_mcp_server.py
+++ b/src/test_cs_mcp_server.py
@@ -53,7 +53,6 @@ class TestCodeSceneMCP(unittest.IsolatedAsyncioTestCase):
             result = await c.call_tool("code_health_review", {
                 "file_path": self.file_to_review
                 })
-            print(result)
             review = json.loads(result.data)
             
             self.assertEqual(8.65, review['score'])


### PR DESCRIPTION
We changed how we access files to review. This PR updates the tests to reflect the recent API changes where we receive a file path.
Note that I introduced an env var to specify that we're in a test context and shouldn't expect a docker mount path. (Going forward, we should re-write these tests to execute a packaged container).