### PR TITLE
Update Homebrew formula to 0.0.31

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.0.30"
+  version "0.0.31"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "53b197f1f9214cd88a4e1d7d8ade1e5e34682ecb932de849d011f1a6d5a82bbc"
+      sha256 "4dfe07abe6e4992df6ee6967c08d45d55782d6346302454ed742a5035f97aeb0"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "e9efb46cfb41b50e7cda836ef5bfb27b9d1c98286d67c30e91c8fe03c9e0f65e"
+      sha256 "c782b247b0d5e0d16af9efc71b124874e731d1c31c1486e89aba335a01939223"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "5891507ff78400b438a1d938a30bba95b8a61d10027f6623207ce62225eefdc0"
+      sha256 "1ebe2c928c67d5ed7540ebf05fc75780efd1aae34fa206947b3fe11952b6fbf4"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "6aeaaba07e793f115aed3a8196415c82a09cfdc093b3a7407595970b9c5c2dbe"
+      sha256 "d77a46a201f8ce014433e72da173a8b290ea17bf4337b0d70d8108a143416a37"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.0.31.

## Checksums
- macOS ARM64: `4dfe07abe6e4992df6ee6967c08d45d55782d6346302454ed742a5035f97aeb0`
- macOS AMD64: `c782b247b0d5e0d16af9efc71b124874e731d1c31c1486e89aba335a01939223`
- Linux ARM64: `1ebe2c928c67d5ed7540ebf05fc75780efd1aae34fa206947b3fe11952b6fbf4`
- Linux AMD64: `d77a46a201f8ce014433e72da173a8b290ea17bf4337b0d70d8108a143416a37`