### PR TITLE
CS-5718: Fix issue with links pointing to ONPREM incorrectly

### DIFF
--- a/src/code_ownership/code_ownership.py
+++ b/src/code_ownership/code_ownership.py
@@ -2,7 +2,7 @@ from itertools import groupby
 import json
 import os
 from typing import TypedDict, Callable
-from utils import adapt_mounted_file_path_inside_docker
+from utils import adapt_mounted_file_path_inside_docker, normalize_onprem_url
 
 
 class CodeOwnershipDeps(TypedDict):
@@ -37,12 +37,12 @@ class CodeOwnership:
                 return json.dumps([])
 
             result = []
-
             sorted_files = sorted(files, key=lambda x: x['owner'])
             
             for k, g in groupby(sorted_files, key=lambda x: x['owner']):
                 if os.getenv("CS_ONPREM_URL"):
-                    link = f"{os.getenv('CS_ONPREM_URL')}/{project_id}/analyses/latest/social/individuals/system-map?author=author:{k}"
+                    onprem_url = normalize_onprem_url(os.getenv("CS_ONPREM_URL"))
+                    link = f"{onprem_url}/{project_id}/analyses/latest/social/individuals/system-map?author=author:{k}"
                 else:
                     link = f"https://codescene.io/projects/{project_id}/analyses/latest/social/individuals/system-map?author=author:{k}"
 

--- a/src/code_ownership/test_code_ownership.py
+++ b/src/code_ownership/test_code_ownership.py
@@ -77,6 +77,28 @@ class TestCodeOwnership(unittest.TestCase):
 
         self.assertEqual(expected, json.loads(result))
 
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path", "CS_ONPREM_URL": "https://onprem-codescene.io/"})
+    def test_code_ownership_some_found_onprem(self):
+        def mocked_query_api_list(*kwargs):
+            return [{
+                'owner': 'some_owner',
+                'path': '/some-path/some_file.tsx'
+            }]
+
+        self.instance = CodeOwnership(FastMCP("Test"), {
+            'query_api_list_fn': mocked_query_api_list
+        })
+
+        expected = [{
+            "owner": "some_owner",
+            "paths": ["/some-path/some_file.tsx"],
+            "link": "https://onprem-codescene.io/3/analyses/latest/social/individuals/system-map?author=author:some_owner"
+        }]
+
+        result = self.instance.code_ownership_for_path(3, "/some-path/some_file.tsx")
+
+        self.assertEqual(expected, json.loads(result))
+
     @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
     def test_code_ownership_throws(self):
         def mocked_query_api_list(*kwargs):

--- a/src/technical_debt_goals/technical_debt_goals.py
+++ b/src/technical_debt_goals/technical_debt_goals.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import TypedDict, Callable
 
-from utils import adapt_mounted_file_path_inside_docker
+from utils import adapt_mounted_file_path_inside_docker, normalize_onprem_url
 
 
 class TechnicalDebtGoalsDeps(TypedDict):
@@ -35,7 +35,8 @@ class TechnicalDebtGoals:
             files = self.deps["query_api_list_fn"](endpoint, params, 'files')
 
             if os.getenv("CS_ONPREM_URL"):
-                link = f"{os.getenv('CS_ONPREM_URL')}/{project_id}/analyses/latest/code/biomarkers"
+                onprem_url = normalize_onprem_url(os.getenv("CS_ONPREM_URL"))
+                link = f"{onprem_url}/{project_id}/analyses/latest/code/biomarkers"
             else:
                 link = f"https://codescene.io/projects/{project_id}/analyses/latest/code/biomarkers"
         
@@ -71,7 +72,8 @@ class TechnicalDebtGoals:
             goals = files[0].get('goals', []) if files else []
 
             if os.getenv("CS_ONPREM_URL"):
-                link = f"{os.getenv('CS_ONPREM_URL')}/{project_id}/analyses/latest/code/biomarkers?name={relative_file_path}"
+                onprem_url = normalize_onprem_url(os.getenv("CS_ONPREM_URL"))
+                link = f"{onprem_url}/{project_id}/analyses/latest/code/biomarkers?name={relative_file_path}"
             else:
                 link = f"https://codescene.io/projects/{project_id}/analyses/latest/code/biomarkers?name={relative_file_path}"
 

--- a/src/technical_debt_goals/test_technical_debt_goals.py
+++ b/src/technical_debt_goals/test_technical_debt_goals.py
@@ -48,6 +48,29 @@ class TestTechnicalDebtGoals(unittest.TestCase):
 
         self.assertEqual(expected, json.loads(result))
 
+    @mock.patch.dict(os.environ, {"CS_ONPREM_URL": "https://onprem-codescene.io"})
+    def test_list_technical_debt_goals_for_project_some_found_onprem(self):
+        def mocked_query_api_list(*kwargs):
+            return [{
+                'path': 'some_path'
+            }]
+
+        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
+            'query_api_list_fn': mocked_query_api_list
+        })
+
+        expected = {
+            "files": [{
+                'path': 'some_path'
+            }],
+            "description": "Found 1 files with technical debt goals for project ID 3.",
+            "link": "https://onprem-codescene.io/3/analyses/latest/code/biomarkers"
+        }
+
+        result = self.instance.list_technical_debt_goals_for_project(3)
+
+        self.assertEqual(expected, json.loads(result))
+
     def test_list_technical_debt_goals_for_project_throws(self):
         def mocked_query_api_list(*kwargs):
             raise Exception("Some error")

--- a/src/technical_debt_hotspots/technical_debt_hotspots.py
+++ b/src/technical_debt_hotspots/technical_debt_hotspots.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Callable, TypedDict
 
-from utils import adapt_mounted_file_path_inside_docker
+from utils import adapt_mounted_file_path_inside_docker, normalize_onprem_url
 
 
 class TechnicalDebtHotspotsDeps(TypedDict):
@@ -36,7 +36,8 @@ class TechnicalDebtHotspots:
             hotspots = self.deps["query_api_list_fn"](endpoint, params, 'hotspots')
 
             if os.getenv("CS_ONPREM_URL"):
-                link = f"{os.getenv('CS_ONPREM_URL')}/{project_id}/analyses/latest/code/technical-debt/system-map#hotspots"
+                onprem_url = normalize_onprem_url(os.getenv("CS_ONPREM_URL"))
+                link = f"{onprem_url}/{project_id}/analyses/latest/code/technical-debt/system-map#hotspots"
             else:
                 link = f"https://codescene.io/projects/{project_id}/analyses/latest/code/technical-debt/system-map#hotspots"
                 
@@ -73,7 +74,8 @@ class TechnicalDebtHotspots:
             hotspot = hotspots[0] if hotspots else None
 
             if os.getenv("CS_ONPREM_URL"):
-                link = f"{os.getenv('CS_ONPREM_URL')}/{project_id}/analyses/latest/code/technical-debt/system-map#hotspots"
+                onprem_url = normalize_onprem_url(os.getenv("CS_ONPREM_URL"))
+                link = f"{onprem_url}/{project_id}/analyses/latest/code/technical-debt/system-map#hotspots"
             else:
                 link = f"https://codescene.io/projects/{project_id}/analyses/latest/code/technical-debt/system-map#hotspots"
                 

--- a/src/technical_debt_hotspots/test_technical_debt_hotspots.py
+++ b/src/technical_debt_hotspots/test_technical_debt_hotspots.py
@@ -129,6 +129,31 @@ class TestTechnicalDebtHotspots(unittest.TestCase):
 
         self.assertEqual(expected, json.loads(result))
 
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path", "CS_ONPREM_URL": "https://onprem-codescene.io"})
+    def test_list_technical_debt_hotspots_for_project_file_some_found_onprem(self):
+        def mocked_query_api_list(*kwargs):
+            return [{
+                'path': 'some_file.tsx',
+                'revisions': 55
+            }]
+
+        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
+            'query_api_list_fn': mocked_query_api_list
+        })
+
+        expected = {
+            "hotspot": {
+                'path': 'some_file.tsx',
+                'revisions': 55
+            },
+            "description": "Found technical debt hotspot for file some_file.tsx in project ID 3.",
+            "link": "https://onprem-codescene.io/3/analyses/latest/code/technical-debt/system-map#hotspots"
+        }
+
+        result = self.instance.list_technical_debt_hotspots_for_project_file("/some-path/some_file.tsx", 3)
+
+        self.assertEqual(expected, json.loads(result))
+
     @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
     def test_list_technical_debt_hotspots_for_project_file_throws(self):
         def mocked_query_api_list(*kwargs):

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,11 @@
 from .docker_path_adapter import adapt_mounted_file_path_inside_docker
-from .codescene_api_client import get_api_url, get_api_request_headers, query_api, query_api_list
+from .codescene_api_client import (
+    normalize_onprem_url, 
+    get_api_url, 
+    get_api_request_headers, 
+    query_api, 
+    query_api_list
+)
 from .code_health_analysis import (
     run_local_tool,
     run_cs_cli,
@@ -7,5 +13,5 @@ from .code_health_analysis import (
     cs_cli_path,
     make_cs_cli_review_command_for,
     cs_cli_review_command_for,
-    analyze_code
+    analyze_code,
 )

--- a/src/utils/codescene_api_client.py
+++ b/src/utils/codescene_api_client.py
@@ -1,9 +1,14 @@
 import os
 import requests
 
+def normalize_onprem_url(url: str) -> str:
+    if url.endswith('/'):
+        url = url[:-1]
+
+    return url
 
 def get_api_url() -> str:
-    url = os.getenv("CS_ONPREM_URL")
+    url = normalize_onprem_url(os.getenv("CS_ONPREM_URL") or "")
     return f"{url}/api" if url else "https://api.codescene.io"
 
 


### PR DESCRIPTION
This fixes an issue where if the `CS_ONPREM_URL` env variable ended with a `/`, then some of the links pointing to a CS Instance would not work.