### PR TITLE
Update Homebrew formula to 0.0.28

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.0.26"
+  version "0.0.28"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "8e13a634e26e08c56a900aa01b0e8889fe84c3914ccf1c38e6b05bc7a085652f"
+      sha256 "ab0089540b3fb7663de3e79b29de774842d0e6e5b61255fe3f3e2630627a6934"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.0.28.

## Checksums
- macOS ARM64: `7c3ea2bc082ad2f03da1c5bc89d1a488e8e7486936a72a37f39e1a7a3ffdfbea`
- macOS AMD64: `189e2263561a4fcbf2fb4603d88ae508cf44dd657cef10e0dd1f228a812a5ba1`
- Linux ARM64: `e3c08b9db8b943947cb45b962def006862d0001273a4f1a36f45d3430cc830eb`
- Linux AMD64: `ab0089540b3fb7663de3e79b29de774842d0e6e5b61255fe3f3e2630627a6934`