### PR TITLE
CS-5858: Add `CodeOwnership` tool

### DIFF
--- a/src/code_ownership/__init__.py
+++ b/src/code_ownership/__init__.py
@@ -1,0 +1,1 @@
+from .code_ownership import CodeOwnership

--- a/src/code_ownership/code_ownership.py
+++ b/src/code_ownership/code_ownership.py
@@ -1,0 +1,55 @@
+import json
+import os
+from typing import TypedDict, Callable
+from utils import adapt_mounted_file_path_inside_docker
+
+
+class CodeOwnershipDeps(TypedDict):
+    query_api_list_fn: Callable[[str, dict, str], list]
+
+class CodeOwnership:
+    def __init__(self, mcp_instance, deps: CodeOwnershipDeps):
+        self.deps = deps
+
+        mcp_instance.tool(self.code_ownership_for_path)
+
+    def code_ownership_for_path(self, project_id: int, path: str) -> str:
+        """
+        Find the owner or owners of a specific path in a project.
+
+        Returns:
+            A list of owners for the given path. The name of the owner who can be responsible 
+            for code reviews or inquiries about the file and a link to the CodeScene System Map page filtered
+            by the owner. Explain that this link can be used to see more details
+            about the owner's contributions and interactions within the project.
+        """
+        try:
+            endpoint = f"v2/projects/{project_id}/analyses/latest/files"
+            mounted_path = adapt_mounted_file_path_inside_docker(path)
+            relative_path = mounted_path.lstrip("/mount/")
+            params = {'filter': f"path~{relative_path}", 'fields': 'owner,path'}
+            files = self.deps["query_api_list_fn"](endpoint, params, 'files')
+            
+            if not files or len(files) == 0:
+                return json.dumps([])
+
+            result = []
+
+            for file in files:
+                owner = file.get('owner', 'Unknown')
+
+                if os.getenv("CS_ONPREM_URL"):
+                    link = f"{os.getenv('CS_ONPREM_URL')}/{project_id}/analyses/latest/social/individuals/system-map?author=author:{owner}"
+                else:
+                    link = f"https://codescene.io/projects/{project_id}/analyses/latest/social/individuals/system-map?author=author:{owner}"
+
+                result.append({
+                    'owner': owner,
+                    'path': file.get('path'),
+                    'link': link
+                })
+
+            return json.dumps(result)
+        
+        except Exception as e:
+            return f"Error: {e}"

--- a/src/code_ownership/test_code_ownership.py
+++ b/src/code_ownership/test_code_ownership.py
@@ -1,0 +1,81 @@
+import json
+import os
+import unittest
+from unittest import mock
+
+from fastmcp import FastMCP
+
+from . import CodeOwnership
+
+class TestCodeOwnership(unittest.TestCase):
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
+    def test_code_ownership_none_found(self):
+        def mocked_query_api_list(*kwargs):
+            return []
+
+        self.instance = CodeOwnership(FastMCP("Test"), {
+            'query_api_list_fn': mocked_query_api_list
+        })
+
+        expected = []
+        result = self.instance.code_ownership_for_path(3, "/some-path/some_file.tsx")
+
+        self.assertEqual(expected, json.loads(result))
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
+    def test_code_ownership_some_found(self):
+        def mocked_query_api_list(*kwargs):
+            return [{
+                'owner': 'some_owner',
+                'path': '/some-path/some_file.tsx'
+            }]
+
+        self.instance = CodeOwnership(FastMCP("Test"), {
+            'query_api_list_fn': mocked_query_api_list
+        })
+
+        expected = [{
+            "owner": "some_owner",
+            "path": "/some-path/some_file.tsx",
+            "link": "https://codescene.io/projects/3/analyses/latest/social/individuals/system-map?author=author:some_owner"
+        }]
+
+        result = self.instance.code_ownership_for_path(3, "/some-path/some_file.tsx")
+
+        self.assertEqual(expected, json.loads(result))
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path", "CS_ONPREM_URL": "https://onprem-codescene.io"})
+    def test_code_ownership_some_found_onprem(self):
+        def mocked_query_api_list(*kwargs):
+            return [{
+                'owner': 'some_owner',
+                'path': '/some-path/some_file.tsx'
+            }]
+
+        self.instance = CodeOwnership(FastMCP("Test"), {
+            'query_api_list_fn': mocked_query_api_list
+        })
+
+        expected = [{
+            "owner": "some_owner",
+            "path": "/some-path/some_file.tsx",
+            "link": "https://onprem-codescene.io/3/analyses/latest/social/individuals/system-map?author=author:some_owner"
+        }]
+
+        result = self.instance.code_ownership_for_path(3, "/some-path/some_file.tsx")
+
+        self.assertEqual(expected, json.loads(result))
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
+    def test_code_ownership_throws(self):
+        def mocked_query_api_list(*kwargs):
+            raise Exception("Some error")
+
+        self.instance = CodeOwnership(FastMCP("Test"), {
+            'query_api_list_fn': mocked_query_api_list
+        })
+
+        expected = "Error: Some error"
+        result = self.instance.code_ownership_for_path(3, "/some-path/some_file.tsx")
+
+        self.assertEqual(expected, result)

--- a/src/cs_mcp_server.py
+++ b/src/cs_mcp_server.py
@@ -9,6 +9,7 @@ from pre_commit_code_health_safeguard import PreCommitCodeHealthSafeguard
 from select_project import SelectProject
 from technical_debt_goals import TechnicalDebtGoals
 from technical_debt_hotspots import TechnicalDebtHotspots
+from code_ownership import CodeOwnership
 from utils import query_api_list, analyze_code, run_local_tool
 
 mcp = FastMCP("CodeScene")
@@ -162,6 +163,10 @@ if __name__ == "__main__":
     })
 
     TechnicalDebtHotspots(mcp, {
+        'query_api_list_fn': query_api_list
+    })
+
+    CodeOwnership(mcp, {
         'query_api_list_fn': query_api_list
     })
 


### PR DESCRIPTION
This tool will help you find out who is the owner of any given path in a project. This can be a particular file or a folder, it'll work with both, and it will link to the System Map page for more information about a specific owner or if there are multiple then to the generic System Map page.