### PR TITLE
CS-6214: Fix documentation paths for both Docker and Nuitka builds

### DIFF
--- a/src/cs_mcp_server.py
+++ b/src/cs_mcp_server.py
@@ -19,11 +19,12 @@ from utils import query_api_list, analyze_code, run_local_tool, post_refactor
 mcp = FastMCP("CodeScene")
 
 def get_resource_path(relative_path):
-    if os.getenv("CS_MOUNT_PATH"):
-        return Path(f"./{relative_path}")
-    else: 
-        base_path = Path(__file__).parent.absolute()
-        return base_path / relative_path
+    base_path = Path(__file__).parent.absolute()
+    # Nuitka sets __compiled__ as a module attribute when running as compiled executable
+    # Nuitka bundles docs at src/docs, Docker has them at docs/
+    if hasattr(get_resource_path, "__compiled__") or "__compiled__" in globals():
+        return base_path / "src" / relative_path
+    return base_path / relative_path
 
 
 # Offer prompts that capture the key use cases. These prompts are more than a 
@@ -83,7 +84,7 @@ def plan_code_health_refactoring(context: str | None = None) -> str:
 # We want the MCP Server to explain its key concepts like Code Health.
 
 def read_documentation_content_for(md_doc_name):
-    return get_resource_path(f"src/docs/code-health/{md_doc_name}").read_text(encoding="utf-8")
+    return get_resource_path(f"docs/code-health/{md_doc_name}").read_text(encoding="utf-8")
 
 @mcp.tool()
 def explain_code_health(context: str | None = None) -> str:
@@ -111,7 +112,7 @@ def resource_title_from_md_heading_in(path: Path) -> str:
         return first_line.lstrip("#").strip()
 
 def doc_to_file_resources(doc):
-    doc_path = get_resource_path(f"src/docs/code-health/{doc['doc-path']}").resolve()
+    doc_path = get_resource_path(f"docs/code-health/{doc['doc-path']}").resolve()
     doc_resource = FileResource(
         uri=f"file://codescene-docs/code-health/{doc['doc-path']}",
         path=doc_path,


### PR DESCRIPTION
The `get_resource_path` function was using incorrect paths causing `FileNotFoundError` when loading documentation files. The issue was a path duplication where `src/` was being added twice.

- Remove `src/` prefix from doc path strings (now just docs/code-health/...)
- Detect Nuitka compiled binary via `__compiled__` attribute
- Add `src/` prefix only when running as Nuitka executable (which bundles at src/docs)