### PR TITLE
Elevate the Code Health in the test code

### DIFF
--- a/src/technical_debt_goals/test_technical_debt_goals.py
+++ b/src/technical_debt_goals/test_technical_debt_goals.py
@@ -4,160 +4,164 @@ import unittest
 from unittest import mock
 
 from fastmcp import FastMCP
-
 from . import TechnicalDebtGoals
 
+PROJECT_ID = 3
+FILE_PATH = "/some-path/some_file.tsx"
+FILE_NAME = "some_file.tsx"
+
+# -----------------------------------------------------------------------------
+# Test Strategy: Table-Driven Tests
+# -----------------------------------------------------------------------------
+# This test suite uses a table-driven approach, where each test scenario is
+# represented as a dictionary containing:
+#   - scenario name
+#   - mock API return value
+#   - expected output
+#   - environment setup (on-prem/cloud, project/file)
+#   - error simulation (if applicable)
+#
+# The main test method loops over all scenarios, using subTest for isolation.
+# Each scenario is executed with its own environment and mock, and the result
+# is asserted against the expected output.
+#
+# This strategy ensures:
+#   - All key behaviors are covered (none/some/error, project/file, cloud/on-prem)
+#   - Adding new scenarios is easy and does not require new test methods
+#   - The test logic is concise, maintainable, and intent-revealing
+# -----------------------------------------------------------------------------
+
+project_goals_none_found = {
+    "name": "project_goals_none_found",
+    "mock_return": [],
+    "expected": {
+        "files": [],
+        "description": f"Found 0 files with technical debt goals for project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/biomarkers"
+    },
+    "onprem": False,
+    "method": "project"
+}
+project_goals_some_found = {
+    "name": "project_goals_some_found",
+    "mock_return": [{"path": "some_path"}],
+    "expected": {
+        "files": [{"path": "some_path"}],
+        "description": f"Found 1 files with technical debt goals for project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/biomarkers"
+    },
+    "onprem": False,
+    "method": "project"
+}
+project_goals_some_found_onprem = {
+    "name": "project_goals_some_found_onprem",
+    "mock_return": [{"path": "some_path"}],
+    "expected": {
+        "files": [{"path": "some_path"}],
+        "description": f"Found 1 files with technical debt goals for project ID {PROJECT_ID}.",
+        "link": f"https://onprem-codescene.io/{PROJECT_ID}/analyses/latest/code/biomarkers"
+    },
+    "onprem": True,
+    "method": "project"
+}
+project_goals_error = {
+    "name": "project_goals_error",
+    "mock_return": Exception("Some error"),
+    "expected": "Error: Some error",
+    "onprem": False,
+    "method": "project",
+    "is_error": True
+}
+
+file_goals_none_found = {
+    "name": "file_goals_none_found",
+    "mock_return": [],
+    "expected": {
+        "goals": [],
+        "description": f"Found 0 technical debt goals for file {FILE_NAME} in project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/biomarkers?name={FILE_NAME}"
+    },
+    "onprem": False,
+    "method": "file"
+}
+file_goals_some_found = {
+    "name": "file_goals_some_found",
+    "mock_return": [{"path": FILE_NAME, "goals": [{"name": "some goal"}]}],
+    "expected": {
+        "goals": [{"name": "some goal"}],
+        "description": f"Found 1 technical debt goals for file {FILE_NAME} in project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/biomarkers?name={FILE_NAME}"
+    },
+    "onprem": False,
+    "method": "file"
+}
+file_goals_some_found_onprem = {
+    "name": "file_goals_some_found_onprem",
+    "mock_return": [{"path": FILE_NAME, "goals": [{"name": "some goal"}]}],
+    "expected": {
+        "goals": [{"name": "some goal"}],
+        "description": f"Found 1 technical debt goals for file {FILE_NAME} in project ID {PROJECT_ID}.",
+        "link": f"https://onprem-codescene.io/{PROJECT_ID}/analyses/latest/code/biomarkers?name={FILE_NAME}"
+    },
+    "onprem": True,
+    "method": "file"
+}
+file_goals_error = {
+    "name": "file_goals_error",
+    "mock_return": Exception("Some error"),
+    "expected": "Error: Some error",
+    "onprem": False,
+    "method": "file",
+    "is_error": True
+}
+
 class TestTechnicalDebtGoals(unittest.TestCase):
-    def test_list_technical_debt_goals_for_project_none_found(self):
-        def mocked_query_api_list(*kwargs):
-            return []
+    def setUp(self):
+        self.project_id = PROJECT_ID
+        self.file_path = FILE_PATH
+        self.file_name = FILE_NAME
 
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
+    def _patch_environment(self, scenario):
+        patch_dict = {}
+        if scenario["onprem"]:
+            patch_dict["CS_ONPREM_URL"] = "https://onprem-codescene.io"
+        if scenario["method"] == "file":
+            patch_dict["CS_MOUNT_PATH"] = "/some-path"
+        return mock.patch.dict(os.environ, patch_dict)
 
-        expected = {
-            "files": [],
-            "description": "Found 0 files with technical debt goals for project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/biomarkers"
-        }
+    def _make_mocked_instance(self, scenario):
+        def mocked_query_api_list(*args, **kwargs):
+            if scenario.get("is_error"):
+                raise scenario["mock_return"]
+            return scenario["mock_return"]
+        return TechnicalDebtGoals(FastMCP("Test"), {'query_api_list_fn': mocked_query_api_list})
 
-        result = self.instance.list_technical_debt_goals_for_project(3)
+    def _execute_scenario(self, scenario):
+        with self._patch_environment(scenario):
+            instance = self._make_mocked_instance(scenario)
+            if scenario["method"] == "project":
+                return instance.list_technical_debt_goals_for_project(self.project_id)
+            
+            return instance.list_technical_debt_goals_for_project_file(self.file_path, self.project_id)
 
-        self.assertEqual(expected, json.loads(result))
+    def _assert_scenario(self, scenario):
+        result = self._execute_scenario(scenario)
+        if isinstance(result, str) and not scenario.get("is_error"):
+            result = json.loads(result)
+        self.assertEqual(scenario["expected"], result)
 
-    def test_list_technical_debt_goals_for_project_some_found(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_path'
-            }]
-
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "files": [{
-                'path': 'some_path'
-            }],
-            "description": "Found 1 files with technical debt goals for project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/biomarkers"
-        }
-
-        result = self.instance.list_technical_debt_goals_for_project(3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_ONPREM_URL": "https://onprem-codescene.io"})
-    def test_list_technical_debt_goals_for_project_some_found_onprem(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_path'
-            }]
-
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "files": [{
-                'path': 'some_path'
-            }],
-            "description": "Found 1 files with technical debt goals for project ID 3.",
-            "link": "https://onprem-codescene.io/3/analyses/latest/code/biomarkers"
-        }
-
-        result = self.instance.list_technical_debt_goals_for_project(3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    def test_list_technical_debt_goals_for_project_throws(self):
-        def mocked_query_api_list(*kwargs):
-            raise Exception("Some error")
-
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = "Error: Some error"
-        result = self.instance.list_technical_debt_goals_for_project(3)
-
-        self.assertEqual(expected, result)
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
-    def test_list_technical_debt_goals_for_project_file_none_found(self):
-        def mocked_query_api_list(*kwargs):
-            return []
-
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "goals": [],
-            "description": "Found 0 technical debt goals for file some_file.tsx in project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/biomarkers?name=some_file.tsx"
-        }
-
-        result = self.instance.list_technical_debt_goals_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
-    def test_list_technical_debt_goals_for_project_file_some_found(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_file.tsx',
-                'goals': [{'name': 'some goal'}]
-            }]
-
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "goals": [{'name': 'some goal'}],
-            "description": "Found 1 technical debt goals for file some_file.tsx in project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/biomarkers?name=some_file.tsx"
-        }
-
-        result = self.instance.list_technical_debt_goals_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path", "CS_ONPREM_URL": "http://onprem-codescene"})
-    def test_list_technical_debt_goals_for_project_file_some_found_onprem(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_file.tsx',
-                'goals': [{'name': 'some goal'}]
-            }]
-
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "goals": [{'name': 'some goal'}],
-            "description": "Found 1 technical debt goals for file some_file.tsx in project ID 3.",
-            "link": "http://onprem-codescene/3/analyses/latest/code/biomarkers?name=some_file.tsx"
-        }
-
-        result = self.instance.list_technical_debt_goals_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
-    def test_list_technical_debt_goals_for_project_file_throws(self):
-        def mocked_query_api_list(*kwargs):
-            raise Exception("Some error")
-
-        self.instance = TechnicalDebtGoals(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = "Error: Some error"
-        result = self.instance.list_technical_debt_goals_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, result)
-        
+    def test_td_goal_scenarios(self):
+        """Table-driven test for technical debt goals scenarios."""
+        all_goal_scenarios = [
+            project_goals_none_found,
+            project_goals_some_found,
+            project_goals_some_found_onprem,
+            project_goals_error,
+            file_goals_none_found,
+            file_goals_some_found,
+            file_goals_some_found_onprem,
+            file_goals_error,
+        ]
+        for scenario in all_goal_scenarios:
+            with self.subTest(scenario=scenario["name"]):
+                self._assert_scenario(scenario)

--- a/src/technical_debt_hotspots/test_technical_debt_hotspots.py
+++ b/src/technical_debt_hotspots/test_technical_debt_hotspots.py
@@ -4,166 +4,149 @@ import unittest
 from unittest import mock
 
 from fastmcp import FastMCP
-
 from . import TechnicalDebtHotspots
 
+PROJECT_ID = 3
+FILE_PATH = "/some-path/some_file.tsx"
+FILE_NAME = "some_file.tsx"
 
+# -----------------------------------------------------------------------------
+# Scenario Data Purpose
+# -----------------------------------------------------------------------------
+# The scenario data below represents all key situations the technical debt
+# hotspot API should handle for both project-level and file-level queries.
+# Each scenario dictionary specifies:
+#   - The test case name ('name')
+#   - The mock data returned by the API ('mock_return')
+#   - The expected output ('expected')
+#   - Whether the test simulates an on-premises CodeScene instance ('onprem')
+#   - Whether the query is for a whole project or a specific file ('method')
+#
+# These scenarios ensure the test suite covers:
+#   - No hotspots found (empty results)
+#   - A single hotspot found (with details)
+#   - Correct handling of both cloud and on-prem URLs
+#   - Both project-wide and file-specific queries
+#
+# This structure makes the tests easy to extend and guarantees robust coverage
+# of all major API behaviors.
+# -----------------------------------------------------------------------------
+
+project_none_found = {
+    "name": "project_none_found",
+    "mock_return": [],
+    "expected": {
+        "hotspots": [],
+        "description": f"Found 0 files with technical debt hotspots for project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/technical-debt/system-map#hotspots"
+    },
+    "onprem": False,
+    "method": "project"
+}
+project_single_hotspot_found = {
+    "name": "project_some_found",
+    "mock_return": [{"path": "some_path"}],
+    "expected": {
+        "hotspots": [{"path": "some_path"}],
+        "description": f"Found 1 files with technical debt hotspots for project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/technical-debt/system-map#hotspots"
+    },
+    "onprem": False,
+    "method": "project"
+}
+project_single_hotspot_found_onprem = {
+    "name": "project_some_found_onprem",
+    "mock_return": [{"path": "some_path"}],
+    "expected": {
+        "hotspots": [{"path": "some_path"}],
+        "description": f"Found 1 files with technical debt hotspots for project ID {PROJECT_ID}.",
+        "link": f"https://onprem-codescene.io/{PROJECT_ID}/analyses/latest/code/technical-debt/system-map#hotspots"
+    },
+    "onprem": True,
+    "method": "project"
+}
+
+# Now provide the variations on hotspots files to test:
+file_none_found = {
+    "name": "file_none_found",
+    "mock_return": [],
+    "expected": {
+        "hotspot": {},
+        "description": f"Found no technical debt hotspot for file {FILE_NAME} in project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/technical-debt/system-map#hotspots"
+    },
+    "onprem": False,
+    "method": "file"
+}
+file_single_hotspot_found = {
+    "name": "file_some_found",
+    "mock_return": [{"path": FILE_NAME, "revisions": 55}],
+    "expected": {
+        "hotspot": {"path": FILE_NAME, "revisions": 55},
+        "description": f"Found technical debt hotspot for file {FILE_NAME} in project ID {PROJECT_ID}.",
+        "link": f"https://codescene.io/projects/{PROJECT_ID}/analyses/latest/code/technical-debt/system-map#hotspots"
+    },
+    "onprem": False,
+    "method": "file"
+}
+file_single_hotspot_found_onprem = {
+    "name": "file_some_found_onprem",
+    "mock_return": [{"path": FILE_NAME, "revisions": 55}],
+    "expected": {
+        "hotspot": {"path": FILE_NAME, "revisions": 55},
+        "description": f"Found technical debt hotspot for file {FILE_NAME} in project ID {PROJECT_ID}.",
+        "link": f"https://onprem-codescene.io/{PROJECT_ID}/analyses/latest/code/technical-debt/system-map#hotspots"
+    },
+    "onprem": True,
+    "method": "file"
+}
 class TestTechnicalDebtHotspots(unittest.TestCase):
-    def test_list_technical_debt_hotspots_for_project_none_found(self):
-        def mocked_query_api_list(*kwargs):
-            return []
+    def setUp(self):
+        self.project_id = PROJECT_ID
+        self.file_path = FILE_PATH
+        self.file_name = FILE_NAME
 
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
+    def make_instance(self, query_api_list_fn):
+        return TechnicalDebtHotspots(FastMCP("Test"), {'query_api_list_fn': query_api_list_fn})
 
-        expected = {
-            "hotspots": [],
-            "description": "Found 0 files with technical debt hotspots for project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/technical-debt/system-map#hotspots"
-        }
+    def assert_json_result(self, actual, expected):
+        self.assertEqual(expected, json.loads(actual))
 
-        result = self.instance.list_technical_debt_hotspots_for_project(3)
+    def _patch_environment(self, scenario):
+        patch_dict = {}
+        if scenario["onprem"]:
+            patch_dict["CS_ONPREM_URL"] = "https://onprem-codescene.io"
+        if scenario["method"] == "file":
+            patch_dict["CS_MOUNT_PATH"] = "/some-path"
+        return mock.patch.dict(os.environ, patch_dict)
 
-        self.assertEqual(expected, json.loads(result))
+    def _make_mocked_instance(self, scenario):
+        def mocked_query_api_list(*args, **kwargs):
+            return scenario["mock_return"]
+        return TechnicalDebtHotspots(FastMCP("Test"), {'query_api_list_fn': mocked_query_api_list})
 
-    def test_list_technical_debt_hotspots_for_project_some_found(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_path'
-            }]
+    def _execute_scenario(self, scenario):
+        with self._patch_environment(scenario):
+            instance = self._make_mocked_instance(scenario)
+            if scenario["method"] == "project":
+                return instance.list_technical_debt_hotspots_for_project(self.project_id)
+          
+            return instance.list_technical_debt_hotspots_for_project_file(self.file_path, self.project_id)
 
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
+    def _assert_scenario(self, scenario):
+        result = self._execute_scenario(scenario)
+        self.assert_json_result(result, scenario["expected"])
 
-        expected = {
-            "hotspots": [{
-                'path': 'some_path'
-            }],
-            "description": "Found 1 files with technical debt hotspots for project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/technical-debt/system-map#hotspots"
-        }
-
-        result = self.instance.list_technical_debt_hotspots_for_project(3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_ONPREM_URL": "https://onprem-codescene.io"})
-    def test_list_technical_debt_hotspots_for_project_some_found_onprem(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_path'
-            }]
-
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "hotspots": [{
-                'path': 'some_path'
-            }],
-            "description": "Found 1 files with technical debt hotspots for project ID 3.",
-            "link": "https://onprem-codescene.io/3/analyses/latest/code/technical-debt/system-map#hotspots"
-        }
-
-        result = self.instance.list_technical_debt_hotspots_for_project(3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    def test_list_technical_debt_hotspots_for_project_throws(self):
-        def mocked_query_api_list(*kwargs):
-            raise Exception("Some error")
-
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = "Error: Some error"
-        result = self.instance.list_technical_debt_hotspots_for_project(3)
-
-        self.assertEqual(expected, result)
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
-    def test_list_technical_debt_hotspots_for_project_file_none_found(self):
-        def mocked_query_api_list(*kwargs):
-            return []
-
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "hotspot": {},
-            "description": "Found no technical debt hotspot for file some_file.tsx in project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/technical-debt/system-map#hotspots"
-        }
-
-        result = self.instance.list_technical_debt_hotspots_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
-    def test_list_technical_debt_hotspots_for_project_file_some_found(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_file.tsx',
-                'revisions': 55
-            }]
-
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "hotspot": {
-                'path': 'some_file.tsx',
-                'revisions': 55
-            },
-            "description": "Found technical debt hotspot for file some_file.tsx in project ID 3.",
-            "link": "https://codescene.io/projects/3/analyses/latest/code/technical-debt/system-map#hotspots"
-        }
-
-        result = self.instance.list_technical_debt_hotspots_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path", "CS_ONPREM_URL": "https://onprem-codescene.io"})
-    def test_list_technical_debt_hotspots_for_project_file_some_found_onprem(self):
-        def mocked_query_api_list(*kwargs):
-            return [{
-                'path': 'some_file.tsx',
-                'revisions': 55
-            }]
-
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = {
-            "hotspot": {
-                'path': 'some_file.tsx',
-                'revisions': 55
-            },
-            "description": "Found technical debt hotspot for file some_file.tsx in project ID 3.",
-            "link": "https://onprem-codescene.io/3/analyses/latest/code/technical-debt/system-map#hotspots"
-        }
-
-        result = self.instance.list_technical_debt_hotspots_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, json.loads(result))
-
-    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/some-path"})
-    def test_list_technical_debt_hotspots_for_project_file_throws(self):
-        def mocked_query_api_list(*kwargs):
-            raise Exception("Some error")
-
-        self.instance = TechnicalDebtHotspots(FastMCP("Test"), {
-            'query_api_list_fn': mocked_query_api_list
-        })
-
-        expected = "Error: Some error"
-        result = self.instance.list_technical_debt_hotspots_for_project_file("/some-path/some_file.tsx", 3)
-
-        self.assertEqual(expected, result)
+    def test_td_hotspots_api_scenarios(self):
+        """A table-driven test that executes all technical debt hotspot scenarios."""
+        all_scenarios = [
+            project_none_found,
+            project_single_hotspot_found,
+            project_single_hotspot_found_onprem,
+            file_none_found,
+            file_single_hotspot_found,
+            file_single_hotspot_found_onprem,
+        ]
+        for scenario in all_scenarios:
+            with self.subTest(scenario=scenario["name"]):
+                self._assert_scenario(scenario)


### PR DESCRIPTION
The Code Health is strong, but two test suites stand out as having 9.3 in Code Health. 
We want to keep the code at a perfect 10.0 so that everything remains AI-friendly.

This PR refactors the identified code duplication by shifting the testing to a table-driven approach. 
Hopefully, those tests communicate the intent and purpose of the tests better, too.