### PR TITLE
CS-5718: Make MCP server Nuitka ready, create static binaries

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -28,12 +28,12 @@ jobs:
             arch: amd64
             cli-url: https://downloads.codescene.io/enterprise/cli/cs-macos-amd64-latest.zip
             artifact-name: cs-mcp-macos-amd64
-            output-path: cs-mcp-macos-amd64
+            output-path: cs-mcp
           - os: macos-latest
             arch: aarch64
             cli-url: https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip
             artifact-name: cs-mcp-macos-aarch64
-            output-path: cs-mcp-macos-aarch64
+            output-path: cs-mcp
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,9 +1,13 @@
-name: Build executables
+name: Build and publish executables
 
-on:
+on: 
   pull_request:
     branches:
       - main
+  # push:
+  #   tags:
+  #     - 'MCP-[0-9]+.[0-9]+.[0-9]+'
+  #     - 'MCP-[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build-exe-linux-x86:
@@ -40,7 +44,7 @@ jobs:
           name: cs-mcp-linux-x86
           path: cs-mcp
 
-  build-exe-linux-arm:
+  build-exe-linux-aarch64:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -71,7 +75,7 @@ jobs:
       - name: Upload Executable Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cs-mcp-linux-arm
+          name: cs-mcp-linux-aarch64
           path: cs-mcp
 
   build-exe-macos:
@@ -134,6 +138,7 @@ jobs:
       - name: Build Executable
         run: |
           .\venv\Scripts\python -m nuitka --onefile `
+            --assume-yes-for-downloads `
             --include-data-dir=./src/docs=src/docs `
             --include-data-files=./cs.exe=cs `
             --output-filename=cs-mcp.exe `
@@ -144,3 +149,26 @@ jobs:
         with:
           name: cs-mcp-x86.exe
           path: cs-mcp.exe
+        
+  # publish-to-release:
+  #   permissions:
+  #     contents: write 
+  #   needs: [build-exe-linux-x86, build-exe-linux-aarch64, build-exe-macos, build-exe-windows-x86] # Make sure this matches your build job ID
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download all artifacts
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         path: ./all-binaries
+  #         merge-multiple: true
+
+  #     - name: Upload to Existing Release
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         tag_name: ${{ github.ref_name }}
+  #         files: |
+  #           ./all-binaries/cs-mcp-linux-x86
+  #           ./all-binaries/cs-mcp-linux-aarch64
+  #           ./all-binaries/cs-mcp-macos
+  #           ./all-binaries/cs-mcp.exe
+  #         append_body: true

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,13 +1,13 @@
 name: Build and publish executables
 
 on: 
-  pull_request:
-    branches:
-      - main
-  # push:
-  #   tags:
-  #     - 'MCP-[0-9]+.[0-9]+.[0-9]+'
-  #     - 'MCP-[0-9]+.[0-9]+.[0-9]+-*'
+  # pull_request:
+  #   branches:
+  #     - main
+  push:
+    tags:
+      - 'MCP-[0-9]+.[0-9]+.[0-9]+'
+      - 'MCP-[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
   build-exe-unix:
@@ -142,22 +142,22 @@ jobs:
   #       with:
   #         name: cs-mcp-aarch64.exe
         
-  # publish-to-release:
-  #   permissions:
-  #     contents: write 
-  #   needs: [build-exe-unix, build-exe-windows-amd64]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Download all artifacts
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         path: ./all-binaries
-  #         merge-multiple: true
+  publish-to-release:
+    permissions:
+      contents: write 
+    needs: [build-exe-unix, build-exe-windows-amd64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./all-binaries
+          merge-multiple: true
 
-  #     - name: Upload to Existing Release
-  #       uses: softprops/action-gh-release@v2
-  #       with:
-  #         tag_name: ${{ github.ref_name }}
-  #         files: |
-  #           ./all-binaries/*
-  #         append_body: true
+      - name: Upload to Existing Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            ./all-binaries/*
+          append_body: true

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -6,10 +6,9 @@ on:
       - main
 
 jobs:
-  build-exe-linux:
+  build-exe-linux-x86:
     runs-on: ubuntu-24.04
     steps:
-      # Checkout source code and setup
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -34,3 +33,114 @@ jobs:
         run: |
           source .venv/bin/activate
           make create-executable
+
+      - name: Upload Executable Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cs-mcp-linux-x86
+          path: cs-mcp
+
+  build-exe-linux-arm:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13' 
+
+      - name: Install deps
+        run: |
+          python -m venv .venv/
+          source .venv/bin/activate
+          pip install -r src/requirements.txt
+          pip install Nuitka
+
+      - name: Download CodeScene CLI zip
+        run: |
+          wget https://downloads.codescene.io/enterprise/cli/cs-linux-aarch64-latest.zip -O codescene-cli-linux.zip
+          unzip codescene-cli-linux.zip -d .
+
+      - name: Build Executable
+        run: |
+          source .venv/bin/activate
+          make create-executable
+
+      - name: Upload Executable Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cs-mcp-linux-arm
+          path: cs-mcp
+
+  build-exe-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13' 
+
+      - name: Install deps
+        run: |
+          python -m venv .venv/
+          source .venv/bin/activate
+          pip install -r src/requirements.txt
+          pip install Nuitka
+
+      - name: Download CodeScene CLI zip
+        run: |
+          wget https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip -O codescene-cli-macos.zip
+          unzip codescene-cli-macos.zip -d .
+
+      - name: Build Executable
+        run: |
+          source .venv/bin/activate
+          make create-executable
+
+      - name: Upload Executable Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: cs-mcp-macos
+          path: cs-mcp
+
+  build-windows-x86:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: actions/setup-python@v5 # Standard stable version
+        with:
+          python-version: '3.13'
+
+      - name: Install deps
+        run: |
+          python -m venv venv
+          .\venv\Scripts\python -m pip install --upgrade pip
+          .\venv\Scripts\pip install -r src/requirements.txt
+          .\venv\Scripts\pip install Nuitka
+
+      - name: Download CodeScene CLI zip
+        run: |
+          Invoke-WebRequest -Uri "https://downloads.codescene.io/enterprise/cli/cs-windows-amd64-latest.zip" -OutFile "codescene-cli-windows.zip"
+          Expand-Archive -Path "codescene-cli-windows.zip" -DestinationPath "."
+
+      - name: Build Executable
+        run: |
+          .\venv\Scripts\python -m nuitka --onefile `
+            --include-data-dir=./src/docs=src/docs `
+            --include-data-files=./cs=cs `
+            --output-filename=cs-mcp.exe `
+            src/cs_mcp_server.py
+
+      - name: Upload Executable Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cs-mcp-x86.exe
+          path: cs-mcp.exe

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -10,8 +10,31 @@ on:
   #     - 'MCP-[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
-  build-exe-linux-amd64:
-    runs-on: ubuntu-24.04
+  build-exe-unix:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            arch: amd64
+            cli-url: https://downloads.codescene.io/enterprise/cli/cs-linux-amd64-latest.zip
+            artifact-name: cs-mcp-linux-amd64
+            output-path: cs-mcp
+          - os: ubuntu-24.04
+            arch: aarch64
+            cli-url: https://downloads.codescene.io/enterprise/cli/cs-linux-aarch64-latest.zip
+            artifact-name: cs-mcp-linux-aarch64
+            output-path: cs-mcp
+          - os: macos-14-large
+            arch: amd64
+            cli-url: https://downloads.codescene.io/enterprise/cli/cs-macos-amd64-latest.zip
+            artifact-name: cs-mcp-macos-amd64
+            output-path: cs-mcp-macos-amd64
+          - os: macos-latest
+            arch: aarch64
+            cli-url: https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip
+            artifact-name: cs-mcp-macos-aarch64
+            output-path: cs-mcp-macos-aarch64
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,10 +51,10 @@ jobs:
           pip install -r src/requirements.txt
           pip install Nuitka
 
-      - name: Download CodeScene CLI zip
+      - name: Download CodeScene CLI
         run: |
-          wget https://downloads.codescene.io/enterprise/cli/cs-linux-amd64-latest.zip -O codescene-cli-linux.zip
-          unzip codescene-cli-linux.zip -d .
+          wget ${{ matrix.cli-url }} -O codescene-cli.zip
+          unzip codescene-cli.zip -d .
 
       - name: Build Executable
         run: |
@@ -41,110 +64,8 @@ jobs:
       - name: Upload Executable Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cs-mcp-linux-amd64
-          path: cs-mcp
-
-  build-exe-linux-aarch64:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13' 
-
-      - name: Install deps
-        run: |
-          python -m venv .venv/
-          source .venv/bin/activate
-          pip install -r src/requirements.txt
-          pip install Nuitka
-
-      - name: Download CodeScene CLI zip
-        run: |
-          wget https://downloads.codescene.io/enterprise/cli/cs-linux-aarch64-latest.zip -O codescene-cli-linux.zip
-          unzip codescene-cli-linux.zip -d .
-
-      - name: Build Executable
-        run: |
-          source .venv/bin/activate
-          make create-executable
-
-      - name: Upload Executable Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cs-mcp-linux-aarch64
-          path: cs-mcp
-
-  build-exe-macos-amd64:
-    runs-on: macos-14-large
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13' 
-
-      - name: Install deps
-        run: |
-          python -m venv .venv/
-          source .venv/bin/activate
-          pip install -r src/requirements.txt
-          pip install Nuitka
-
-      - name: Download CodeScene CLI zip
-        run: |
-          wget https://downloads.codescene.io/enterprise/cli/cs-macos-amd64-latest.zip -O codescene-cli-macos.zip
-          unzip codescene-cli-macos.zip -d .
-
-      - name: Build Executable
-        run: |
-          source .venv/bin/activate
-          make create-executable
-
-      - name: Upload Executable Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cs-mcp-macos-amd64
-          path: cs-mcp-macos-amd64
-
-  build-exe-macos-aarch64:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13' 
-
-      - name: Install deps
-        run: |
-          python -m venv .venv/
-          source .venv/bin/activate
-          pip install -r src/requirements.txt
-          pip install Nuitka
-
-      - name: Download CodeScene CLI zip
-        run: |
-          wget https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip -O codescene-cli-macos.zip
-          unzip codescene-cli-macos.zip -d .
-
-      - name: Build Executable
-        run: |
-          source .venv/bin/activate
-          make create-executable
-
-      - name: Upload Executable Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cs-mcp-macos-aarch64
-          path: cs-mcp-macos-aarch64
+          name: ${{ matrix.artifact-name }}
+          path: ${{ matrix.output-path }}
 
   build-exe-windows-amd64:
     runs-on: windows-latest
@@ -174,7 +95,7 @@ jobs:
           .\venv\Scripts\python -m nuitka --onefile `
             --assume-yes-for-downloads `
             --include-data-dir=./src/docs=src/docs `
-            --include-data-files=./cs.exe=cs `
+            --include-data-files=./cs.exe=cs.exe `
             --output-filename=cs-mcp.exe `
             src/cs_mcp_server.py
 
@@ -184,47 +105,47 @@ jobs:
           name: cs-mcp-amd64.exe
           path: cs-mcp.exe
 
-  build-exe-windows-aarch64:
-    runs-on: windows-11-arm
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  # build-exe-windows-aarch64:
+  #   runs-on: windows-11-arm
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
       
-      - uses: actions/setup-python@v5 # Standard stable version
-        with:
-          python-version: '3.13'
+  #     - uses: actions/setup-python@v5 # Standard stable version
+  #       with:
+  #         python-version: '3.13'
 
-      - name: Install deps
-        run: |
-          python -m venv venv
-          .\venv\Scripts\python -m pip install --upgrade pip
-          .\venv\Scripts\pip install -r src/requirements.txt
-          .\venv\Scripts\pip install Nuitka
+  #     - name: Install deps
+  #       run: |
+  #         python -m venv venv
+  #         .\venv\Scripts\python -m pip install --upgrade pip
+  #         .\venv\Scripts\pip install -r src/requirements.txt
+  #         .\venv\Scripts\pip install Nuitka
 
-      - name: Download CodeScene CLI zip
-        run: |
-          Invoke-WebRequest -Uri "https://downloads.codescene.io/enterprise/cli/cs-windows-aarch64-latest.zip" -OutFile "codescene-cli-windows.zip"
-          Expand-Archive -Path "codescene-cli-windows.zip" -DestinationPath "."
+  #     - name: Download CodeScene CLI zip
+  #       run: |
+  #         Invoke-WebRequest -Uri "https://downloads.codescene.io/enterprise/cli/cs-windows-amd64-latest.zip" -OutFile "codescene-cli-windows.zip"
+  #         Expand-Archive -Path "codescene-cli-windows.zip" -DestinationPath "."
 
-      - name: Build Executable
-        run: |
-          .\venv\Scripts\python -m nuitka --onefile `
-            --assume-yes-for-downloads `
-            --include-data-dir=./src/docs=src/docs `
-            --include-data-files=./cs.exe=cs `
-            --output-filename=cs-mcp.exe `
-            src/cs_mcp_server.py
+  #     - name: Build Executable
+  #       run: |
+  #         .\venv\Scripts\python -m nuitka --onefile `
+  #           --assume-yes-for-downloads `
+  #           --include-data-dir=./src/docs=src/docs `
+  #           --include-data-files=./cs.exe=cs `
+  #           --output-filename=cs-mcp.exe `
+  #           src/cs_mcp_server.py
 
-      - name: Upload Executable Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cs-mcp-aarch64.exe
+  #     - name: Upload Executable Artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: cs-mcp-aarch64.exe
         
   # publish-to-release:
   #   permissions:
   #     contents: write 
-  #   needs: [build-exe-linux-amd64, build-exe-linux-aarch64, build-exe-macos-amd64, build-exe-macos-aarch64, build-exe-windows-amd64, build-exe-windows-aarch64]
+  #   needs: [build-exe-unix, build-exe-windows-amd64]
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Download all artifacts

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -25,10 +25,10 @@ jobs:
           pip install -r src/requirements.txt
           pip install Nuitka
 
-      - name: Download CodeScene CLI
+      - name: Download CodeScene CLI zip
         run: |
-          RUN curl https://downloads.codescene.io/enterprise/cli/install-cs-tool.sh | bash -s -- -y
-          cp /root/.local/bin/cs ./cs
+          wget https://downloads.codescene.io/enterprise/cli/cs-linux-amd64-latest.zip -O codescene-cli-linux.zip
+          unzip codescene-cli-linux.zip -d .
 
       - name: Build Executable
         run: |

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -25,6 +25,11 @@ jobs:
           pip install -r src/requirements.txt
           pip install Nuitka
 
+      - name: Download CodeScene CLI
+        run: |
+          RUN curl https://downloads.codescene.io/enterprise/cli/install-cs-tool.sh | bash -s -- -y
+          cp /root/.local/bin/cs ./cs
+
       - name: Build Executable
         run: |
           source .venv/bin/activate

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -183,11 +183,48 @@ jobs:
         with:
           name: cs-mcp-amd64.exe
           path: cs-mcp.exe
+
+  build-exe-windows-aarch64:
+    runs-on: windows-11-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: actions/setup-python@v5 # Standard stable version
+        with:
+          python-version: '3.13'
+
+      - name: Install deps
+        run: |
+          python -m venv venv
+          .\venv\Scripts\python -m pip install --upgrade pip
+          .\venv\Scripts\pip install -r src/requirements.txt
+          .\venv\Scripts\pip install Nuitka
+
+      - name: Download CodeScene CLI zip
+        run: |
+          Invoke-WebRequest -Uri "https://downloads.codescene.io/enterprise/cli/cs-windows-aarch64-latest.zip" -OutFile "codescene-cli-windows.zip"
+          Expand-Archive -Path "codescene-cli-windows.zip" -DestinationPath "."
+
+      - name: Build Executable
+        run: |
+          .\venv\Scripts\python -m nuitka --onefile `
+            --assume-yes-for-downloads `
+            --include-data-dir=./src/docs=src/docs `
+            --include-data-files=./cs.exe=cs `
+            --output-filename=cs-mcp.exe `
+            src/cs_mcp_server.py
+
+      - name: Upload Executable Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cs-mcp-aarch64.exe
         
   # publish-to-release:
   #   permissions:
   #     contents: write 
-  #   needs: [build-exe-linux-amd64, build-exe-linux-aarch64, build-exe-macos-amd64, build-exe-macos-aarch64, build-exe-windows-amd64]
+  #   needs: [build-exe-linux-amd64, build-exe-linux-aarch64, build-exe-macos-amd64, build-exe-macos-aarch64, build-exe-windows-amd64, build-exe-windows-aarch64]
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Download all artifacts
@@ -201,8 +238,5 @@ jobs:
   #       with:
   #         tag_name: ${{ github.ref_name }}
   #         files: |
-  #           ./all-binaries/cs-mcp-linux-x86
-  #           ./all-binaries/cs-mcp-linux-aarch64
-  #           ./all-binaries/cs-mcp-macos
-  #           ./all-binaries/cs-mcp.exe
+  #           ./all-binaries/*
   #         append_body: true

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -108,7 +108,7 @@ jobs:
           name: cs-mcp-macos
           path: cs-mcp
 
-  build-windows-x86:
+  build-exe-windows-x86:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -135,7 +135,7 @@ jobs:
         run: |
           .\venv\Scripts\python -m nuitka --onefile `
             --include-data-dir=./src/docs=src/docs `
-            --include-data-files=./cs=cs `
+            --include-data-files=./cs.exe=cs `
             --output-filename=cs-mcp.exe `
             src/cs_mcp_server.py
 

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,31 @@
+name: Build executables
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-exe-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      # Checkout source code and setup
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13' 
+
+      - name: Install deps
+        run: |
+          python -m venv .venv/
+          source .venv/bin/activate
+          pip install -r src/requirements.txt
+          pip install Nuitka
+
+      - name: Build Executable
+        run: |
+          source .venv/bin/activate
+          make create-executable

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -10,7 +10,7 @@ on:
   #     - 'MCP-[0-9]+.[0-9]+.[0-9]+-*'
 
 jobs:
-  build-exe-linux-x86:
+  build-exe-linux-amd64:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       - name: Upload Executable Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cs-mcp-linux-x86
+          name: cs-mcp-linux-amd64
           path: cs-mcp
 
   build-exe-linux-aarch64:
@@ -78,7 +78,41 @@ jobs:
           name: cs-mcp-linux-aarch64
           path: cs-mcp
 
-  build-exe-macos:
+  build-exe-macos-amd64:
+    runs-on: macos-14-large
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13' 
+
+      - name: Install deps
+        run: |
+          python -m venv .venv/
+          source .venv/bin/activate
+          pip install -r src/requirements.txt
+          pip install Nuitka
+
+      - name: Download CodeScene CLI zip
+        run: |
+          wget https://downloads.codescene.io/enterprise/cli/cs-macos-amd64-latest.zip -O codescene-cli-macos.zip
+          unzip codescene-cli-macos.zip -d .
+
+      - name: Build Executable
+        run: |
+          source .venv/bin/activate
+          make create-executable
+
+      - name: Upload Executable Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cs-mcp-macos-amd64
+          path: cs-mcp-macos-amd64
+
+  build-exe-macos-aarch64:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -109,10 +143,10 @@ jobs:
       - name: Upload Executable Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cs-mcp-macos
-          path: cs-mcp
+          name: cs-mcp-macos-aarch64
+          path: cs-mcp-macos-aarch64
 
-  build-exe-windows-x86:
+  build-exe-windows-amd64:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -147,13 +181,13 @@ jobs:
       - name: Upload Executable Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cs-mcp-x86.exe
+          name: cs-mcp-amd64.exe
           path: cs-mcp.exe
         
   # publish-to-release:
   #   permissions:
   #     contents: write 
-  #   needs: [build-exe-linux-x86, build-exe-linux-aarch64, build-exe-macos, build-exe-windows-x86] # Make sure this matches your build job ID
+  #   needs: [build-exe-linux-amd64, build-exe-linux-aarch64, build-exe-macos-amd64, build-exe-macos-aarch64, build-exe-windows-amd64]
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Download all artifacts

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -35,7 +35,7 @@ jobs:
           make create-executable
 
       - name: Upload Executable Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cs-mcp-linux-x86
           path: cs-mcp
@@ -69,7 +69,7 @@ jobs:
           make create-executable
 
       - name: Upload Executable Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cs-mcp-linux-arm
           path: cs-mcp
@@ -103,7 +103,7 @@ jobs:
           make create-executable
 
       - name: Upload Executable Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cs-mcp-macos
           path: cs-mcp

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
 __pycache__
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 create-executable:
 	python3.13 -m nuitka --onefile \
+	--assume-yes-for-downloads \
 	--include-data-dir=./src/docs=src/docs \
 	--include-data-files=./cs=cs \
 	--output-filename=cs-mcp \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+create-executable:
+	python3.13 -m nuitka --onefile \
+	--include-data-dir=./src/docs=src/docs \
+	--include-data-files=./cs=cs \
+	--output-filename=cs-mcp \
+	src/cs_mcp_server.py

--- a/README.md
+++ b/README.md
@@ -491,63 +491,7 @@ seems to hallucinate parts of the path some of the time. We're still investigati
 
 </details>
 
-## Building the docker instance locally
+## Building Locally
 
-You can build and run the dockerized CodeScene MCP server by first cloning the repo and then building the Docker image:
-
-```sh
-docker build -t codescene-mcp .
-```
-
-And then configuring the MCP in your editor, for example in VS Code:
-
-```json
-"codescene-mcp": {
-    "type": "stdio",
-    "command": "docker",
-    "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "CS_ACCESS_TOKEN",
-        "-e",
-        "CS_MOUNT_PATH=<PATH_TO_CODE>",
-        "--mount",
-        "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro",
-        "codescene-mcp"
-    ]
-}
-```
-
-This configuration will automatically pick up the `CS_ACCESS_TOKEN` environment variable, but if you can't create a system-wide one then you can manually specify it like this:
-
-```json
-"codescene-mcp": {
-    "type": "stdio",
-    "command": "docker",
-    "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "CS_ACCESS_TOKEN",
-        "-e",
-        "CS_MOUNT_PATH=<PATH_TO_CODE>",
-        "--mount",
-        "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro",
-        "codescene-mcp"
-    ],
-    "env": {
-		"CS_ACCESS_TOKEN": "token-goes-here",
-    }
-}
-```
-
-Or when running it from the CLI, like this:
-
-```sh
-docker run -i --rm -e CS_ACCESS_TOKEN=token-goes-here codescene-mcp
-```
-
-**Note:** if you want to use CodeScene On-prem, you need to additionally pass the `CS_ONPREM_URL` environment variable to it.
+- [Building the Docker image locally](docs/building-docker-locally.md)
+- [Building a static executable locally](docs/building-executable-locally.md)

--- a/docs/building-docker-locally.md
+++ b/docs/building-docker-locally.md
@@ -1,0 +1,60 @@
+# Building the Docker Instance Locally
+
+You can build and run the dockerized CodeScene MCP server by first cloning the repo and then building the Docker image:
+
+```sh
+docker build -t codescene-mcp .
+```
+
+And then configuring the MCP in your editor, for example in VS Code:
+
+```json
+"codescene-mcp": {
+    "type": "stdio",
+    "command": "docker",
+    "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "CS_ACCESS_TOKEN",
+        "-e",
+        "CS_MOUNT_PATH=<PATH_TO_CODE>",
+        "--mount",
+        "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro",
+        "codescene-mcp"
+    ]
+}
+```
+
+This configuration will automatically pick up the `CS_ACCESS_TOKEN` environment variable, but if you can't create a system-wide one then you can manually specify it like this:
+
+```json
+"codescene-mcp": {
+    "type": "stdio",
+    "command": "docker",
+    "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "CS_ACCESS_TOKEN",
+        "-e",
+        "CS_MOUNT_PATH=<PATH_TO_CODE>",
+        "--mount",
+        "type=bind,src=<PATH_TO_CODE>,dst=/mount/,ro",
+        "codescene-mcp"
+    ],
+    "env": {
+		"CS_ACCESS_TOKEN": "token-goes-here",
+    }
+}
+```
+
+Or when running it from the CLI, like this:
+
+```sh
+docker run -i --rm -e CS_ACCESS_TOKEN=token-goes-here codescene-mcp
+```
+
+**Note:** if you want to use CodeScene On-prem, you need to additionally pass the `CS_ONPREM_URL` environment variable to it.

--- a/docs/building-executable-locally.md
+++ b/docs/building-executable-locally.md
@@ -1,0 +1,79 @@
+# Building a Static Executable Locally
+
+If you prefer a standalone binary instead of Docker, you can compile the MCP server into a single executable using [Nuitka](https://nuitka.net/).
+
+## Prerequisites
+
+- **Python 3.13** (required)
+- **Nuitka** (`pip install Nuitka`)
+- **CodeScene CLI** binary (`cs`) for your platform, downloaded from:
+  - Linux amd64: https://downloads.codescene.io/enterprise/cli/cs-linux-amd64-latest.zip
+  - Linux aarch64: https://downloads.codescene.io/enterprise/cli/cs-linux-aarch64-latest.zip
+  - macOS amd64: https://downloads.codescene.io/enterprise/cli/cs-macos-amd64-latest.zip
+  - macOS aarch64: https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip
+  - Windows amd64: https://downloads.codescene.io/enterprise/cli/cs-windows-amd64-latest.zip
+
+## Build Steps
+
+1. Clone the repository and set up a virtual environment:
+
+```sh
+git clone https://github.com/codescene-oss/codescene-mcp.git
+cd codescene-mcp
+python3.13 -m venv .venv
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+```
+
+2. Install dependencies:
+
+```sh
+pip install -r src/requirements.txt
+pip install Nuitka
+```
+
+3. Download and extract the CodeScene CLI for your platform. For example, on macOS aarch64:
+
+```sh
+wget https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip -O codescene-cli.zip
+unzip codescene-cli.zip -d .
+```
+
+4. Build the executable:
+
+**Linux / macOS:**
+```sh
+python3.13 -m nuitka --onefile \
+  --assume-yes-for-downloads \
+  --include-data-dir=./src/docs=src/docs \
+  --include-data-files=./cs=cs \
+  --output-filename=cs-mcp \
+  src/cs_mcp_server.py
+```
+
+**Windows:**
+```powershell
+python -m nuitka --onefile `
+  --assume-yes-for-downloads `
+  --include-data-dir=./src/docs=src/docs `
+  --include-data-files=./cs.exe=cs.exe `
+  --output-filename=cs-mcp.exe `
+  src/cs_mcp_server.py
+```
+
+This will produce a single `cs-mcp` (or `cs-mcp.exe` on Windows) executable that bundles the MCP server, its dependencies, and the CodeScene CLI.
+
+## Using the Executable
+
+Configure your MCP client to use the executable directly instead of Docker. For example, in VS Code:
+
+```json
+"codescene-mcp": {
+    "type": "stdio",
+    "command": "/path/to/cs-mcp",
+    "env": {
+        "CS_ACCESS_TOKEN": "your-token-here"
+    }
+}
+```
+
+Since the executable runs natively without Docker, you don't need to configure mount paths — the MCP server can access files directly from your filesystem.

--- a/src/code_health_auto_refactor/auto_refactor.py
+++ b/src/code_health_auto_refactor/auto_refactor.py
@@ -1,8 +1,9 @@
 import json
 import os
 import re
+from pathlib import Path
 from typing import Callable, TypedDict, Optional
-from utils import adapt_mounted_file_path_inside_docker, cs_cli_path
+from utils import adapt_mounted_file_path_inside_docker, cs_cli_path, find_git_root
 
 class AutoRefactorError(Exception):
     pass
@@ -17,17 +18,19 @@ class AutoRefactor:
 
         mcp_instance.tool(self.code_health_auto_refactor)
 
-    def _run_cs_cli(self, args: list[str]):
-        output = self.deps["run_local_tool_fn"]([cs_cli_path()] + args)
+    def _run_cs_cli(self, args: list[str], git_root: str):
+        output = self.deps["run_local_tool_fn"]([cs_cli_path()] + args, git_root)
         return json.loads(output)
         
-    def _parse_fns(self, file_path: str) -> list[dict]:
-        cli_command = ["parse-fns", "--path", adapt_mounted_file_path_inside_docker(file_path)]
-        return self._run_cs_cli(cli_command)
+    def _parse_fns(self, file_path: str, git_root: str) -> list[dict]:
+        relative_path = str(Path(file_path).relative_to(git_root))
+        cli_command = ["parse-fns", "--path", adapt_mounted_file_path_inside_docker(relative_path)]
+        return self._run_cs_cli(cli_command, git_root)
 
-    def _review(self, file_path: str) -> dict:
-        cli_command = ["review", "--output-format=json", adapt_mounted_file_path_inside_docker(file_path)]
-        return self._run_cs_cli(cli_command)
+    def _review(self, file_path: str, git_root: str) -> dict:
+        relative_path = str(Path(file_path).relative_to(git_root))
+        cli_command = ["review", "--output-format=json", adapt_mounted_file_path_inside_docker(relative_path)]
+        return self._run_cs_cli(cli_command, git_root)
 
     def _get_function(self, functions: list[dict], function_name: str) -> dict:
         return next((f for f in functions if f["name"] == function_name), False)
@@ -98,8 +101,9 @@ class AutoRefactor:
             if os.getenv("CS_ACE_ACCESS_TOKEN") is None:
                 return f"Error: This tool needs a token valid for CodeScene ACE in CS_ACE_ACCESS_TOKEN. See the ACE activation instructions in https://github.com/codescene-oss/codescene-mcp-server?tab=readme-ov-file#-activate-ace-in-codescene-mcp"
             
-            functions = self._parse_fns(file_path)
-            review = self._review(file_path)
+            git_root = find_git_root(file_path)
+            functions = self._parse_fns(file_path, git_root)
+            review = self._review(file_path, git_root)
 
             function = self._get_function(functions, function_name)
             if not function:

--- a/src/code_health_auto_refactor/auto_refactor.py
+++ b/src/code_health_auto_refactor/auto_refactor.py
@@ -3,7 +3,7 @@ import os
 import re
 from pathlib import Path
 from typing import Callable, TypedDict, Optional
-from utils import adapt_mounted_file_path_inside_docker, cs_cli_path, find_git_root
+from utils import adapt_mounted_file_path_inside_docker, cs_cli_path, find_git_root, get_platform_details
 
 class AutoRefactorError(Exception):
     pass
@@ -19,17 +19,26 @@ class AutoRefactor:
         mcp_instance.tool(self.code_health_auto_refactor)
 
     def _run_cs_cli(self, args: list[str], git_root: str):
-        output = self.deps["run_local_tool_fn"]([cs_cli_path()] + args, git_root)
+        output = self.deps["run_local_tool_fn"]([cs_cli_path(get_platform_details())] + args, git_root)
         return json.loads(output)
+    
+    def _get_cli_file_path(self, file_path: str, git_root: str) -> str:
+        """Get the appropriate file path for CLI commands based on environment."""
+        if os.getenv("CS_MOUNT_PATH"):
+            # Docker environment - use mounted path
+            return adapt_mounted_file_path_inside_docker(file_path)
+        else:
+            # Local environment - use relative path from git root
+            return str(Path(file_path).relative_to(git_root))
         
     def _parse_fns(self, file_path: str, git_root: str) -> list[dict]:
-        relative_path = str(Path(file_path).relative_to(git_root))
-        cli_command = ["parse-fns", "--path", adapt_mounted_file_path_inside_docker(relative_path)]
+        cli_path = self._get_cli_file_path(file_path, git_root)
+        cli_command = ["parse-fns", "--path", cli_path]
         return self._run_cs_cli(cli_command, git_root)
 
     def _review(self, file_path: str, git_root: str) -> dict:
-        relative_path = str(Path(file_path).relative_to(git_root))
-        cli_command = ["review", "--output-format=json", adapt_mounted_file_path_inside_docker(relative_path)]
+        cli_path = self._get_cli_file_path(file_path, git_root)
+        cli_command = ["review", "--output-format=json", cli_path]
         return self._run_cs_cli(cli_command, git_root)
 
     def _get_function(self, functions: list[dict], function_name: str) -> dict:

--- a/src/code_health_auto_refactor/test_auto_refactor.py
+++ b/src/code_health_auto_refactor/test_auto_refactor.py
@@ -20,8 +20,9 @@ def mock_run_local_tool(command: list, cwd: str = None):
       return file.read()
     
 class TestAutoRefactor(unittest.TestCase):
+    @mock.patch('code_health_auto_refactor.auto_refactor.find_git_root', return_value='/some-path')
     @mock.patch.dict(os.environ, {"CS_ACE_ACCESS_TOKEN": "some-token", "CS_MOUNT_PATH": "/some-path"})
-    def test_refactor(self):
+    def test_refactor(self, mock_find_git_root):
 
         def mock_post_refactor(payload: dict) -> dict:
             payload['source-snippet'].pop('body')
@@ -84,8 +85,9 @@ class TestAutoRefactor(unittest.TestCase):
 
         self.assertEqual(expected, json.loads(result))
 
+    @mock.patch('code_health_auto_refactor.auto_refactor.find_git_root', return_value='/some-path')
     @mock.patch.dict(os.environ, {"CS_ACE_ACCESS_TOKEN": "some-token", "CS_MOUNT_PATH": "/some-path"})
-    def test_refactor_throws(self):
+    def test_refactor_throws(self, mock_find_git_root):
         def raise_exception(*kwargs):
             raise Exception("Some error")
 
@@ -99,8 +101,9 @@ class TestAutoRefactor(unittest.TestCase):
 
         self.assertEqual(expected, result)
     
+    @mock.patch('code_health_auto_refactor.auto_refactor.find_git_root', return_value='/some-path')
     @mock.patch.dict(os.environ, {"CS_ACE_ACCESS_TOKEN": "some-token", "CS_MOUNT_PATH": "/some-path"})
-    def test_refactor_missing_function(self):
+    def test_refactor_missing_function(self, mock_find_git_root):
         self.instance = AutoRefactor(FastMCP('Test'), {
             'post_refactor_fn': None,
             'run_local_tool_fn': mock_run_local_tool,
@@ -111,8 +114,9 @@ class TestAutoRefactor(unittest.TestCase):
 
         self.assertEqual(expected, result)
         
+    @mock.patch('code_health_auto_refactor.auto_refactor.find_git_root', return_value='/some-path')
     @mock.patch.dict(os.environ, {"CS_ACE_ACCESS_TOKEN": "some-token", "CS_MOUNT_PATH": "/some-path"})
-    def test_refactor_no_code_smells(self):
+    def test_refactor_no_code_smells(self, mock_find_git_root):
         self.instance = AutoRefactor(FastMCP('Test'), {
             'post_refactor_fn': None,
             'run_local_tool_fn': mock_run_local_tool,
@@ -136,8 +140,9 @@ class TestAutoRefactor(unittest.TestCase):
 
         self.assertEqual(expected, result)
          
+    @mock.patch('code_health_auto_refactor.auto_refactor.find_git_root', return_value='/some-path')
     @mock.patch.dict(os.environ, {"CS_ACE_ACCESS_TOKEN": "invalid-token", "CS_MOUNT_PATH": "/some-path"})
-    def test_refactor_invalid_token(self):
+    def test_refactor_invalid_token(self, mock_find_git_root):
         self.instance = AutoRefactor(FastMCP('Test'), {
             'post_refactor_fn': post_refactor,
             'run_local_tool_fn': mock_run_local_tool,

--- a/src/code_health_auto_refactor/test_auto_refactor.py
+++ b/src/code_health_auto_refactor/test_auto_refactor.py
@@ -152,3 +152,20 @@ class TestAutoRefactor(unittest.TestCase):
         result = self.instance.code_health_auto_refactor("/some-path/some-file.cpp", 'Document::moveObject')
 
         self.assertEqual(expected, result)
+
+    @mock.patch('code_health_auto_refactor.auto_refactor.find_git_root', return_value='/some-path')
+    @mock.patch.dict(os.environ, {"CS_ACE_ACCESS_TOKEN": "some-token"}, clear=False)
+    def test_get_cli_file_path_without_mount_path(self, mock_find_git_root):
+        """Test that _get_cli_file_path returns relative path when CS_MOUNT_PATH is not set."""
+        # Remove CS_MOUNT_PATH if it exists
+        os.environ.pop("CS_MOUNT_PATH", None)
+        
+        self.instance = AutoRefactor(FastMCP('Test'), {
+            'post_refactor_fn': None,
+            'run_local_tool_fn': mock_run_local_tool,
+        })
+        
+        result = self.instance._get_cli_file_path("/some-path/src/file.cpp", "/some-path")
+        
+        # Should return relative path
+        self.assertEqual("src/file.cpp", result)

--- a/src/cs_mcp_server.py
+++ b/src/cs_mcp_server.py
@@ -1,3 +1,4 @@
+import os
 from fastmcp import FastMCP
 from fastmcp.resources import FileResource
 from pathlib import Path
@@ -14,6 +15,14 @@ from code_ownership import CodeOwnership
 from utils import query_api_list, analyze_code, run_local_tool, post_refactor
 
 mcp = FastMCP("CodeScene")
+
+def get_resource_path(relative_path):
+    if os.getenv("CS_MOUNT_PATH"):
+        return Path(f"./{relative_path}")
+    else: 
+        base_path = Path(__file__).parent.absolute()
+        return base_path / relative_path
+
 
 # Offer prompts that capture the key use cases. These prompts are more than a 
 # convenience; they also enable feature discoverability and guide users.
@@ -72,7 +81,7 @@ def plan_code_health_refactoring(context: str | None = None) -> str:
 # We want the MCP Server to explain its key concepts like Code Health.
 
 def read_documentation_content_for(md_doc_name):
-    return Path(f"./src/docs/code-health/{md_doc_name}").read_text(encoding="utf-8")
+    return get_resource_path(f"src/docs/code-health/{md_doc_name}").read_text(encoding="utf-8")
 
 @mcp.tool()
 def explain_how_code_health_works(context: str | None = None) -> str:
@@ -100,7 +109,7 @@ def resource_title_from_md_heading_in(path: Path) -> str:
         return first_line.lstrip("#").strip()
 
 def doc_to_file_resources(doc):
-    doc_path = Path(f"./src/docs/code-health/{doc['doc-path']}").resolve()
+    doc_path = get_resource_path(f"src/docs/code-health/{doc['doc-path']}").resolve()
     doc_resource = FileResource(
         uri=f"file://codescene-docs/code-health/{doc['doc-path']}",
         path=doc_path,

--- a/src/pre_commit_code_health_safeguard/delta_analyzer.py
+++ b/src/pre_commit_code_health_safeguard/delta_analyzer.py
@@ -2,7 +2,7 @@ import json
 from typing import TypedDict, Callable, Optional
 
 from code_health_tools.delta_analysis import analyze_delta_output
-from utils import cs_cli_path, adapt_mounted_file_path_inside_docker, run_cs_cli, track, with_version_check
+from utils import cs_cli_path, adapt_mounted_file_path_inside_docker, run_cs_cli, track, with_version_check, get_platform_details
 
 
 class PreCommitCodeHealthSafeguardDeps(TypedDict):
@@ -41,6 +41,6 @@ class PreCommitCodeHealthSafeguard:
                  - findings: an array describing improvements/degradation for each code smell.
              - Each quality gate indicates if the file meets the required Code Health standards, helping teams enforce healthy code before commit.
         """
-        cli_command = [cs_cli_path(), "delta", "--output-format=json"]
+        cli_command = [cs_cli_path(get_platform_details()), "delta", "--output-format=json"]
 
         return run_cs_cli(lambda: self._safeguard_code_on(cli_command, git_repository_path))

--- a/src/pre_commit_code_health_safeguard/test.py
+++ b/src/pre_commit_code_health_safeguard/test.py
@@ -9,7 +9,7 @@ from .delta_analyzer import PreCommitCodeHealthSafeguard
 class TestPreCommitCodeHealthSafeguard(unittest.TestCase):
     @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
     def test_pre_commit_code_health_safeguard(self):
-        def mock_run_local_tool(cli_command, path):
+        def mock_run_local_tool(cli_command, path, extra_env=None):
             return json.dumps([{
                 'name': 'test.tsx'
             }])
@@ -31,7 +31,7 @@ class TestPreCommitCodeHealthSafeguard(unittest.TestCase):
 
     @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
     def test_pre_commit_code_health_safeguard_invalid_response(self):
-        def mock_run_local_tool(cli_command, path):
+        def mock_run_local_tool(cli_command, path, extra_env=None):
             return "string output"
 
         self.instance = PreCommitCodeHealthSafeguard(FastMCP("Test"), {

--- a/src/pre_commit_code_health_safeguard/test_delta_analyzer.py
+++ b/src/pre_commit_code_health_safeguard/test_delta_analyzer.py
@@ -9,7 +9,7 @@ from .delta_analyzer import PreCommitCodeHealthSafeguard
 class TestPreCommitCodeHealthSafeguard(unittest.TestCase):
     @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
     def test_pre_commit_code_health_safeguard(self):
-        def mock_run_local_tool(cli_command, path):
+        def mock_run_local_tool(cli_command, path, extra_env=None):
             return json.dumps([{
                 'name': 'test.tsx'
             }])
@@ -31,7 +31,7 @@ class TestPreCommitCodeHealthSafeguard(unittest.TestCase):
 
     @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
     def test_pre_commit_code_health_safeguard_invalid_response(self):
-        def mock_run_local_tool(cli_command, path):
+        def mock_run_local_tool(cli_command, path, extra_env=None):
             return "string output"
 
         self.instance = PreCommitCodeHealthSafeguard(FastMCP("Test"), {
@@ -43,3 +43,33 @@ Input: string output"""
         result = self.instance.pre_commit_code_health_safeguard("/my/git/path")
 
         self.assertEqual(expected, result)
+
+    def test_pre_commit_code_health_safeguard_local_binary(self):
+        """Test that local/native binary mode works without CS_MOUNT_PATH."""
+        # Ensure CS_MOUNT_PATH is NOT set (simulating native binary)
+        os.environ.pop("CS_MOUNT_PATH", None)
+        
+        captured_path = []
+        
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_path.append(path)
+            return json.dumps([{
+                'name': 'test.tsx'
+            }])
+
+        self.instance = PreCommitCodeHealthSafeguard(FastMCP("Test"), {
+            'run_local_tool_fn': mock_run_local_tool
+        })
+
+        expected = {
+            "results": [
+                {"name": "test.tsx", "verdict": "unknown", "findings": []}
+            ],
+            "quality_gates": "passed"
+        }
+
+        result = self.instance.pre_commit_code_health_safeguard("/my/local/git/path")
+
+        self.assertEqual(json.dumps(expected), result)
+        # Verify the path was passed directly without Docker translation
+        self.assertEqual(captured_path[-1], "/my/local/git/path")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,5 @@
 from .docker_path_adapter import adapt_mounted_file_path_inside_docker
+from .platform_details import get_platform_details, PlatformDetails
 from .codescene_api_client import (
     normalize_onprem_url, 
     get_api_url, 
@@ -14,6 +15,7 @@ from .code_health_analysis import (
     make_cs_cli_review_command_for,
     cs_cli_review_command_for,
     analyze_code,
+    find_git_root,
 )
 from .ace_api_client import (
     post_refactor

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,4 @@
-from .docker_path_adapter import adapt_mounted_file_path_inside_docker
+from .docker_path_adapter import adapt_mounted_file_path_inside_docker, adapt_worktree_gitdir_for_docker
 from .platform_details import get_platform_details, PlatformDetails
 from .codescene_api_client import (
     normalize_onprem_url, 

--- a/src/utils/code_health_analysis.py
+++ b/src/utils/code_health_analysis.py
@@ -3,8 +3,38 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 from errors import CodeSceneCliError
 from .docker_path_adapter import adapt_mounted_file_path_inside_docker
+from .platform_details import get_platform_details
+
+
+def find_git_root(file_path: str) -> str:
+    """
+    Finds the git repository root for a given file path.
+    
+    Args:
+        file_path (str): Path to a file in the repository
+        
+    Returns:
+        str: Path to the git repository root
+        
+    Raises:
+        CodeSceneCliError: If not in a git repository
+    """
+    current_path = Path(file_path).resolve()
+    
+    # If it's a file, start from its parent directory
+    if current_path.is_file():
+        current_path = current_path.parent
+    
+    # Walk up the directory tree looking for .git
+    while current_path != current_path.parent:
+        if (current_path / '.git').exists():
+            return str(current_path)
+        current_path = current_path.parent
+    
+    raise CodeSceneCliError(f"Not in a git repository: {file_path}")
 
 
 def run_local_tool(command: list, cwd: str = None):
@@ -18,17 +48,30 @@ def run_local_tool(command: list, cwd: str = None):
     Returns:
         str: Combined stdout and stderr output
     """
-    env = {
-        'CS_CONTEXT': 'mcp-server',
-        'CS_ACCESS_TOKEN': os.getenv("CS_ACCESS_TOKEN", "")
-    }
+    # Start with a copy of the current environment
+    env = os.environ.copy()
+    
+    # Override/add MCP-specific variables
+    env['CS_CONTEXT'] = 'mcp-server'
+    env['CS_ACCESS_TOKEN'] = os.getenv("CS_ACCESS_TOKEN", "")
 
     if os.getenv("CS_ONPREM_URL"):
         env['CS_ONPREM_URL'] = os.getenv("CS_ONPREM_URL")
 
+    # Apply platform-specific environment configuration
+    platform = get_platform_details()
+    
+    # Set platform-specific Java options (e.g., temp directory on Windows)
+    java_options = platform.get_java_options()
+    if java_options:
+        env['_JAVA_OPTIONS'] = java_options
+    
+    env = platform.configure_environment(env)
+
     result = subprocess.run(command, capture_output=True, text=True, cwd=cwd, env=env)
     if result.returncode != 0:
         raise CodeSceneCliError(f"CLI command failed: {result.stderr}")
+    
     return result.stdout
 
 
@@ -56,28 +99,29 @@ def code_health_from_cli_output(cli_output) -> float:
     return r['score']
 
 
-def cs_cli_path():
+def cs_cli_path(platform_details):
     bundle_dir = Path(__file__).parent.parent.absolute()
 
-    # Check for platform-specific binary name
-    if sys.platform == "win32":
-        internal_cs_path = bundle_dir / "cs.exe"
-    else:
-        internal_cs_path = bundle_dir / "cs"
+    # Check for bundled binary using platform-specific name
+    internal_cs_path = bundle_dir / platform_details.get_cli_binary_name()
 
     if internal_cs_path.exists():
         if not os.access(internal_cs_path, os.X_OK):
             os.chmod(internal_cs_path, 0o755)
         return str(internal_cs_path)
 
+    # Check for environment variable override
     if os.getenv("CS_CLI_PATH"):
         return os.getenv("CS_CLI_PATH")
 
+    # Fall back to static docker default
     return '/root/.local/bin/cs'
 
 
-def make_cs_cli_review_command_for(cli_command: str, file_path: str):
-    cs_cli = cs_cli_path()
+def make_cs_cli_review_command_for(cli_command: str, file_path: str, platform_details=None):
+    if platform_details is None:
+        platform_details = get_platform_details()
+    cs_cli = cs_cli_path(platform_details)
 
     if os.getenv("CS_MOUNT_PATH"):
         mount_file_path = adapt_mounted_file_path_inside_docker(file_path)
@@ -87,9 +131,16 @@ def make_cs_cli_review_command_for(cli_command: str, file_path: str):
     return [cs_cli, cli_command, mount_file_path, "--output-format=json"]
 
 
-def cs_cli_review_command_for(file_path: str):
-    return make_cs_cli_review_command_for("review", file_path)
+def cs_cli_review_command_for(file_path: str, platform_details=None):
+    return make_cs_cli_review_command_for("review", file_path, platform_details)
 
 
 def analyze_code(file_path: str) -> str:
-    return run_local_tool(cs_cli_review_command_for(file_path))
+    if os.getenv("CS_MOUNT_PATH"):
+        # Docker environment - use file path directly, path adaptation handled by cs_cli_review_command_for
+        return run_local_tool(cs_cli_review_command_for(file_path))
+    else:
+        # Local/Nuitka binary - find git root and use relative path
+        git_root = find_git_root(file_path)
+        relative_path = str(Path(file_path).relative_to(git_root))
+        return run_local_tool(cs_cli_review_command_for(relative_path), cwd=git_root)

--- a/src/utils/code_health_analysis.py
+++ b/src/utils/code_health_analysis.py
@@ -37,13 +37,14 @@ def find_git_root(file_path: str) -> str:
     raise CodeSceneCliError(f"Not in a git repository: {file_path}")
 
 
-def run_local_tool(command: list, cwd: str = None):
+def run_local_tool(command: list, cwd: str = None, extra_env: dict = None):
     """
     Runs a local command-line tool and captures its output.
 
     Args:
         command (list): The command and its arguments, e.g. ['ls', '-l']
         cwd (str): Optional working directory to run the command in
+        extra_env (dict): Optional extra environment variables to set
 
     Returns:
         str: Combined stdout and stderr output
@@ -67,6 +68,10 @@ def run_local_tool(command: list, cwd: str = None):
         env['_JAVA_OPTIONS'] = java_options
     
     env = platform.configure_environment(env)
+
+    # Apply any extra environment variables (e.g., GIT_DIR for worktrees)
+    if extra_env:
+        env.update(extra_env)
 
     result = subprocess.run(command, capture_output=True, text=True, cwd=cwd, env=env)
     if result.returncode != 0:

--- a/src/utils/code_health_analysis.py
+++ b/src/utils/code_health_analysis.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 import subprocess
+import sys
 from errors import CodeSceneCliError
 from .docker_path_adapter import adapt_mounted_file_path_inside_docker
 
@@ -57,7 +58,12 @@ def code_health_from_cli_output(cli_output) -> float:
 
 def cs_cli_path():
     bundle_dir = Path(__file__).parent.parent.absolute()
-    internal_cs_path = bundle_dir / "cs"
+
+    # Check for platform-specific binary name
+    if sys.platform == "win32":
+        internal_cs_path = bundle_dir / "cs.exe"
+    else:
+        internal_cs_path = bundle_dir / "cs"
 
     if internal_cs_path.exists():
         if not os.access(internal_cs_path, os.X_OK):

--- a/src/utils/platform_details.py
+++ b/src/utils/platform_details.py
@@ -1,0 +1,94 @@
+import os
+import sys
+from abc import ABC, abstractmethod
+
+
+class PlatformDetails(ABC):
+    """Abstract base class for platform-specific operations."""
+    
+    @abstractmethod
+    def get_cli_binary_name(self) -> str:
+        """Returns the platform-specific CLI binary name."""
+        pass
+    
+    
+    @abstractmethod
+    def configure_environment(self, env: dict) -> dict:
+        """
+        Configure platform-specific environment variables.
+        
+        Args:
+            env: Base environment dictionary
+            
+        Returns:
+            Modified environment dictionary
+        """
+        pass
+    
+    @abstractmethod
+    def get_java_options(self) -> str:
+        """Returns platform-specific Java options."""
+        pass
+
+
+class WindowsPlatformDetails(PlatformDetails):
+    """Windows-specific platform details."""
+    
+    def get_cli_binary_name(self) -> str:
+        return "cs.exe"
+    
+    def configure_environment(self, env: dict) -> dict:
+        """Configure Windows-specific environment settings."""
+        env = env.copy()
+        
+        # Ensure Git is findable in PATH for bundled executables
+        common_git_paths = [
+            r"C:\Program Files\Git\cmd",
+            r"C:\Program Files (x86)\Git\cmd",
+            r"C:\Program Files\Git\bin",
+            r"C:\Program Files (x86)\Git\bin",
+        ]
+        
+        existing_path = env.get('PATH', '')
+        for git_path in common_git_paths:
+            if os.path.exists(git_path) and git_path not in existing_path:
+                env['PATH'] = f"{git_path};{existing_path}"
+                break
+        
+        return env
+    
+    def get_java_options(self) -> str:
+        """Set Java temp directory to avoid Windows directory access issues."""
+        import tempfile
+        temp_dir = tempfile.gettempdir()
+        return f'-Djava.io.tmpdir="{temp_dir}"'
+
+
+class UnixPlatformDetails(PlatformDetails):
+    """Unix/Linux/macOS platform details."""
+    
+    def get_cli_binary_name(self) -> str:
+        return "cs"
+    
+    def configure_environment(self, env: dict) -> dict:
+        """Configure Unix-specific environment settings."""
+        # Unix platforms typically don't need special PATH configuration
+        return env.copy()
+    
+    def get_java_options(self) -> str:
+        """Unix platforms typically don't need special Java options."""
+        return ""
+
+
+def get_platform_details() -> PlatformDetails:
+    """
+    Factory function to get the appropriate platform details.
+    
+    Returns:
+        PlatformDetails instance for the current platform
+    """
+    if sys.platform == "win32":
+        return WindowsPlatformDetails()
+    else:
+        # Unix-like systems (Linux, macOS, etc.)
+        return UnixPlatformDetails()

--- a/src/utils/test_code_health_analysis.py
+++ b/src/utils/test_code_health_analysis.py
@@ -1,0 +1,124 @@
+import os
+import unittest
+from unittest import mock
+from pathlib import Path
+
+
+class TestCsCliPath(unittest.TestCase):
+    def setUp(self):
+        self._env = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._env)
+
+    @mock.patch('utils.code_health_analysis.Path.exists')
+    @mock.patch('os.access')
+    def test_returns_bundled_cs_path_when_exists_and_executable(self, mock_access, mock_exists):
+        from utils.code_health_analysis import cs_cli_path
+
+        mock_exists.return_value = True
+        mock_access.return_value = True
+
+        result = cs_cli_path()
+
+        self.assertTrue(result.endswith('/cs'))
+        self.assertIn('src', result)
+
+    @mock.patch('utils.code_health_analysis.Path.exists')
+    @mock.patch('os.access')
+    @mock.patch('os.chmod')
+    def test_sets_executable_permission_when_bundled_cs_not_executable(self, mock_chmod, mock_access, mock_exists):
+        from utils.code_health_analysis import cs_cli_path
+
+        mock_exists.return_value = True
+        mock_access.return_value = False
+
+        result = cs_cli_path()
+
+        mock_chmod.assert_called_once()
+        self.assertTrue(result.endswith('/cs'))
+
+    @mock.patch('utils.code_health_analysis.Path.exists')
+    def test_returns_env_cs_cli_path_when_bundled_not_exists(self, mock_exists):
+        from utils.code_health_analysis import cs_cli_path
+
+        mock_exists.return_value = False
+        os.environ["CS_CLI_PATH"] = "/custom/path/to/cs"
+
+        result = cs_cli_path()
+
+        self.assertEqual(result, "/custom/path/to/cs")
+
+    @mock.patch('utils.code_health_analysis.Path.exists')
+    def test_returns_default_path_when_no_bundled_and_no_env(self, mock_exists):
+        from utils.code_health_analysis import cs_cli_path
+
+        mock_exists.return_value = False
+        os.environ.pop("CS_CLI_PATH", None)
+
+        result = cs_cli_path()
+
+        self.assertEqual(result, '/root/.local/bin/cs')
+
+
+class TestMakeCsCliReviewCommandFor(unittest.TestCase):
+    def setUp(self):
+        self._env = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._env)
+
+    @mock.patch('utils.code_health_analysis.cs_cli_path')
+    def test_returns_command_without_path_adaptation_when_no_mount_path(self, mock_cli_path):
+        from utils.code_health_analysis import make_cs_cli_review_command_for
+
+        mock_cli_path.return_value = "/path/to/cs"
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        result = make_cs_cli_review_command_for("review", "/project/src/foo.py")
+
+        self.assertEqual(result, ["/path/to/cs", "review", "/project/src/foo.py", "--output-format=json"])
+
+    @mock.patch('utils.code_health_analysis.cs_cli_path')
+    @mock.patch('utils.code_health_analysis.adapt_mounted_file_path_inside_docker')
+    def test_adapts_path_when_mount_path_set(self, mock_adapt, mock_cli_path):
+        from utils.code_health_analysis import make_cs_cli_review_command_for
+
+        mock_cli_path.return_value = "/path/to/cs"
+        mock_adapt.return_value = "/mount/src/foo.py"
+        os.environ["CS_MOUNT_PATH"] = "/project"
+
+        result = make_cs_cli_review_command_for("review", "/project/src/foo.py")
+
+        mock_adapt.assert_called_once_with("/project/src/foo.py")
+        self.assertEqual(result, ["/path/to/cs", "review", "/mount/src/foo.py", "--output-format=json"])
+
+    @mock.patch('utils.code_health_analysis.cs_cli_path')
+    def test_supports_different_cli_commands(self, mock_cli_path):
+        from utils.code_health_analysis import make_cs_cli_review_command_for
+
+        mock_cli_path.return_value = "/path/to/cs"
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        result = make_cs_cli_review_command_for("delta", "/project/src/foo.py")
+
+        self.assertEqual(result, ["/path/to/cs", "delta", "/project/src/foo.py", "--output-format=json"])
+
+
+class TestCsCliReviewCommandFor(unittest.TestCase):
+    @mock.patch('utils.code_health_analysis.make_cs_cli_review_command_for')
+    def test_calls_make_with_review_command(self, mock_make):
+        from utils.code_health_analysis import cs_cli_review_command_for
+
+        mock_make.return_value = ["/path/to/cs", "review", "/foo.py", "--output-format=json"]
+
+        result = cs_cli_review_command_for("/foo.py")
+
+        mock_make.assert_called_once_with("review", "/foo.py")
+        self.assertEqual(result, ["/path/to/cs", "review", "/foo.py", "--output-format=json"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/test_code_health_analysis.py
+++ b/src/utils/test_code_health_analysis.py
@@ -25,6 +25,21 @@ class TestCsCliPath(unittest.TestCase):
         self.assertTrue(result.endswith('/cs'))
         self.assertIn('src', result)
 
+    @mock.patch('utils.code_health_analysis.sys')
+    @mock.patch('utils.code_health_analysis.Path.exists')
+    @mock.patch('os.access')
+    def test_returns_bundled_cs_exe_path_on_windows(self, mock_access, mock_exists, mock_sys):
+        from utils.code_health_analysis import cs_cli_path
+
+        mock_sys.platform = "win32"
+        mock_exists.return_value = True
+        mock_access.return_value = True
+
+        result = cs_cli_path()
+
+        self.assertTrue(result.endswith('cs.exe'))
+        self.assertIn('src', result)
+
     @mock.patch('utils.code_health_analysis.Path.exists')
     @mock.patch('os.access')
     @mock.patch('os.chmod')

--- a/src/utils/test_docker_mount_path.py
+++ b/src/utils/test_docker_mount_path.py
@@ -144,3 +144,119 @@ class TestAdaptMountedFilePathInsideDocker(unittest.TestCase):
     def test_relative_path_raises(self):
         with self.assertRaises(CodeSceneCliError):
             adapt_mounted_file_path_inside_docker("src/foo.py")
+
+
+class TestWorktreeGitdirAdapter(unittest.TestCase):
+    """Tests for git worktree support in Docker path adaptation."""
+
+    def setUp(self):
+        self._env = dict(os.environ)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._env)
+
+    def test_read_worktree_gitdir_from_file(self):
+        """Test reading gitdir from a worktree .git file."""
+        from .docker_path_adapter import _read_worktree_gitdir
+        import tempfile
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.git', delete=False) as f:
+            f.write("gitdir: /path/to/main/repo/.git/worktrees/my-branch\n")
+            f.flush()
+            
+            result = _read_worktree_gitdir(f.name)
+            self.assertEqual(result, "/path/to/main/repo/.git/worktrees/my-branch")
+        
+        import os
+        os.unlink(f.name)
+
+    def test_read_worktree_gitdir_returns_none_for_directory(self):
+        """Test that reading gitdir from a directory returns None."""
+        from .docker_path_adapter import _read_worktree_gitdir
+        import tempfile
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _read_worktree_gitdir(tmpdir)
+            self.assertIsNone(result)
+
+    def test_read_worktree_gitdir_returns_none_for_nonexistent(self):
+        """Test that reading gitdir from nonexistent path returns None."""
+        from .docker_path_adapter import _read_worktree_gitdir
+        
+        result = _read_worktree_gitdir("/nonexistent/path/.git")
+        self.assertIsNone(result)
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/Users/david/workspace"})
+    def test_adapt_worktree_gitdir_for_docker(self):
+        """Test full worktree gitdir path translation."""
+        from .docker_path_adapter import adapt_worktree_gitdir_for_docker
+        import tempfile
+        import os as os_module
+        
+        # Create a temp directory structure simulating a mounted worktree
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a mock .git file with a gitdir pointer
+            worktree_dir = os_module.path.join(tmpdir, "worktree")
+            os_module.makedirs(worktree_dir)
+            git_file = os_module.path.join(worktree_dir, ".git")
+            
+            with open(git_file, 'w') as f:
+                f.write("gitdir: /Users/david/workspace/main-repo/.git/worktrees/my-branch\n")
+            
+            # The function should translate the host path in .git file
+            result = adapt_worktree_gitdir_for_docker(worktree_dir)
+            self.assertEqual(result, "/mount/main-repo/.git/worktrees/my-branch")
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/Users/david/workspace"})
+    def test_adapt_worktree_gitdir_returns_none_for_regular_repo(self):
+        """Test that regular repos (with .git directory) return None."""
+        from .docker_path_adapter import adapt_worktree_gitdir_for_docker
+        import tempfile
+        import os as os_module
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create a .git directory (regular repo, not worktree)
+            git_dir = os_module.path.join(tmpdir, ".git")
+            os_module.makedirs(git_dir)
+            
+            result = adapt_worktree_gitdir_for_docker(tmpdir)
+            self.assertIsNone(result)
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/Users/david/project-a"})
+    def test_adapt_worktree_gitdir_returns_none_when_gitdir_outside_mount(self):
+        """Test that gitdir pointing outside mount path returns None."""
+        from .docker_path_adapter import adapt_worktree_gitdir_for_docker
+        import tempfile
+        import os as os_module
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            worktree_dir = os_module.path.join(tmpdir, "worktree")
+            os_module.makedirs(worktree_dir)
+            git_file = os_module.path.join(worktree_dir, ".git")
+            
+            # gitdir points to a different project outside the mount
+            with open(git_file, 'w') as f:
+                f.write("gitdir: /Users/david/project-b/.git/worktrees/branch\n")
+            
+            result = adapt_worktree_gitdir_for_docker(worktree_dir)
+            self.assertIsNone(result)
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "C:\\Users\\david\\workspace"})
+    def test_adapt_worktree_gitdir_with_windows_paths(self):
+        """Test worktree gitdir translation with Windows-style paths."""
+        from .docker_path_adapter import adapt_worktree_gitdir_for_docker
+        import tempfile
+        import os as os_module
+        
+        with tempfile.TemporaryDirectory() as tmpdir:
+            worktree_dir = os_module.path.join(tmpdir, "worktree")
+            os_module.makedirs(worktree_dir)
+            git_file = os_module.path.join(worktree_dir, ".git")
+            
+            # Simulate Windows-style gitdir path in the .git file
+            with open(git_file, 'w') as f:
+                f.write("gitdir: C:\\Users\\david\\workspace\\main-repo\\.git\\worktrees\\my-branch\n")
+            
+            result = adapt_worktree_gitdir_for_docker(worktree_dir)
+            self.assertEqual(result, "/mount/main-repo/.git/worktrees/my-branch")

--- a/src/utils/test_platform_details.py
+++ b/src/utils/test_platform_details.py
@@ -114,6 +114,44 @@ class TestPlatformDetails(unittest.TestCase):
         
         self.assertIn(r'Git\bin', result['PATH'])
         self.assertIn('C:\\existing', result['PATH'])
+    
+    def test_windows_get_java_options_returns_tmpdir_setting(self):
+        details = WindowsPlatformDetails()
+        
+        result = details.get_java_options()
+        
+        self.assertIn('-Djava.io.tmpdir=', result)
+        # Should contain a valid temp directory path
+        self.assertTrue(len(result) > len('-Djava.io.tmpdir=""'))
+    
+    def test_unix_get_java_options_returns_empty_string(self):
+        details = UnixPlatformDetails()
+        
+        result = details.get_java_options()
+        
+        self.assertEqual("", result)
+    
+    def _test_platform_detection(self, platform_name: str, expected_class: str):
+        """Helper to test platform detection with mocked sys.platform."""
+        import utils.platform_details as pd
+        
+        try:
+            pd.sys = mock.MagicMock()
+            pd.sys.platform = platform_name
+            
+            details = pd.get_platform_details()
+            self.assertEqual(expected_class, details.__class__.__name__)
+        finally:
+            pd.sys = sys
+    
+    def test_get_platform_details_returns_windows_on_win32(self):
+        self._test_platform_detection('win32', 'WindowsPlatformDetails')
+    
+    def test_get_platform_details_returns_unix_on_darwin(self):
+        self._test_platform_detection('darwin', 'UnixPlatformDetails')
+    
+    def test_get_platform_details_returns_unix_on_linux(self):
+        self._test_platform_detection('linux', 'UnixPlatformDetails')
 
 
 if __name__ == '__main__':

--- a/src/utils/test_platform_details.py
+++ b/src/utils/test_platform_details.py
@@ -1,0 +1,120 @@
+import unittest
+from unittest import mock
+import sys
+from .platform_details import (
+    get_platform_details,
+    WindowsPlatformDetails,
+    UnixPlatformDetails
+)
+
+
+class TestPlatformDetails(unittest.TestCase):
+    
+    def test_get_platform_details_returns_details(self):
+        # Just test that it returns a details instance, not the specific type
+        # since we're running on a real platform
+        details = get_platform_details()
+        self.assertIsNotNone(details)
+        # Check it has the required methods
+        self.assertTrue(hasattr(details, 'get_cli_binary_name'))
+        self.assertTrue(hasattr(details, 'configure_environment'))
+    
+    def test_windows_cli_binary_name(self):
+        details = WindowsPlatformDetails()
+        self.assertEqual("cs.exe", details.get_cli_binary_name())
+    
+    def test_unix_cli_binary_name(self):
+        details = UnixPlatformDetails()
+        self.assertEqual("cs", details.get_cli_binary_name())
+    
+    @mock.patch('os.path.exists')
+    def test_windows_configure_environment_adds_git_to_path(self, mock_exists):
+        mock_exists.return_value = True
+        details = WindowsPlatformDetails()
+        env = {'PATH': 'C:\\existing\\path'}
+        
+        result = details.configure_environment(env)
+        
+        self.assertIn('Git', result['PATH'])
+        self.assertIn('C:\\existing\\path', result['PATH'])
+        self.assertIn(';', result['PATH'])
+    
+    def test_unix_configure_environment_returns_copy(self):
+        details = UnixPlatformDetails()
+        env = {'PATH': '/usr/bin:/usr/local/bin'}
+        
+        result = details.configure_environment(env)
+        
+        self.assertEqual(env['PATH'], result['PATH'])
+        self.assertIsNot(env, result)  # Should be a copy
+    
+    @mock.patch('os.path.exists')
+    def test_windows_configure_environment_no_git_found(self, mock_exists):
+        mock_exists.return_value = False
+        details = WindowsPlatformDetails()
+        env = {'PATH': 'C:\\existing\\path'}
+        
+        result = details.configure_environment(env)
+        
+        # PATH should remain unchanged if no Git found
+        self.assertEqual('C:\\existing\\path', result['PATH'])
+    
+    @mock.patch('os.path.exists')
+    def test_windows_configure_environment_git_already_in_path(self, mock_exists):
+        # Return False for all paths so nothing gets added
+        mock_exists.return_value = False
+        details = WindowsPlatformDetails()
+        git_path = r'C:\Program Files\Git\cmd'
+        env = {'PATH': f'{git_path};C:\\existing\\path'}
+        
+        result = details.configure_environment(env)
+        
+        # If git is already in path and we can't find other git paths,
+        # the PATH should remain unchanged
+        self.assertEqual(env['PATH'], result['PATH'])
+    
+    def test_windows_configure_environment_preserves_other_env_vars(self):
+        details = WindowsPlatformDetails()
+        env = {
+            'PATH': 'C:\\test',
+            'HOME': 'C:\\Users\\test',
+            'CUSTOM_VAR': 'value'
+        }
+        
+        result = details.configure_environment(env)
+        
+        self.assertEqual('C:\\Users\\test', result['HOME'])
+        self.assertEqual('value', result['CUSTOM_VAR'])
+    
+    def test_unix_configure_environment_preserves_all_vars(self):
+        details = UnixPlatformDetails()
+        env = {
+            'PATH': '/usr/bin',
+            'HOME': '/home/user',
+            'SHELL': '/bin/bash'
+        }
+        
+        result = details.configure_environment(env)
+        
+        self.assertEqual(env['PATH'], result['PATH'])
+        self.assertEqual(env['HOME'], result['HOME'])
+        self.assertEqual(env['SHELL'], result['SHELL'])
+    
+    @mock.patch('os.path.exists')
+    def test_windows_finds_first_existing_git_path(self, mock_exists):
+        # Simulate only the third path existing
+        def exists_side_effect(path):
+            return r'C:\Program Files\Git\bin' in path
+        
+        mock_exists.side_effect = exists_side_effect
+        details = WindowsPlatformDetails()
+        env = {'PATH': 'C:\\existing'}
+        
+        result = details.configure_environment(env)
+        
+        self.assertIn(r'Git\bin', result['PATH'])
+        self.assertIn('C:\\existing', result['PATH'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR makes changes to the way we do paths so that we could also leverage the Nuitka compiler to create static binaries, and it adds GH workflows to do just that.