### PR TITLE
CS-6216: Add SSL certificate support for on-premise instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,45 @@ seems to hallucinate parts of the path some of the time. We're still investigati
 
 </details>
 
+<details>
+
+<summary>How do I configure SSL certificates for on-premise CodeScene instances?</summary>
+
+If your organization uses an internal CA (Certificate Authority) for your on-premise CodeScene instance, you need to configure the MCP server to trust that certificate.
+
+Set the `REQUESTS_CA_BUNDLE` environment variable to point to your CA certificate file (PEM format):
+
+```bash
+export REQUESTS_CA_BUNDLE=/path/to/your/internal-ca.crt
+```
+
+This single environment variable configures SSL for both the Python MCP server and the embedded Java-based CodeScene CLI. The MCP server automatically converts the PEM certificate to a Java-compatible truststore at runtime.
+
+**Example for VS Code with Docker:**
+```json
+"codescene": {
+  "command": "docker",
+  "args": [
+    "run", "-i", "--rm",
+    "-e", "CS_ACCESS_TOKEN",
+    "-e", "CS_ONPREM_URL",
+    "-e", "REQUESTS_CA_BUNDLE=/mount/certs/internal-ca.crt",
+    "-e", "CS_MOUNT_PATH=${input:CS_MOUNT_PATH}",
+    "--mount", "type=bind,src=${input:CS_MOUNT_PATH},dst=/mount/,ro",
+    "--mount", "type=bind,src=/path/to/certs,dst=/mount/certs,ro",
+    "codescene/codescene-mcp"
+  ],
+  "env": {
+    "CS_ACCESS_TOKEN": "${input:CS_ACCESS_TOKEN}",
+    "CS_ONPREM_URL": "${input:CS_ONPREM_URL}"
+  }
+}
+```
+
+The MCP also supports `SSL_CERT_FILE` and `CURL_CA_BUNDLE` as alternatives to `REQUESTS_CA_BUNDLE`.
+
+</details>
+
 ## Building Locally
 
 - [Building the Docker image locally](docs/building-docker-locally.md)

--- a/src/utils/platform_details.py
+++ b/src/utils/platform_details.py
@@ -31,6 +31,109 @@ class PlatformDetails(ABC):
         pass
 
 
+def _get_ssl_truststore_options() -> str:
+    """
+    Returns Java truststore options for custom CA certificates.
+    
+    Checks these environment variables in order of precedence:
+    
+    1. REQUESTS_CA_BUNDLE: Standard Python/requests CA bundle path (PEM format).
+       This allows users to configure SSL certificates once for both the Python
+       MCP server and the embedded Java CLI.
+       
+    2. SSL_CERT_FILE: Alternative standard CA certificate path (PEM format).
+    
+    3. CURL_CA_BUNDLE: curl-style CA bundle path (PEM format).
+    
+    The PEM certificate is converted to a PKCS12 truststore at runtime for Java.
+    Requires the 'cryptography' package.
+    
+    Returns:
+        Java options string for SSL configuration, or empty string if not configured.
+    """
+    # Check standard CA bundle environment variables in order of precedence
+    ca_cert_path = (
+        os.getenv("REQUESTS_CA_BUNDLE") or 
+        os.getenv("SSL_CERT_FILE") or
+        os.getenv("CURL_CA_BUNDLE")
+    )
+    
+    if not ca_cert_path:
+        return ""
+    
+    if not os.path.isfile(ca_cert_path):
+        return ""
+    
+    truststore = _create_truststore_from_pem(ca_cert_path)
+    if truststore:
+        return (
+            f'-Djavax.net.ssl.trustStore="{truststore}" '
+            f'-Djavax.net.ssl.trustStoreType=PKCS12 '
+            f'-Djavax.net.ssl.trustStorePassword=changeit'
+        )
+    
+    return ""
+
+
+def _create_truststore_from_pem(pem_path: str) -> str | None:
+    """
+    Creates a PKCS12 truststore from a PEM certificate file.
+    
+    Args:
+        pem_path: Path to the PEM certificate file
+        
+    Returns:
+        Path to the created PKCS12 truststore, or None if creation failed
+    """
+    import tempfile
+    import hashlib
+    
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives.serialization import pkcs12, BestAvailableEncryption
+    except ImportError:
+        # cryptography not available - can't convert PEM
+        return None
+    
+    try:
+        # Read and parse the PEM certificate(s)
+        with open(pem_path, 'rb') as f:
+            pem_data = f.read()
+        
+        # Parse all certificates in the PEM file
+        certs = []
+        for cert in x509.load_pem_x509_certificates(pem_data):
+            certs.append(pkcs12.PKCS12Certificate(cert, None))
+        
+        if not certs:
+            return None
+        
+        # Create a deterministic path based on the cert content
+        # so we don't recreate it on every invocation
+        cert_hash = hashlib.sha256(pem_data).hexdigest()[:16]
+        truststore_path = os.path.join(
+            tempfile.gettempdir(), 
+            f'cs-mcp-truststore-{cert_hash}.p12'
+        )
+        
+        # Only create if it doesn't exist
+        if not os.path.exists(truststore_path):
+            # Use serialize_java_truststore which is designed for CA-only truststores
+            p12_data = pkcs12.serialize_java_truststore(
+                certs=certs,
+                encryption_algorithm=BestAvailableEncryption(b"changeit")
+            )
+            
+            with open(truststore_path, 'wb') as f:
+                f.write(p12_data)
+        
+        return truststore_path
+        
+    except Exception:
+        # If anything goes wrong, return None and let Java produce the SSL error
+        return None
+
+
 class WindowsPlatformDetails(PlatformDetails):
     """Windows-specific platform details."""
     
@@ -58,10 +161,16 @@ class WindowsPlatformDetails(PlatformDetails):
         return env
     
     def get_java_options(self) -> str:
-        """Set Java temp directory to avoid Windows directory access issues."""
+        """Set Java temp directory and SSL options for Windows."""
         import tempfile
         temp_dir = tempfile.gettempdir()
-        return f'-Djava.io.tmpdir="{temp_dir}"'
+        options = [f'-Djava.io.tmpdir="{temp_dir}"']
+        
+        ssl_options = _get_ssl_truststore_options()
+        if ssl_options:
+            options.append(ssl_options)
+        
+        return ' '.join(options)
 
 
 class UnixPlatformDetails(PlatformDetails):
@@ -76,8 +185,8 @@ class UnixPlatformDetails(PlatformDetails):
         return env.copy()
     
     def get_java_options(self) -> str:
-        """Unix platforms typically don't need special Java options."""
-        return ""
+        """Returns SSL truststore options if configured, empty string otherwise."""
+        return _get_ssl_truststore_options()
 
 
 def get_platform_details() -> PlatformDetails:

--- a/src/utils/test_platform_details.py
+++ b/src/utils/test_platform_details.py
@@ -1,10 +1,14 @@
 import unittest
 from unittest import mock
 import sys
+import os
+import tempfile
 from .platform_details import (
     get_platform_details,
     WindowsPlatformDetails,
-    UnixPlatformDetails
+    UnixPlatformDetails,
+    _get_ssl_truststore_options,
+    _create_truststore_from_pem
 )
 
 
@@ -124,7 +128,12 @@ class TestPlatformDetails(unittest.TestCase):
         # Should contain a valid temp directory path
         self.assertTrue(len(result) > len('-Djava.io.tmpdir=""'))
     
+    @mock.patch.dict(os.environ, {}, clear=True)
     def test_unix_get_java_options_returns_empty_string(self):
+        # Ensure no SSL env vars are set
+        for key in ['REQUESTS_CA_BUNDLE', 'SSL_CERT_FILE', 'CURL_CA_BUNDLE']:
+            os.environ.pop(key, None)
+        
         details = UnixPlatformDetails()
         
         result = details.get_java_options()
@@ -152,6 +161,189 @@ class TestPlatformDetails(unittest.TestCase):
     
     def test_get_platform_details_returns_unix_on_linux(self):
         self._test_platform_detection('linux', 'UnixPlatformDetails')
+
+
+class TestSSLTruststoreOptions(unittest.TestCase):
+    """Tests for SSL truststore configuration using REQUESTS_CA_BUNDLE."""
+    
+    # Valid self-signed CA certificate for testing (generated with cryptography library)
+    TEST_CA_CERT_PEM = b"""-----BEGIN CERTIFICATE-----
+MIIDPzCCAiegAwIBAgIUdGj465l77xx7Je8KqOESIqx9zXYwDQYJKoZIhvcNAQEL
+BQAwTzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
+EDAOBgNVBAoMB1Rlc3QgQ0ExEDAOBgNVBAMMB1Rlc3QgQ0EwHhcNMjYwMTE2MDky
+OTQ5WhcNMjcwMTE2MDkyOTQ5WjBPMQswCQYDVQQGEwJVUzENMAsGA1UECAwEVGVz
+dDENMAsGA1UEBwwEVGVzdDEQMA4GA1UECgwHVGVzdCBDQTEQMA4GA1UEAwwHVGVz
+dCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMqoClSXXim/fiI9
+Lc3X/4D4rHK6cWAnKVPA+CetSJiGrMrfeJZMSTWUv19M8aKlmbZsQxN4X4neycWE
+UxH9y3XaqV9grmGvutTgw98t6fhawevGrjmcA+ygQ5S37reRQOHtc9ob51b8b9Rr
+nyE8qIU2dkZ115VpFN+/woG2LG23iGj2dJ3AaZc/R8X0UQu5tQCDwTOeO/zMWPGG
+xjzDpnFs4u7IAwPECEgEuxHH8PHapUoc0d+Aq/wBKM015qdohoaydrztzXp6DKJ5
+RBv/cn+lTpFdvJQS0CceIo+hOUa46ONq63VM3SQhT7enOWToONBxrZpof18bITFd
+2h4XxoMCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+AQEAHDWTjJILOtrCBRFksVyvniUGFR8ioz2cE4R8xcKAFxNOPKLuxwm+ilbUBX3A
+8VOCJjR6IimsLMhAUEi5FGDiVVhOwIp1+pULEigTG7r72yOCr2xnw8NrX9UbJNnx
+rlyCjEN9URBpriiGGegixH6AoLVW0SjEsJ7CgfqmfWzKU+nsPIunvePtFhSw5jHC
+mHwYTxYcxYW33TK9qQxs119A9+qG5Z+cJlDtYrfHirHwPZQeuQ25jhKE5FUUiuiq
+iblIIstcPF4n6wQ0ieNajmj5nHXQEypkek8D/ANbwwhlVQ3u/hldcAyj4qD7G5oJ
+sC0Nc9QdNQt5Tos5Je5S7CWL0w==
+-----END CERTIFICATE-----"""
+    
+    def setUp(self):
+        """Save original env vars and clear SSL-related ones."""
+        self.original_env = os.environ.copy()
+        for key in ['REQUESTS_CA_BUNDLE', 'SSL_CERT_FILE', 'CURL_CA_BUNDLE']:
+            os.environ.pop(key, None)
+    
+    def tearDown(self):
+        """Restore original env vars."""
+        os.environ.clear()
+        os.environ.update(self.original_env)
+    
+    def test_returns_empty_string_when_no_env_vars_set(self):
+        result = _get_ssl_truststore_options()
+        self.assertEqual("", result)
+    
+    def test_returns_empty_string_when_ca_bundle_file_not_found(self):
+        os.environ['REQUESTS_CA_BUNDLE'] = '/nonexistent/ca-bundle.crt'
+        
+        result = _get_ssl_truststore_options()
+        
+        self.assertEqual("", result)
+    
+    def test_returns_truststore_options_when_valid_pem_exists(self):
+        # Create a temporary file with a valid PEM certificate
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(self.TEST_CA_CERT_PEM)
+            pem_path = f.name
+        
+        try:
+            os.environ['REQUESTS_CA_BUNDLE'] = pem_path
+            
+            result = _get_ssl_truststore_options()
+            
+            self.assertIn('-Djavax.net.ssl.trustStore=', result)
+            self.assertIn('-Djavax.net.ssl.trustStoreType=PKCS12', result)
+            self.assertIn('-Djavax.net.ssl.trustStorePassword=changeit', result)
+        finally:
+            os.unlink(pem_path)
+    
+    def test_ssl_cert_file_is_used_as_fallback(self):
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(self.TEST_CA_CERT_PEM)
+            pem_path = f.name
+        
+        try:
+            os.environ['SSL_CERT_FILE'] = pem_path
+            
+            result = _get_ssl_truststore_options()
+            
+            self.assertIn('-Djavax.net.ssl.trustStore=', result)
+        finally:
+            os.unlink(pem_path)
+    
+    def test_curl_ca_bundle_is_used_as_fallback(self):
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(self.TEST_CA_CERT_PEM)
+            pem_path = f.name
+        
+        try:
+            os.environ['CURL_CA_BUNDLE'] = pem_path
+            
+            result = _get_ssl_truststore_options()
+            
+            self.assertIn('-Djavax.net.ssl.trustStore=', result)
+        finally:
+            os.unlink(pem_path)
+    
+    def test_requests_ca_bundle_takes_precedence(self):
+        # Create two different files
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(self.TEST_CA_CERT_PEM)
+            requests_path = f.name
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(self.TEST_CA_CERT_PEM)
+            ssl_path = f.name
+        
+        try:
+            os.environ['REQUESTS_CA_BUNDLE'] = requests_path
+            os.environ['SSL_CERT_FILE'] = ssl_path
+            
+            result = _get_ssl_truststore_options()
+            
+            # Should produce a truststore (we can't easily verify which cert was used,
+            # but we verify the mechanism works)
+            self.assertIn('-Djavax.net.ssl.trustStore=', result)
+        finally:
+            os.unlink(requests_path)
+            os.unlink(ssl_path)
+    
+    def test_returns_empty_for_invalid_pem_content(self):
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(b"not a valid certificate")
+            pem_path = f.name
+        
+        try:
+            os.environ['REQUESTS_CA_BUNDLE'] = pem_path
+            
+            result = _get_ssl_truststore_options()
+            
+            # Should return empty string for invalid PEM
+            self.assertEqual("", result)
+        finally:
+            os.unlink(pem_path)
+    
+    def test_windows_includes_ssl_options_in_java_options(self):
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(self.TEST_CA_CERT_PEM)
+            pem_path = f.name
+        
+        try:
+            os.environ['REQUESTS_CA_BUNDLE'] = pem_path
+            details = WindowsPlatformDetails()
+            
+            result = details.get_java_options()
+            
+            # Should include both tmpdir and truststore
+            self.assertIn('-Djava.io.tmpdir=', result)
+            self.assertIn('-Djavax.net.ssl.trustStore=', result)
+        finally:
+            os.unlink(pem_path)
+    
+    def test_unix_includes_ssl_options_when_configured(self):
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            f.write(self.TEST_CA_CERT_PEM)
+            pem_path = f.name
+        
+        try:
+            os.environ['REQUESTS_CA_BUNDLE'] = pem_path
+            details = UnixPlatformDetails()
+            
+            result = details.get_java_options()
+            
+            self.assertIn('-Djavax.net.ssl.trustStore=', result)
+        finally:
+            os.unlink(pem_path)
+
+
+class TestCreateTruststoreFromPem(unittest.TestCase):
+    """Tests for PEM to PKCS12 conversion."""
+    
+    def test_returns_none_when_cryptography_not_available(self):
+        # This test verifies graceful handling when cryptography is not installed
+        # We can't easily mock the import, so we just verify the function exists
+        # and handles errors gracefully
+        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+            # Write invalid PEM data
+            f.write(b"not a valid certificate")
+            pem_path = f.name
+        
+        try:
+            result = _create_truststore_from_pem(pem_path)
+            # Should return None for invalid PEM (or a path if cryptography worked)
+            # Either way, it should not raise an exception
+            self.assertTrue(result is None or isinstance(result, str))
+        finally:
+            os.unlink(pem_path)
 
 
 if __name__ == '__main__':

--- a/src/utils/test_platform_details.py
+++ b/src/utils/test_platform_details.py
@@ -3,6 +3,8 @@ from unittest import mock
 import sys
 import os
 import tempfile
+from contextlib import contextmanager
+from typing import Generator
 from .platform_details import (
     get_platform_details,
     WindowsPlatformDetails,
@@ -10,6 +12,41 @@ from .platform_details import (
     _get_ssl_truststore_options,
     _create_truststore_from_pem
 )
+
+
+# Valid self-signed CA certificate for testing (generated with cryptography library)
+TEST_CA_CERT_PEM = b"""-----BEGIN CERTIFICATE-----
+MIIDPzCCAiegAwIBAgIUdGj465l77xx7Je8KqOESIqx9zXYwDQYJKoZIhvcNAQEL
+BQAwTzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
+EDAOBgNVBAoMB1Rlc3QgQ0ExEDAOBgNVBAMMB1Rlc3QgQ0EwHhcNMjYwMTE2MDky
+OTQ5WhcNMjcwMTE2MDkyOTQ5WjBPMQswCQYDVQQGEwJVUzENMAsGA1UECAwEVGVz
+dDENMAsGA1UEBwwEVGVzdDEQMA4GA1UECgwHVGVzdCBDQTEQMA4GA1UEAwwHVGVz
+dCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMqoClSXXim/fiI9
+Lc3X/4D4rHK6cWAnKVPA+CetSJiGrMrfeJZMSTWUv19M8aKlmbZsQxN4X4neycWE
+UxH9y3XaqV9grmGvutTgw98t6fhawevGrjmcA+ygQ5S37reRQOHtc9ob51b8b9Rr
+nyE8qIU2dkZ115VpFN+/woG2LG23iGj2dJ3AaZc/R8X0UQu5tQCDwTOeO/zMWPGG
+xjzDpnFs4u7IAwPECEgEuxHH8PHapUoc0d+Aq/wBKM015qdohoaydrztzXp6DKJ5
+RBv/cn+lTpFdvJQS0CceIo+hOUa46ONq63VM3SQhT7enOWToONBxrZpof18bITFd
+2h4XxoMCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+AQEAHDWTjJILOtrCBRFksVyvniUGFR8ioz2cE4R8xcKAFxNOPKLuxwm+ilbUBX3A
+8VOCJjR6IimsLMhAUEi5FGDiVVhOwIp1+pULEigTG7r72yOCr2xnw8NrX9UbJNnx
+rlyCjEN9URBpriiGGegixH6AoLVW0SjEsJ7CgfqmfWzKU+nsPIunvePtFhSw5jHC
+mHwYTxYcxYW33TK9qQxs119A9+qG5Z+cJlDtYrfHirHwPZQeuQ25jhKE5FUUiuiq
+iblIIstcPF4n6wQ0ieNajmj5nHXQEypkek8D/ANbwwhlVQ3u/hldcAyj4qD7G5oJ
+sC0Nc9QdNQt5Tos5Je5S7CWL0w==
+-----END CERTIFICATE-----"""
+
+
+@contextmanager
+def temp_pem_file(content: bytes = TEST_CA_CERT_PEM) -> Generator[str, None, None]:
+    """Context manager for creating and cleaning up temporary PEM files."""
+    with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
+        f.write(content)
+        pem_path = f.name
+    try:
+        yield pem_path
+    finally:
+        os.unlink(pem_path)
 
 
 class TestPlatformDetails(unittest.TestCase):
@@ -166,28 +203,6 @@ class TestPlatformDetails(unittest.TestCase):
 class TestSSLTruststoreOptions(unittest.TestCase):
     """Tests for SSL truststore configuration using REQUESTS_CA_BUNDLE."""
     
-    # Valid self-signed CA certificate for testing (generated with cryptography library)
-    TEST_CA_CERT_PEM = b"""-----BEGIN CERTIFICATE-----
-MIIDPzCCAiegAwIBAgIUdGj465l77xx7Je8KqOESIqx9zXYwDQYJKoZIhvcNAQEL
-BQAwTzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
-EDAOBgNVBAoMB1Rlc3QgQ0ExEDAOBgNVBAMMB1Rlc3QgQ0EwHhcNMjYwMTE2MDky
-OTQ5WhcNMjcwMTE2MDkyOTQ5WjBPMQswCQYDVQQGEwJVUzENMAsGA1UECAwEVGVz
-dDENMAsGA1UEBwwEVGVzdDEQMA4GA1UECgwHVGVzdCBDQTEQMA4GA1UEAwwHVGVz
-dCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMqoClSXXim/fiI9
-Lc3X/4D4rHK6cWAnKVPA+CetSJiGrMrfeJZMSTWUv19M8aKlmbZsQxN4X4neycWE
-UxH9y3XaqV9grmGvutTgw98t6fhawevGrjmcA+ygQ5S37reRQOHtc9ob51b8b9Rr
-nyE8qIU2dkZ115VpFN+/woG2LG23iGj2dJ3AaZc/R8X0UQu5tQCDwTOeO/zMWPGG
-xjzDpnFs4u7IAwPECEgEuxHH8PHapUoc0d+Aq/wBKM015qdohoaydrztzXp6DKJ5
-RBv/cn+lTpFdvJQS0CceIo+hOUa46ONq63VM3SQhT7enOWToONBxrZpof18bITFd
-2h4XxoMCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
-AQEAHDWTjJILOtrCBRFksVyvniUGFR8ioz2cE4R8xcKAFxNOPKLuxwm+ilbUBX3A
-8VOCJjR6IimsLMhAUEi5FGDiVVhOwIp1+pULEigTG7r72yOCr2xnw8NrX9UbJNnx
-rlyCjEN9URBpriiGGegixH6AoLVW0SjEsJ7CgfqmfWzKU+nsPIunvePtFhSw5jHC
-mHwYTxYcxYW33TK9qQxs119A9+qG5Z+cJlDtYrfHirHwPZQeuQ25jhKE5FUUiuiq
-iblIIstcPF4n6wQ0ieNajmj5nHXQEypkek8D/ANbwwhlVQ3u/hldcAyj4qD7G5oJ
-sC0Nc9QdNQt5Tos5Je5S7CWL0w==
------END CERTIFICATE-----"""
-    
     def setUp(self):
         """Save original env vars and clear SSL-related ones."""
         self.original_env = os.environ.copy()
@@ -198,6 +213,10 @@ sC0Nc9QdNQt5Tos5Je5S7CWL0w==
         """Restore original env vars."""
         os.environ.clear()
         os.environ.update(self.original_env)
+    
+    def _assert_truststore_options_present(self, result: str) -> None:
+        """Assert that truststore options are present in the result."""
+        self.assertIn('-Djavax.net.ssl.trustStore=', result)
     
     def test_returns_empty_string_when_no_env_vars_set(self):
         result = _get_ssl_truststore_options()
@@ -211,210 +230,114 @@ sC0Nc9QdNQt5Tos5Je5S7CWL0w==
         self.assertEqual("", result)
     
     def test_returns_truststore_options_when_valid_pem_exists(self):
-        # Create a temporary file with a valid PEM certificate
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file() as pem_path:
             os.environ['REQUESTS_CA_BUNDLE'] = pem_path
             
             result = _get_ssl_truststore_options()
             
-            self.assertIn('-Djavax.net.ssl.trustStore=', result)
+            self._assert_truststore_options_present(result)
             self.assertIn('-Djavax.net.ssl.trustStoreType=PKCS12', result)
             self.assertIn('-Djavax.net.ssl.trustStorePassword=changeit', result)
-        finally:
-            os.unlink(pem_path)
     
     def test_ssl_cert_file_is_used_as_fallback(self):
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file() as pem_path:
             os.environ['SSL_CERT_FILE'] = pem_path
-            
             result = _get_ssl_truststore_options()
-            
-            self.assertIn('-Djavax.net.ssl.trustStore=', result)
-        finally:
-            os.unlink(pem_path)
+            self._assert_truststore_options_present(result)
     
     def test_curl_ca_bundle_is_used_as_fallback(self):
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file() as pem_path:
             os.environ['CURL_CA_BUNDLE'] = pem_path
-            
             result = _get_ssl_truststore_options()
-            
-            self.assertIn('-Djavax.net.ssl.trustStore=', result)
-        finally:
-            os.unlink(pem_path)
+            self._assert_truststore_options_present(result)
     
     def test_requests_ca_bundle_takes_precedence(self):
-        # Create two different files
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            requests_path = f.name
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            ssl_path = f.name
-        
-        try:
+        with temp_pem_file() as requests_path, temp_pem_file() as ssl_path:
             os.environ['REQUESTS_CA_BUNDLE'] = requests_path
             os.environ['SSL_CERT_FILE'] = ssl_path
             
             result = _get_ssl_truststore_options()
             
-            # Should produce a truststore (we can't easily verify which cert was used,
-            # but we verify the mechanism works)
-            self.assertIn('-Djavax.net.ssl.trustStore=', result)
-        finally:
-            os.unlink(requests_path)
-            os.unlink(ssl_path)
+            self._assert_truststore_options_present(result)
     
     def test_returns_empty_for_invalid_pem_content(self):
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(b"not a valid certificate")
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file(b"not a valid certificate") as pem_path:
             os.environ['REQUESTS_CA_BUNDLE'] = pem_path
-            
             result = _get_ssl_truststore_options()
-            
-            # Should return empty string for invalid PEM
             self.assertEqual("", result)
-        finally:
-            os.unlink(pem_path)
     
     def test_windows_includes_ssl_options_in_java_options(self):
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file() as pem_path:
             os.environ['REQUESTS_CA_BUNDLE'] = pem_path
             details = WindowsPlatformDetails()
             
             result = details.get_java_options()
             
-            # Should include both tmpdir and truststore
             self.assertIn('-Djava.io.tmpdir=', result)
-            self.assertIn('-Djavax.net.ssl.trustStore=', result)
-        finally:
-            os.unlink(pem_path)
+            self._assert_truststore_options_present(result)
     
     def test_unix_includes_ssl_options_when_configured(self):
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file() as pem_path:
             os.environ['REQUESTS_CA_BUNDLE'] = pem_path
             details = UnixPlatformDetails()
             
             result = details.get_java_options()
             
-            self.assertIn('-Djavax.net.ssl.trustStore=', result)
-        finally:
-            os.unlink(pem_path)
+            self._assert_truststore_options_present(result)
 
 
 class TestCreateTruststoreFromPem(unittest.TestCase):
     """Tests for PEM to PKCS12 conversion."""
     
-    # Valid test certificate (same as in TestSSLTruststoreOptions)
-    TEST_CA_CERT_PEM = TestSSLTruststoreOptions.TEST_CA_CERT_PEM
-    
     def test_returns_none_for_invalid_pem_content(self):
         """Test that invalid PEM content returns None via exception handler."""
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            # Write invalid PEM data - triggers exception handler
-            f.write(b"not a valid certificate")
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file(b"not a valid certificate") as pem_path:
             result = _create_truststore_from_pem(pem_path)
-            # Should return None for invalid PEM
             self.assertIsNone(result)
-        finally:
-            os.unlink(pem_path)
     
     def test_returns_none_for_empty_pem_file(self):
         """Test that an empty PEM file returns None via exception handler."""
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            # Write empty content - triggers exception in load_pem_x509_certificates
-            f.write(b"")
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file(b"") as pem_path:
             result = _create_truststore_from_pem(pem_path)
             self.assertIsNone(result)
-        finally:
-            os.unlink(pem_path)
     
     def test_creates_truststore_and_reuses_existing(self):
         """Test that truststore is created and reused on subsequent calls."""
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        truststore_path = None
-        try:
-            # First call creates the truststore
+        with temp_pem_file() as pem_path:
             truststore_path = _create_truststore_from_pem(pem_path)
             self.assertIsNotNone(truststore_path)
-            assert truststore_path is not None  # Type narrowing for mypy
+            assert truststore_path is not None  # Type narrowing
             self.assertTrue(os.path.exists(truststore_path))
             
-            # Get the file's modification time
             mtime1 = os.path.getmtime(truststore_path)
             
-            # Second call should reuse the existing truststore (not recreate it)
+            # Second call should reuse existing truststore
             result2 = _create_truststore_from_pem(pem_path)
             self.assertEqual(truststore_path, result2)
             
-            # File should not have been modified
-            assert result2 is not None  # Type narrowing for mypy
+            assert result2 is not None  # Type narrowing
             mtime2 = os.path.getmtime(result2)
             self.assertEqual(mtime1, mtime2)
-        finally:
-            os.unlink(pem_path)
-            # Clean up truststore if created
-            if truststore_path and os.path.exists(truststore_path):
-                os.unlink(truststore_path)
+            
+            # Clean up truststore
+            os.unlink(truststore_path)
     
     def test_returns_none_on_file_read_error(self):
         """Test that file read errors are handled gracefully."""
-        # Use a path that doesn't exist - triggers exception handler
         result = _create_truststore_from_pem("/nonexistent/path/cert.pem")
         self.assertIsNone(result)
     
     def test_returns_none_when_no_certs_parsed(self):
-        """Test handling when certificate parsing returns empty list (line 109)."""
+        """Test handling when certificate parsing returns empty list."""
         from cryptography import x509
         
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        try:
-            # Mock load_pem_x509_certificates to return empty list
-            with mock.patch.object(
-                x509, 'load_pem_x509_certificates', return_value=[]
-            ):
+        with temp_pem_file() as pem_path:
+            with mock.patch.object(x509, 'load_pem_x509_certificates', return_value=[]):
                 result = _create_truststore_from_pem(pem_path)
                 self.assertIsNone(result)
-        finally:
-            os.unlink(pem_path)
     
     def test_returns_none_when_cryptography_import_fails(self):
-        """Test handling when cryptography module is not available (lines 94-96)."""
+        """Test handling when cryptography module is not available."""
         import utils.platform_details as pd
         import builtins
         
@@ -425,20 +348,12 @@ class TestCreateTruststoreFromPem(unittest.TestCase):
                 raise ImportError("No module named 'cryptography'")
             return original_import(name, *args, **kwargs)
         
-        with tempfile.NamedTemporaryFile(suffix='.pem', delete=False) as f:
-            f.write(self.TEST_CA_CERT_PEM)
-            pem_path = f.name
-        
-        try:
+        with temp_pem_file() as pem_path:
             with mock.patch.object(builtins, '__import__', side_effect=mock_import):
-                # Need to reload the function context - use exec to simulate fresh import
-                # Since the import happens inside the function, we need to test it directly
                 result = pd._create_truststore_from_pem(pem_path)
-                # When cryptography is available (as it is in test env), this will succeed
+                # When cryptography is available, this will succeed
                 # The ImportError branch can only be hit in envs without cryptography
                 self.assertTrue(result is None or isinstance(result, str))
-        finally:
-            os.unlink(pem_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Automatically configure Java truststore from REQUESTS_CA_BUNDLE environment variable, allowing users to configure SSL certificates once for both the Python MCP server and the embedded Java CLI.

- Reuse standard CA bundle env vars (REQUESTS_CA_BUNDLE, SSL_CERT_FILE, CURL_CA_BUNDLE)
- Convert PEM certificates to PKCS12 truststore at runtime using cryptography library
- Cache generated truststore in temp directory to avoid regeneration
- Add comprehensive tests for SSL truststore configuration
- Document SSL configuration in README FAQ