### PR TITLE
CS-5884: improve error reporting for mismatched env paths

### DIFF
--- a/src/utils/docker_path_adapter.py
+++ b/src/utils/docker_path_adapter.py
@@ -20,19 +20,26 @@ def normalize_path(path: str) -> Path:
 
 def find_first_mismatch(a: tuple, b: tuple) -> int | None:
     """
-    Returns the index of the first mismatched segment, or None if all match.
+    Returns the index of the first mismatched segment, or None if all segments match.
+    Example: a = ('/', 'C', 'foo'), b = ('/', 'D', 'foo') -> returns 1
     """
-    for i, (seg_a, seg_b) in enumerate(zip(a, b)):
-        if seg_a != seg_b:
-            return i
+    for index, (left, right) in enumerate(zip(a, b)):
+        if left != right:
+            return index
+
+    has_extra_segments = len(a) != len(b)
+    if has_extra_segments:
+        # the first extra segment is the point of divergence:
+        first_extra_segment_index = min(len(a), len(b))
+        return first_extra_segment_index
     return None
 
 def path_mismatch_error(file_path: Path, mount_path: Path) -> CodeSceneCliError:
     file_parts, mount_parts = file_path.parts, mount_path.parts
     idx = find_first_mismatch(file_parts, mount_parts)
     if idx is not None:
-        user_segment = file_parts[idx]
-        mount_segment = mount_parts[idx]
+        user_segment = file_parts[idx] if idx < len(file_parts) else '<none>'
+        mount_segment = mount_parts[idx] if idx < len(mount_parts) else '<none>'
         suggestion = (
             f"Path mismatch at segment {idx}: "
             f"'{user_segment}' (input) vs '{mount_segment}' (mount). "

--- a/src/utils/docker_path_adapter.py
+++ b/src/utils/docker_path_adapter.py
@@ -1,57 +1,78 @@
+
 import os
 from pathlib import Path, PureWindowsPath
 from errors import CodeSceneCliError
 
-def normalize_path(path: str) -> str:
+def normalize_path(path: str) -> Path:
     """
     Normalize a file path to a POSIX-style Path object.
-    Converts Windows-style paths to POSIX-style.
-    
-    Note that while it always uses PureWindowsPath for normalization,
-    it does not assume the input is necessarily a Windows path and 
-    works fine with POSIX paths as well.
+    Handles both Windows and POSIX paths.
     """
-    def get_windows_drive_letter(path: str) -> str | None:
-        if len(path) >= 2 and path[1] == ':':    
-            return path[0].upper()
+    def get_windows_drive_letter(p: str) -> str | None:
+        if len(p) >= 2 and p[1] == ':':
+            return p[0].upper()
         return None
-    
-    normalized_path = PureWindowsPath(path).as_posix()
+    normalized = PureWindowsPath(path).as_posix()
+    drive = get_windows_drive_letter(path)
+    if drive:
+        normalized = f'/{drive}/' + normalized[2:]
+    return Path(normalized)
 
-    if drive := get_windows_drive_letter(path):
-        normalized_path = f'/{drive}/' + normalized_path[2:]
+def find_first_mismatch(a: tuple, b: tuple) -> int | None:
+    """
+    Returns the index of the first mismatched segment, or None if all match.
+    """
+    for i, (seg_a, seg_b) in enumerate(zip(a, b)):
+        if seg_a != seg_b:
+            return i
+    return None
 
-    return Path(normalized_path)
+def path_mismatch_error(file_path: Path, mount_path: Path) -> CodeSceneCliError:
+    file_parts, mount_parts = file_path.parts, mount_path.parts
+    idx = find_first_mismatch(file_parts, mount_parts)
+    if idx is not None:
+        user_segment = file_parts[idx]
+        mount_segment = mount_parts[idx]
+        suggestion = (
+            f"Path mismatch at segment {idx}: "
+            f"'{user_segment}' (input) vs '{mount_segment}' (mount). "
+            f"Check for case sensitivity or typos. "
+            f"To fix: ensure your CS_MOUNT_PATH matches the input path exactly."
+        )
+    else:
+        suggestion = (
+            "file_path is not under CS_MOUNT_PATH. "
+            "Check for typos or incorrect mount configuration."
+        )
+    return CodeSceneCliError(
+        f"file_path is not under CS_MOUNT_PATH: {str(file_path)!r}. {suggestion}"
+    )
+
+def relative_path_under_mount(file_path: Path, mount_path: Path) -> Path:
+    """
+    Returns the path of file_path relative to mount_path, or raises a detailed error.
+    """
+    try:
+        return file_path.relative_to(mount_path)
+    except ValueError:
+        raise path_mismatch_error(file_path, mount_path)
 
 def adapt_mounted_file_path_inside_docker(file_path: str) -> str:
     """
     Convert a host-mounted absolute file path into the path the container sees.
-
-    - Requires the environment variable `CS_MOUNT_PATH` to be set.
-    - `file_path` must be absolute and located under `CS_MOUNT_PATH`.
-    - Returns a POSIX-style path rooted at '/mount' (e.g. '/mount/src/foo.py').
+    Requires CS_MOUNT_PATH env var. Returns POSIX path rooted at '/mount'.
     """
     mount = os.getenv("CS_MOUNT_PATH")
     if not mount:
         raise CodeSceneCliError("CS_MOUNT_PATH not defined.")
-    
-    normalized_mount_path = normalize_path(mount)
-    normalized_file_path = normalize_path(file_path)
 
-    if not normalized_file_path.is_absolute():
+    mount_path = normalize_path(mount)
+    user_path = normalize_path(file_path)
+
+    if not user_path.is_absolute():
         raise CodeSceneCliError(f"file_path must be absolute: {file_path!r}")
 
-    def relative_path_under_mount(file_path: Path, mount_path: Path) -> Path:
-        try:
-            return file_path.relative_to(mount_path)
-        except ValueError:
-            raise CodeSceneCliError(f"file_path is not under CS_MOUNT_PATH: {str(file_path)!r}")
-
-    relative = relative_path_under_mount(normalized_file_path, normalized_mount_path)
-
-    # If the file points to the mount root, relative_to yields '.'
+    relative = relative_path_under_mount(user_path, mount_path)
     if relative == Path("."):
         return "/mount"
-
-    mount_posix_style = "/mount/" + relative.as_posix()
-    return mount_posix_style
+    return f"/mount/{relative.as_posix()}"

--- a/src/utils/test_docker_mount_path.py
+++ b/src/utils/test_docker_mount_path.py
@@ -27,6 +27,8 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
             ("/",                   "/src/foo.py",                      "/mount/src/foo.py"),
             ("C:\\code\\project",   "C:\\code\\project\\src\\foo.py",   "/mount/src/foo.py"),
             ("c:\\code\\ööproject", "c:\\code\\ööproject\\src\\föö.py", "/mount/src/föö.py"),
+            # User path longer than mount path (positive case)
+            ("/mnt/project",        "/mnt/project/src/foo.py/bar.py",   "/mount/src/foo.py/bar.py"),
         ]
         for mount, user_input, expected in cases:
             with self.subTest(mount=mount, user_input=user_input):
@@ -77,8 +79,8 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
         cases = [
             # Case sensitivity mismatch
             {
-                "mount": "c:\\git\\myproject",
-                "user_input": "c:\\Git\\myproject",
+                "mount": "c:\git\myproject",
+                "user_input": "c:\Git\myproject",
                 "expected_msg": "Path mismatch at segment 2: 'Git' (input) vs 'git' (mount)."
             },
             # Path not under mount at all
@@ -98,6 +100,12 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
                 "mount": "C:\\code\\project",
                 "user_input": "D:\\code\\project\\src\\foo.py",
                 "expected_msg": "Path mismatch at segment 1: 'D' (input) vs 'C' (mount)."
+            },
+            # Mount path longer than user path (negative case)
+            {
+                "mount": "/mnt/project/src/foo.py/bar.py",
+                "user_input": "/mnt/project",
+                "expected_msg": "Path mismatch at segment 3: '<none>' (input) vs 'src' (mount)."
             },
         ]
         for case in cases:

--- a/src/utils/test_docker_mount_path.py
+++ b/src/utils/test_docker_mount_path.py
@@ -107,6 +107,30 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
                 "user_input": "/mnt/project",
                 "expected_msg": "Path mismatch at segment 3: '<none>' (input) vs 'src' (mount)."
             },
+            # User path is root, mount path is a subpath (negative)
+            {
+                "mount": "/foo.py",
+                "user_input": "/",
+                "expected_msg": "Path mismatch at segment 1: '<none>' (input) vs 'foo.py' (mount)."
+            },
+            # Mount path is a prefix, but not a true parent (negative)
+            {
+                "mount": "/mnt/pro",
+                "user_input": "/mnt/project/foo.py",
+                "expected_msg": "Path mismatch at segment 2: 'project' (input) vs 'pro' (mount)."
+            },
+            # Negative unicode/typo case
+            {
+                "mount": "c:\\code\\ööproject",
+                "user_input": "c:\\code\\ööprojeckt\\src\\föö.py",
+                "expected_msg": "Path mismatch at segment 3: 'ööprojeckt' (input) vs 'ööproject' (mount)."
+            },
+            # Extra segments in the middle (negative)
+            {
+                "mount": "/mnt/project/foo.py",
+                "user_input": "/mnt/project/bar.py/baz.py",
+                "expected_msg": "Path mismatch at segment 3: 'bar.py' (input) vs 'foo.py' (mount)."
+            },
         ]
         for case in cases:
             with self.subTest(mount=case["mount"], user_input=case["user_input"]):

--- a/src/utils/test_docker_mount_path.py
+++ b/src/utils/test_docker_mount_path.py
@@ -19,12 +19,13 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
 
     def test_mappings(self):
         cases = [
-            ("/mnt/project", "/mnt/project/src/foo.py", "/mount/src/foo.py"),
-            ("/mnt/project/", "/mnt/project/src/foo.py", "/mount/src/foo.py"),
-            ("/mnt/project", "/mnt/project", "/mount"),
-            ("/mnt/project", "/mnt/project/", "/mount"),
-            ("/", "/src/foo.py", "/mount/src/foo.py"),
-            ("C:\\code\\project", "C:\\code\\project\\src\\foo.py", "/mount/src/foo.py"),
+            # mount                 user_input                          expected
+            ("/mnt/project",        "/mnt/project/src/foo.py",          "/mount/src/foo.py"),
+            ("/mnt/project/",       "/mnt/project/src/foo.py",          "/mount/src/foo.py"),
+            ("/mnt/project",        "/mnt/project",                     "/mount"),
+            ("/mnt/project",        "/mnt/project/",                    "/mount"),
+            ("/",                   "/src/foo.py",                      "/mount/src/foo.py"),
+            ("C:\\code\\project",   "C:\\code\\project\\src\\foo.py",   "/mount/src/foo.py"),
             ("c:\\code\\ööproject", "c:\\code\\ööproject\\src\\föö.py", "/mount/src/föö.py"),
         ]
         for mount, user_input, expected in cases:
@@ -40,6 +41,72 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
         os.environ.pop("CS_MOUNT_PATH", None)
         with self.assertRaises(CodeSceneCliError):
             adapt_mounted_file_path_inside_docker("/mnt/project/src/foo.py")
+
+    def test_erronous_mount_path_is_diagnosed(self):
+        """
+        The user is responsible for providing the mount path in the MCP config.
+        A simple typo will wreck it, so the error message is important in order
+        for users to self-diagnose the problem.
+
+        Note there's a table-driven test just below that checks the error reporting.
+        However, I still like to keep this test as a more verbose example on how 
+        it looks and works.
+        """
+        LOWER_CASE_MOUNT_PATH = "c:\\git\\myproject"
+        UPPER_CASE_USER_INPUT_PATH = "c:\\Git\\myproject"
+        os.environ["CS_MOUNT_PATH"] = LOWER_CASE_MOUNT_PATH
+        user_input = UPPER_CASE_USER_INPUT_PATH
+
+        with self.assertRaises(CodeSceneCliError) as context:
+            adapt_mounted_file_path_inside_docker(user_input)
+
+        error_message = str(context.exception)
+        expected_message = (
+            "file_path is not under CS_MOUNT_PATH: '/C/Git/myproject'. "
+            "Path mismatch at segment 2: 'Git' (input) vs 'git' (mount). "
+            "Check for case sensitivity or typos. "
+            "To fix: ensure your CS_MOUNT_PATH matches the input path exactly."
+        )
+        self.assertEqual(error_message, expected_message)
+
+    def test_path_mismatch_reporting(self):
+        """
+        Table-driven test for error scenarios in adapt_mounted_file_path_inside_docker.
+        Each case specifies mount path, user input, and expected error message (full or partial).
+        """
+        cases = [
+            # Case sensitivity mismatch
+            {
+                "mount": "c:\\git\\myproject",
+                "user_input": "c:\\Git\\myproject",
+                "expected_msg": "Path mismatch at segment 2: 'Git' (input) vs 'git' (mount)."
+            },
+            # Path not under mount at all
+            {
+                "mount": "/mnt/project",
+                "user_input": "/other/foo.py",
+                "expected_msg": "file_path is not under CS_MOUNT_PATH"
+            },
+            # Typo in segment
+            {
+                "mount": "/mnt/projct",
+                "user_input": "/mnt/project/src/foo.py",
+                "expected_msg": "Path mismatch at segment 2: 'project' (input) vs 'projct' (mount)."
+            },
+            # Windows drive letter mismatch
+            {
+                "mount": "C:\\code\\project",
+                "user_input": "D:\\code\\project\\src\\foo.py",
+                "expected_msg": "Path mismatch at segment 1: 'D' (input) vs 'C' (mount)."
+            },
+        ]
+        for case in cases:
+            with self.subTest(mount=case["mount"], user_input=case["user_input"]):
+                os.environ["CS_MOUNT_PATH"] = case["mount"]
+                with self.assertRaises(CodeSceneCliError) as context:
+                    adapt_mounted_file_path_inside_docker(case["user_input"])
+                error_message = str(context.exception)
+                self.assertIn(case["expected_msg"], error_message)
 
     @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/mnt/project"})
     def test_relative_path_raises(self):


### PR DESCRIPTION
This PR improves the error message in case there's a misconfiguration of the CS_MOUNT_PATH. 
The error message will specify details on where the mismatch is in order to deliver an actionable response that users apply to self-diagnose the config error.