### PR TITLE
CS-5883: Normalize paths and add support for Windows file systems

### DIFF
--- a/src/utils/docker_path_adapter.py
+++ b/src/utils/docker_path_adapter.py
@@ -1,7 +1,27 @@
 import os
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from errors import CodeSceneCliError
 
+def normalize_path(path: str) -> str:
+    """
+    Normalize a file path to a POSIX-style Path object.
+    Converts Windows-style paths to POSIX-style.
+    
+    Note that while it always uses PureWindowsPath for normalization,
+    it does not assume the input is necessarily a Windows path and 
+    works fine with POSIX paths as well.
+    """
+    def get_windows_drive_letter(path: str) -> str | None:
+        if len(path) >= 2 and path[1] == ':':    
+            return path[0].upper()
+        return None
+    
+    normalized_path = PureWindowsPath(path).as_posix()
+
+    if drive := get_windows_drive_letter(path):
+        normalized_path = f'/{drive}/' + normalized_path[2:]
+
+    return Path(normalized_path)
 
 def adapt_mounted_file_path_inside_docker(file_path: str) -> str:
     """
@@ -14,9 +34,11 @@ def adapt_mounted_file_path_inside_docker(file_path: str) -> str:
     mount = os.getenv("CS_MOUNT_PATH")
     if not mount:
         raise CodeSceneCliError("CS_MOUNT_PATH not defined.")
+    
+    normalized_mount_path = normalize_path(mount)
+    normalized_file_path = normalize_path(file_path)
 
-    p = Path(file_path)
-    if not p.is_absolute():
+    if not normalized_file_path.is_absolute():
         raise CodeSceneCliError(f"file_path must be absolute: {file_path!r}")
 
     def relative_path_under_mount(file_path: Path, mount_path: Path) -> Path:
@@ -25,7 +47,7 @@ def adapt_mounted_file_path_inside_docker(file_path: str) -> str:
         except ValueError:
             raise CodeSceneCliError(f"file_path is not under CS_MOUNT_PATH: {str(file_path)!r}")
 
-    relative = relative_path_under_mount(p, Path(mount))
+    relative = relative_path_under_mount(normalized_file_path, normalized_mount_path)
 
     # If the file points to the mount root, relative_to yields '.'
     if relative == Path("."):

--- a/src/utils/test_docker_mount_path.py
+++ b/src/utils/test_docker_mount_path.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 from unittest import mock
-
 from errors import CodeSceneCliError
 from .docker_path_adapter import adapt_mounted_file_path_inside_docker
 
@@ -25,6 +24,8 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
             ("/mnt/project", "/mnt/project", "/mount"),
             ("/mnt/project", "/mnt/project/", "/mount"),
             ("/", "/src/foo.py", "/mount/src/foo.py"),
+            ("C:\\code\\project", "C:\\code\\project\\src\\foo.py", "/mount/src/foo.py"),
+            ("c:\\code\\ööproject", "c:\\code\\ööproject\\src\\föö.py", "/mount/src/föö.py"),
         ]
         for mount, user_input, expected in cases:
             with self.subTest(mount=mount, user_input=user_input):


### PR DESCRIPTION
This adds support for Windows filesystems, where previously using the MCP from Windows would not work.