### PR TITLE
CS-6308: Fix `CS_MOUNT_PATH` needed in static exe

### DIFF
--- a/src/code_ownership/code_ownership.py
+++ b/src/code_ownership/code_ownership.py
@@ -2,7 +2,7 @@ from itertools import groupby
 import json
 import os
 from typing import TypedDict, Callable
-from utils import adapt_mounted_file_path_inside_docker, normalize_onprem_url, track, track_error, with_version_check
+from utils import get_relative_file_path_for_api, normalize_onprem_url, track, track_error, with_version_check
 
 
 class CodeOwnershipDeps(TypedDict):
@@ -30,8 +30,7 @@ class CodeOwnership:
         """
         try:
             endpoint = f"v2/projects/{project_id}/analyses/latest/files"
-            mounted_path = adapt_mounted_file_path_inside_docker(path)
-            relative_path = mounted_path.lstrip("/mount/")
+            relative_path = get_relative_file_path_for_api(path)
             params = {'filter': f"path~{relative_path}", 'fields': 'owner,path'}
             files = self.deps["query_api_list_fn"](endpoint, params, 'files')
             

--- a/src/technical_debt_goals/technical_debt_goals.py
+++ b/src/technical_debt_goals/technical_debt_goals.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import TypedDict, Callable
 
-from utils import adapt_mounted_file_path_inside_docker, normalize_onprem_url, track, track_error, with_version_check
+from utils import get_relative_file_path_for_api, normalize_onprem_url, track, track_error, with_version_check
 
 
 class TechnicalDebtGoalsDeps(TypedDict):
@@ -70,8 +70,7 @@ class TechnicalDebtGoals:
         """
         try:
             endpoint = f"v2/projects/{project_id}/analyses/latest/files"
-            mounted_file_path = adapt_mounted_file_path_inside_docker(file_path)
-            relative_file_path = mounted_file_path.lstrip("/mount/")
+            relative_file_path = get_relative_file_path_for_api(file_path)
             params = {'filter': f"path~{relative_file_path}", 'fields': 'goals'}
             files = self.deps["query_api_list_fn"](endpoint, params, 'files')
             goals = files[0].get('goals', []) if files else []

--- a/src/technical_debt_hotspots/technical_debt_hotspots.py
+++ b/src/technical_debt_hotspots/technical_debt_hotspots.py
@@ -2,7 +2,7 @@ import json
 import os
 from typing import Callable, TypedDict
 
-from utils import adapt_mounted_file_path_inside_docker, normalize_onprem_url, track, track_error, with_version_check
+from utils import get_relative_file_path_for_api, normalize_onprem_url, track, track_error, with_version_check
 
 
 class TechnicalDebtHotspotsDeps(TypedDict):
@@ -71,8 +71,7 @@ class TechnicalDebtHotspots:
             Make sure to include this link in the output, and explain its purpose clearly.
         """
         try:
-            mounted_file_path = adapt_mounted_file_path_inside_docker(file_path)
-            relative_file_path = mounted_file_path.lstrip("/mount/")
+            relative_file_path = get_relative_file_path_for_api(file_path)
             endpoint = f"/v2/projects/{project_id}/analyses/latest/technical-debt"
             params = {'filter': f"file_name~{relative_file_path}", 'refactoring_targets': "true"}
             hotspots = self.deps["query_api_list_fn"](endpoint, params, 'result')

--- a/src/technical_debt_hotspots/test_technical_debt_hotspots.py
+++ b/src/technical_debt_hotspots/test_technical_debt_hotspots.py
@@ -183,3 +183,20 @@ class TestTechnicalDebtHotspots(unittest.TestCase):
         for scenario in all_scenarios:
             with self.subTest(scenario=scenario["name"]):
                 self._assert_scenario(scenario)
+
+    @mock.patch('technical_debt_hotspots.technical_debt_hotspots.get_relative_file_path_for_api')
+    @mock.patch('requests.post', side_effect=mocked_requests_post)
+    def test_file_hotspots_static_mode(self, mock_post, mock_get_path):
+        """Test that file-level hotspots work in static executable mode (no CS_MOUNT_PATH)."""
+        mock_get_path.return_value = "src/some_file.tsx"
+        
+        def mocked_query_api_list(*args, **kwargs):
+            return [{"path": "src/some_file.tsx", "revisions": 42, "code_health": 5.5}]
+        
+        instance = TechnicalDebtHotspots(FastMCP("Test"), {'query_api_list_fn': mocked_query_api_list})
+        result = instance.list_technical_debt_hotspots_for_project_file("/some/git/repo/src/some_file.tsx", PROJECT_ID)
+        
+        mock_get_path.assert_called_once_with("/some/git/repo/src/some_file.tsx")
+        result_data = json.loads(result)
+        self.assertEqual(result_data['hotspot']['revisions'], 42)
+        self.assertIn("src/some_file.tsx", result_data['description'])

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,4 +1,4 @@
-from .docker_path_adapter import adapt_mounted_file_path_inside_docker, adapt_worktree_gitdir_for_docker
+from .docker_path_adapter import adapt_mounted_file_path_inside_docker, adapt_worktree_gitdir_for_docker, get_relative_file_path_for_api
 from .platform_details import get_platform_details, PlatformDetails, get_ssl_cli_args
 from .codescene_api_client import (
     normalize_onprem_url, 

--- a/tests/path-resolution-integration/README.md
+++ b/tests/path-resolution-integration/README.md
@@ -1,0 +1,91 @@
+# Path Resolution Integration Tests
+
+This directory contains integration tests for verifying that MCP tools
+correctly resolve file paths in both Docker and static executable modes.
+
+## Background
+
+The following MCP tools require file path resolution to convert absolute
+paths to relative paths for CodeScene API calls:
+
+- `code_ownership_for_path`
+- `list_technical_debt_hotspots_for_project_file`
+- `list_technical_debt_goals_for_project_file`
+
+These tools previously only worked in Docker mode (with `CS_MOUNT_PATH` set)
+and would fail with "CS_MOUNT_PATH not defined" error in static executable mode.
+
+The fix introduces a helper function `get_relative_file_path_for_api()` that:
+- In **Docker mode** (`CS_MOUNT_PATH` set): Uses the mount path to translate paths
+- In **Static mode** (no `CS_MOUNT_PATH`):
+  - If path is relative: Returns as-is
+  - If path is absolute and in a git repo: Uses git root detection to compute relative paths
+  - If path is absolute and NOT in a git repo: Returns path unchanged (graceful fallback)
+
+## Test Files
+
+### `test_static_variant.py`
+
+Tests the static executable variant (without `CS_MOUNT_PATH`).
+
+**Usage:**
+```bash
+python test_static_variant.py /path/to/cs-mcp
+```
+
+**What it tests:**
+1. MCP server starts successfully without `CS_MOUNT_PATH`
+2. `code_ownership_for_path` works with files in a git repository
+3. `list_technical_debt_hotspots_for_project_file` works with files in a git repository
+4. `list_technical_debt_goals_for_project_file` works with files in a git repository
+5. `code_ownership_for_path` works with files OUTSIDE a git repository (no error)
+6. `code_ownership_for_path` works with relative paths (no git/mount requirements)
+
+The test creates both a temporary git repository and a non-git directory
+to verify both scenarios work correctly.
+
+### `test_docker_run.py`
+
+Tests the Docker variant (with `CS_MOUNT_PATH` set).
+
+**Usage:**
+```bash
+# With default image name (codescene-mcp)
+python test_docker_run.py
+
+# With custom image
+DOCKER_IMAGE=my-codescene-mcp python test_docker_run.py
+
+# With custom test data path
+TEST_DATA_PATH=/path/to/test/data python test_docker_run.py
+```
+
+**Environment variables:**
+- `DOCKER_IMAGE`: Docker image name to test (default: `codescene-mcp`)
+- `TEST_DATA_PATH`: Path to test data files (creates temp if not set)
+
+**What it tests:**
+1. Docker container starts successfully with `CS_MOUNT_PATH` set
+2. `code_ownership_for_path` works with path translation
+3. `list_technical_debt_hotspots_for_project_file` works with path translation
+4. `list_technical_debt_goals_for_project_file` works with path translation
+
+## Running Both Tests
+
+To ensure the fix works in both modes, run both test files:
+
+```bash
+# Test static executable mode
+python tests/path-resolution-integration/test_static_variant.py ./dist/cs-mcp
+
+# Test Docker mode
+python tests/path-resolution-integration/test_docker_run.py
+```
+
+## Note
+
+These tests verify that the path resolution doesn't fail with the
+`CS_MOUNT_PATH not defined` error. They may still return API errors
+(e.g., authentication errors) if proper CodeScene credentials are not
+configured, but that's expected - the key verification is that the
+path resolution step succeeds.

--- a/tests/path-resolution-integration/mcp_test_utils.py
+++ b/tests/path-resolution-integration/mcp_test_utils.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Shared utilities for MCP integration tests.
+
+This module provides common functionality for testing MCP tools:
+- MCPClient: A client for communicating with MCP servers via stdio
+- Test helpers for checking tool responses
+- Common test patterns for path resolution tests
+"""
+
+import json
+import os
+import queue
+import subprocess
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+
+# MCP Protocol message IDs
+_msg_id = 0
+
+
+def next_msg_id():
+    global _msg_id
+    _msg_id += 1
+    return _msg_id
+
+
+def print_header(msg: str):
+    print(f"\n{'='*60}")
+    print(f"  {msg}")
+    print(f"{'='*60}\n")
+
+
+def print_test(name: str, passed: bool, details: str = ""):
+    status = "\u2713 PASS" if passed else "\u2717 FAIL"
+    print(f"  {status}: {name}")
+    if details:
+        for line in details.split('\n')[:5]:
+            print(f"         {line}")
+
+
+def extract_result_text(tool_response: dict) -> str:
+    """Extract the actual result text from MCP response format."""
+    if "result" not in tool_response:
+        return ""
+    result = tool_response["result"]
+    if not isinstance(result, dict):
+        return ""
+    content = result.get("content", [])
+    if content and isinstance(content, list):
+        return content[0].get("text", "")
+    structured = result.get("structuredContent", {})
+    return structured.get("result", "")
+
+
+class MCPClient:
+    """MCP client that communicates with the server via stdio."""
+    
+    def __init__(self, command: list, env: dict = None):
+        self.command = command
+        self.env = env or os.environ.copy()
+        self.process = None
+        self.response_queue = queue.Queue()
+        self.reader_thread = None
+        
+    def start(self):
+        """Start the MCP server process."""
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+            text=True,
+            encoding="utf-8",
+            bufsize=1
+        )
+        self.reader_thread = threading.Thread(target=self._read_responses, daemon=True)
+        self.reader_thread.start()
+        time.sleep(1)
+        return self.process.poll() is None
+    
+    def _read_responses(self):
+        """Read responses from the server in a background thread."""
+        try:
+            while self.process and self.process.poll() is None:
+                line = self.process.stdout.readline()
+                if line:
+                    self.response_queue.put(line.strip())
+        except Exception as e:
+            self.response_queue.put(f"ERROR: {e}")
+    
+    def send_request(self, method: str, params: dict = None) -> dict:
+        """Send a JSON-RPC request and wait for response."""
+        request = {
+            "jsonrpc": "2.0",
+            "id": next_msg_id(),
+            "method": method,
+            "params": params or {}
+        }
+        try:
+            self.process.stdin.write(json.dumps(request) + "\n")
+            self.process.stdin.flush()
+        except Exception as e:
+            return {"error": f"Failed to send request: {e}"}
+        try:
+            response_str = self.response_queue.get(timeout=30)
+            return json.loads(response_str)
+        except queue.Empty:
+            return {"error": "Timeout waiting for response"}
+        except json.JSONDecodeError as e:
+            return {"error": f"Invalid JSON response: {e}"}
+    
+    def send_notification(self, method: str, params: dict = None):
+        """Send a JSON-RPC notification (no response expected)."""
+        notification = {"jsonrpc": "2.0", "method": method}
+        if params:
+            notification["params"] = params
+        try:
+            self.process.stdin.write(json.dumps(notification) + "\n")
+            self.process.stdin.flush()
+        except Exception as e:
+            print(f"Failed to send notification: {e}")
+    
+    def call_tool(self, tool_name: str, arguments: dict) -> dict:
+        """Call an MCP tool."""
+        return self.send_request("tools/call", {"name": tool_name, "arguments": arguments})
+    
+    def initialize(self) -> dict:
+        """Initialize the MCP session and send initialized notification."""
+        response = self.send_request("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "path-resolution-test-client", "version": "1.0.0"}
+        })
+        time.sleep(0.2)
+        self.send_notification("notifications/initialized")
+        time.sleep(0.3)
+        return response
+    
+    def stop(self):
+        """Stop the MCP server process."""
+        if self.process:
+            try:
+                self.process.stdin.close()
+                self.process.terminate()
+                self.process.wait(timeout=5)
+            except Exception:
+                self.process.kill()
+    
+    def get_stderr(self) -> str:
+        """Get any stderr output from the server."""
+        if self.process and self.process.stderr:
+            try:
+                return self.process.stderr.read()
+            except Exception:
+                return ""
+        return ""
+
+
+@dataclass
+class ToolTestConfig:
+    """Configuration for a tool test."""
+    tool_name: str
+    arguments: dict
+    header: str
+    forbidden_patterns: list[str]
+    test_description: str
+
+
+def run_tool_test(command: list, env: dict, config: ToolTestConfig) -> bool:
+    """
+    Run a generic tool test with the given configuration.
+    
+    This is the common test pattern extracted from the individual test functions.
+    It handles:
+    - Starting the MCP client
+    - Initializing the session
+    - Calling the specified tool
+    - Checking the response for forbidden patterns
+    - Cleanup
+    
+    Args:
+        command: The command to start the MCP server
+        env: Environment variables for the server
+        config: Test configuration specifying tool, arguments, and checks
+        
+    Returns:
+        True if the test passed, False otherwise
+    """
+    print_header(config.header)
+    
+    client = MCPClient(command, env=env)
+    
+    try:
+        if not client.start():
+            print_test("MCP server started", False)
+            return False
+        print_test("MCP server started", True)
+        
+        client.initialize()
+        
+        tool_response = client.call_tool(config.tool_name, config.arguments)
+        result_text = extract_result_text(tool_response)
+        
+        # Check for forbidden patterns in the response
+        found_patterns = []
+        for pattern in config.forbidden_patterns:
+            if pattern.lower() in result_text.lower():
+                found_patterns.append(pattern)
+        
+        passed = len(found_patterns) == 0
+        details = f"Response: {result_text[:150]}..."
+        if found_patterns:
+            details = f"Found forbidden patterns: {found_patterns}\n{details}"
+        
+        print_test(config.test_description, passed, details)
+        return passed
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def create_static_mode_env() -> dict:
+    """Create environment for static mode testing (no CS_MOUNT_PATH)."""
+    env = os.environ.copy()
+    env.pop('CS_MOUNT_PATH', None)
+    return env
+
+
+def create_test_git_repo() -> tuple[str, str]:
+    """
+    Create a temporary git repository with a test file.
+    
+    Returns:
+        Tuple of (tmpdir, test_file_path)
+    """
+    tmpdir = tempfile.mkdtemp(prefix="mcp-path-test-")
+    
+    subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmpdir, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True)
+    
+    src_dir = os.path.join(tmpdir, "src")
+    os.makedirs(src_dir)
+    
+    test_file = os.path.join(src_dir, "TestFile.java")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("""public class TestFile {
+    public void hello() {
+        System.out.println("Hello");
+    }
+}
+""")
+    
+    subprocess.run(["git", "add", "."], cwd=tmpdir, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=tmpdir, capture_output=True)
+    
+    return tmpdir, test_file
+
+
+def create_test_file_no_git() -> tuple[str, str]:
+    """
+    Create a temporary file NOT in a git repository.
+    
+    Returns:
+        Tuple of (tmpdir, test_file_path)
+    """
+    tmpdir = tempfile.mkdtemp(prefix="mcp-no-git-test-")
+    
+    src_dir = os.path.join(tmpdir, "src")
+    os.makedirs(src_dir)
+    
+    test_file = os.path.join(src_dir, "TestFile.java")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("""public class TestFile {
+    public void hello() {
+        System.out.println("Hello");
+    }
+}
+""")
+    
+    return tmpdir, test_file
+
+
+def cleanup_test_dir(tmpdir: str):
+    """Clean up a temporary test directory."""
+    import shutil
+    try:
+        shutil.rmtree(tmpdir)
+    except Exception:
+        pass
+
+
+def print_test_summary(results: list[tuple[str, bool]]) -> int:
+    """
+    Print a summary of test results.
+    
+    Args:
+        results: List of (test_name, passed) tuples
+        
+    Returns:
+        Exit code (0 if all passed, 1 otherwise)
+    """
+    print_header("Test Summary")
+    
+    passed = sum(1 for _, p in results if p)
+    total = len(results)
+    
+    for name, result in results:
+        print(f"  {'\u2713 PASS' if result else '\u2717 FAIL'}: {name}")
+    
+    print(f"\n  Total: {passed}/{total} passed")
+    
+    if passed == total:
+        print("\n  All tests passed! \u2713")
+        return 0
+    print(f"\n  {total - passed} test(s) failed! \u2717")
+    return 1

--- a/tests/path-resolution-integration/run-docker-test.sh
+++ b/tests/path-resolution-integration/run-docker-test.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Docker Image Path Resolution Integration Test Runner
+#
+# This script tests the Docker image with CS_MOUNT_PATH set:
+# 1. Builds the Docker image from the main Dockerfile
+# 2. Creates test data directory
+# 3. Runs `docker run -i codescene-mcp` with CS_MOUNT_PATH set
+# 4. Verifies tools work correctly with path translation
+# 5. Cleans up
+#
+# Prerequisites:
+# - Docker installed
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Docker image name for testing
+MCP_IMAGE="codescene-mcp-path-test"
+
+echo "============================================================"
+echo "  Docker Image Path Resolution Integration Test"
+echo "  Testing: docker run with CS_MOUNT_PATH set"
+echo "============================================================"
+echo ""
+
+# Create temp directory for test data
+BUILD_DIR=$(mktemp -d)
+TEST_DATA_DIR="$BUILD_DIR/test-data"
+mkdir -p "$TEST_DATA_DIR"
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    
+    # Remove test image
+    docker rmi "$MCP_IMAGE" 2>/dev/null || true
+    
+    # Remove temp directory
+    rm -rf "$BUILD_DIR"
+    
+    echo "Cleanup complete."
+}
+
+trap cleanup EXIT
+
+# Step 1: Build the Docker image
+echo "Step 1: Building Docker image from main Dockerfile..."
+
+docker build -t "$MCP_IMAGE" "$REPO_ROOT" 2>&1 | tail -5
+
+if ! docker image inspect "$MCP_IMAGE" > /dev/null 2>&1; then
+    echo "  ✗ Failed to build Docker image"
+    exit 1
+fi
+echo "  ✓ Docker image built successfully"
+
+# Step 2: Create test data
+echo ""
+echo "Step 2: Creating test data..."
+
+# Create a simple test file
+cat > "$TEST_DATA_DIR/TestFile.java" << 'EOF'
+public class TestFile {
+    public void hello() {
+        System.out.println("Hello");
+    }
+}
+EOF
+
+echo "  ✓ Test data created at $TEST_DATA_DIR"
+
+# Step 3: Run path resolution tests
+echo ""
+echo "Step 3: Running path resolution tests (Docker mode)..."
+
+# Export environment for the test script
+export DOCKER_IMAGE="$MCP_IMAGE"
+export TEST_DATA_PATH="$TEST_DATA_DIR"
+
+# Run the test Python script (runs on host, uses docker run)
+python3 "$SCRIPT_DIR/test_docker_run.py"
+TEST_EXIT_CODE=$?
+
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo ""
+    echo "============================================================"
+    echo "  Docker Variant Path Resolution Tests PASSED ✓"
+    echo "============================================================"
+else
+    echo ""
+    echo "============================================================"
+    echo "  Docker Variant Path Resolution Tests FAILED ✗"
+    echo "============================================================"
+fi
+
+exit $TEST_EXIT_CODE

--- a/tests/path-resolution-integration/run-path-test.sh
+++ b/tests/path-resolution-integration/run-path-test.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Path Resolution Integration Test Runner
+#
+# This script runs both Docker and static binary path resolution tests.
+#
+# Usage:
+#   ./run-path-test.sh          # Run both Docker and static tests
+#   ./run-path-test.sh docker   # Run only Docker test
+#   ./run-path-test.sh static   # Run only static test
+#
+# The tests verify that MCP tools correctly resolve file paths in both:
+# - Docker mode (with CS_MOUNT_PATH set)
+# - Static executable mode (without CS_MOUNT_PATH)
+#
+# Prerequisites:
+# - Docker installed (for Docker tests)
+# - Python 3.13 + Nuitka (for static tests)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo ""
+echo "============================================================"
+echo "  Path Resolution Integration Tests"
+echo "============================================================"
+echo ""
+echo "These tests verify that MCP tools correctly resolve file paths"
+echo "in both Docker and static executable modes."
+echo ""
+
+TEST_MODE="${1:-both}"
+
+DOCKER_PASSED=false
+STATIC_PASSED=false
+
+run_docker_test() {
+    echo "Running Docker path resolution tests..."
+    echo ""
+    
+    if "$SCRIPT_DIR/run-docker-test.sh"; then
+        DOCKER_PASSED=true
+    fi
+}
+
+run_static_test() {
+    echo "Running static binary path resolution tests..."
+    echo ""
+    
+    if "$SCRIPT_DIR/run-static-test.sh"; then
+        STATIC_PASSED=true
+    fi
+}
+
+case "$TEST_MODE" in
+    docker)
+        run_docker_test
+        ;;
+    static)
+        run_static_test
+        ;;
+    both)
+        run_docker_test
+        echo ""
+        echo "============================================================"
+        echo ""
+        run_static_test
+        ;;
+    *)
+        echo "Usage: $0 [docker|static|both]"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "============================================================"
+echo "  Final Summary"
+echo "============================================================"
+echo ""
+
+if [ "$TEST_MODE" = "both" ] || [ "$TEST_MODE" = "docker" ]; then
+    if $DOCKER_PASSED; then
+        echo "  Docker tests:  PASSED ✓"
+    else
+        echo "  Docker tests:  FAILED ✗"
+    fi
+fi
+
+if [ "$TEST_MODE" = "both" ] || [ "$TEST_MODE" = "static" ]; then
+    if $STATIC_PASSED; then
+        echo "  Static tests:  PASSED ✓"
+    else
+        echo "  Static tests:  FAILED ✗"
+    fi
+fi
+
+echo ""
+
+# Exit with failure if any test failed
+if [ "$TEST_MODE" = "both" ]; then
+    if $DOCKER_PASSED && $STATIC_PASSED; then
+        echo "All path resolution tests passed! ✓"
+        exit 0
+    else
+        echo "Some path resolution tests failed! ✗"
+        exit 1
+    fi
+elif [ "$TEST_MODE" = "docker" ]; then
+    $DOCKER_PASSED && exit 0 || exit 1
+elif [ "$TEST_MODE" = "static" ]; then
+    $STATIC_PASSED && exit 0 || exit 1
+fi

--- a/tests/path-resolution-integration/run-static-test.sh
+++ b/tests/path-resolution-integration/run-static-test.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Static Binary Path Resolution Integration Test Runner
+#
+# This script:
+# 1. Builds the cs-mcp static binary using Nuitka
+# 2. Creates a test git repository
+# 3. Runs the path resolution tests WITHOUT CS_MOUNT_PATH set
+# 4. Verifies tools work correctly in static executable mode
+# 5. Cleans up
+#
+# Prerequisites:
+# - Python 3.13
+# - Nuitka installed (pip install Nuitka)
+# - Git
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "============================================================"
+echo "  Static Binary Path Resolution Integration Test"
+echo "  Testing: cs-mcp binary without CS_MOUNT_PATH"
+echo "============================================================"
+echo ""
+
+# Create temp directory for build artifacts
+BUILD_DIR=$(mktemp -d)
+
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    
+    # Remove build artifacts
+    rm -rf "$BUILD_DIR"
+    
+    # Note: We don't remove the cs-mcp binary or Nuitka build dirs
+    # as they may be wanted for other tests
+    
+    echo "Cleanup complete."
+}
+
+trap cleanup EXIT
+
+# Step 1: Check prerequisites
+echo "Step 1: Checking prerequisites..."
+
+if ! command -v python3.13 &> /dev/null; then
+    echo "  ✗ Python 3.13 not found"
+    echo "  Install Python 3.13 to run static variant tests"
+    exit 1
+fi
+echo "  ✓ Python 3.13 found"
+
+if ! python3.13 -c "import nuitka" 2>/dev/null; then
+    echo "  ✗ Nuitka not found"
+    echo "  Install with: pip install Nuitka"
+    exit 1
+fi
+echo "  ✓ Nuitka found"
+
+if ! command -v git &> /dev/null; then
+    echo "  ✗ Git not found"
+    exit 1
+fi
+echo "  ✓ Git found"
+
+# Step 2: Download CS CLI if not present
+echo ""
+echo "Step 2: Checking CodeScene CLI..."
+
+if [ ! -f "$REPO_ROOT/cs" ]; then
+    echo "  Downloading CodeScene CLI..."
+    
+    # Detect platform
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if [[ $(uname -m) == "arm64" ]]; then
+            CLI_URL="https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip"
+        else
+            CLI_URL="https://downloads.codescene.io/enterprise/cli/cs-macos-amd64-latest.zip"
+        fi
+    elif [[ "$OSTYPE" == "linux"* ]]; then
+        if [[ $(uname -m) == "aarch64" ]]; then
+            CLI_URL="https://downloads.codescene.io/enterprise/cli/cs-linux-aarch64-latest.zip"
+        else
+            CLI_URL="https://downloads.codescene.io/enterprise/cli/cs-linux-amd64-latest.zip"
+        fi
+    else
+        echo "  ✗ Unsupported platform: $OSTYPE"
+        exit 1
+    fi
+    
+    curl -fsSL "$CLI_URL" -o "$BUILD_DIR/cs.zip"
+    unzip -q "$BUILD_DIR/cs.zip" -d "$REPO_ROOT"
+    chmod +x "$REPO_ROOT/cs"
+    echo "  ✓ CodeScene CLI downloaded"
+else
+    echo "  ✓ CodeScene CLI found"
+fi
+
+# Step 3: Build cs-mcp static binary (if not already built)
+echo ""
+echo "Step 3: Checking/Building cs-mcp static binary..."
+
+if [ -f "$REPO_ROOT/cs-mcp" ]; then
+    echo "  ✓ cs-mcp binary already exists, skipping build"
+else
+    echo "  Building cs-mcp (this may take several minutes)..."
+    
+    cd "$REPO_ROOT"
+    
+    # Create virtual environment if needed
+    if [ ! -d ".venv" ]; then
+        python3.13 -m venv .venv
+    fi
+    source .venv/bin/activate
+    
+    # Install dependencies
+    pip install -q -r src/requirements.txt
+    pip install -q Nuitka
+    
+    # Build with Nuitka
+    python3.13 -m nuitka --onefile \
+        --assume-yes-for-downloads \
+        --include-data-dir=./src/docs=src/docs \
+        --include-data-files=./cs=cs \
+        --output-filename=cs-mcp \
+        src/cs_mcp_server.py 2>&1 | tail -5
+    
+    deactivate 2>/dev/null || true
+    
+    if [ ! -f "$REPO_ROOT/cs-mcp" ]; then
+        echo "  ✗ Failed to build cs-mcp binary"
+        exit 1
+    fi
+    echo "  ✓ cs-mcp binary built successfully"
+fi
+
+# Step 4: Run the path resolution tests
+echo ""
+echo "Step 4: Running path resolution tests (static mode)..."
+
+# Ensure CS_MOUNT_PATH is NOT set (static mode)
+unset CS_MOUNT_PATH
+
+# Set a dummy access token for API calls (they'll fail but we're testing path resolution)
+export CS_ACCESS_TOKEN="${CS_ACCESS_TOKEN:-test-token}"
+
+# Activate venv for running tests
+cd "$REPO_ROOT"
+if [ -d ".venv" ]; then
+    source .venv/bin/activate
+fi
+
+# Run the test Python script
+python3 "$SCRIPT_DIR/test_static_variant.py" "$REPO_ROOT/cs-mcp"
+TEST_EXIT_CODE=$?
+
+deactivate 2>/dev/null || true
+
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo ""
+    echo "============================================================"
+    echo "  Static Variant Path Resolution Tests PASSED ✓"
+    echo "============================================================"
+else
+    echo ""
+    echo "============================================================"
+    echo "  Static Variant Path Resolution Tests FAILED ✗"
+    echo "============================================================"
+fi
+
+exit $TEST_EXIT_CODE

--- a/tests/path-resolution-integration/test_docker_run.py
+++ b/tests/path-resolution-integration/test_docker_run.py
@@ -16,59 +16,31 @@ Environment variables (should be set before running):
 - TEST_DATA_PATH: Path to test data files (will create temp if not set)
 """
 
-import json
 import os
 import subprocess
 import sys
 import tempfile
-import threading
-import queue
 import time
-import shutil
 
-# MCP Protocol message IDs
-_msg_id = 0
-
-
-def next_msg_id():
-    global _msg_id
-    _msg_id += 1
-    return _msg_id
-
-
-def print_header(msg: str):
-    print(f"\n{'='*60}")
-    print(f"  {msg}")
-    print(f"{'='*60}\n")
+from mcp_test_utils import (
+    MCPClient,
+    ToolTestConfig,
+    cleanup_test_dir,
+    extract_result_text,
+    print_header,
+    print_test,
+    print_test_summary,
+)
 
 
-def print_test(name: str, passed: bool, details: str = ""):
-    status = "\u2713 PASS" if passed else "\u2717 FAIL"
-    print(f"  {status}: {name}")
-    if details:
-        for line in details.split('\n')[:5]:
-            print(f"         {line}")
+# Forbidden pattern for Docker mode (we check for "not defined" specifically)
+MOUNT_PATH_NOT_DEFINED = "CS_MOUNT_PATH"
 
 
-def extract_result_text(tool_response: dict) -> str:
-    """Extract the actual result text from MCP response format."""
-    if "result" not in tool_response:
-        return ""
-    result = tool_response["result"]
-    if not isinstance(result, dict):
-        return ""
-    content = result.get("content", [])
-    if content and isinstance(content, list):
-        return content[0].get("text", "")
-    structured = result.get("structuredContent", {})
-    return structured.get("result", "")
-
-
-def create_test_data():
-    """Create a temporary directory with test files."""
+def create_test_data() -> str:
+    """Create a temporary directory with test files for Docker mounting."""
     tmpdir = tempfile.mkdtemp(prefix="mcp-docker-path-test-")
     
-    # Create test file
     test_file = os.path.join(tmpdir, "TestFile.java")
     with open(test_file, "w", encoding="utf-8") as f:
         f.write("""public class TestFile {
@@ -81,141 +53,67 @@ def create_test_data():
     return tmpdir
 
 
-def cleanup_test_data(tmpdir: str):
-    """Clean up the temporary directory."""
-    try:
-        shutil.rmtree(tmpdir)
-    except Exception:
-        pass
-
-
-def build_docker_command(test_data_path: str, docker_image: str):
+def build_docker_command(test_data_path: str, docker_image: str) -> list:
     """Build the docker run command with CS_MOUNT_PATH set."""
-    cmd = [
+    return [
         'docker', 'run', '-i', '--rm',
         '-e', 'CS_MOUNT_PATH=/mount',
         '-e', 'CS_ACCESS_TOKEN=test-token',
         '-v', f'{test_data_path}:/mount:ro',
+        docker_image
     ]
-    cmd.append(docker_image)
-    return cmd
 
 
-class MCPClient:
-    """MCP client that communicates with a Docker container via stdio."""
+def run_docker_tool_test(docker_image: str, test_data_path: str, config: ToolTestConfig) -> bool:
+    """
+    Run a tool test in Docker mode.
     
-    def __init__(self, command: list):
-        self.command = command
-        self.process = None
-        self.response_queue = queue.Queue()
-        self.reader_thread = None
+    Similar to run_tool_test but uses Docker-specific setup.
+    """
+    print_header(config.header)
+    
+    cmd = build_docker_command(test_data_path, docker_image)
+    client = MCPClient(cmd)
+    
+    try:
+        if not client.start():
+            print_test("Docker container started", False)
+            return False
+        print_test("Docker container started", True)
         
-    def start(self):
-        """Start the Docker container."""
-        self.process = subprocess.Popen(
-            self.command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            bufsize=1
+        client.initialize()
+        
+        tool_response = client.call_tool(config.tool_name, config.arguments)
+        result_text = extract_result_text(tool_response)
+        
+        # Check for forbidden patterns - in Docker mode we check for "not defined" specifically
+        has_error = any(
+            pattern.lower() in result_text.lower() and "not defined" in result_text.lower()
+            for pattern in config.forbidden_patterns
         )
-        self.reader_thread = threading.Thread(target=self._read_responses, daemon=True)
-        self.reader_thread.start()
-        time.sleep(2)  # Docker containers take longer to start
-        return self.process.poll() is None
-    
-    def _read_responses(self):
-        """Read responses from the container in a background thread."""
-        try:
-            while self.process and self.process.poll() is None:
-                line = self.process.stdout.readline()
-                if line:
-                    self.response_queue.put(line.strip())
-        except Exception as e:
-            self.response_queue.put(f"ERROR: {e}")
-    
-    def send_request(self, method: str, params: dict = None) -> dict:
-        """Send a JSON-RPC request and wait for response."""
-        request = {
-            "jsonrpc": "2.0",
-            "id": next_msg_id(),
-            "method": method,
-            "params": params or {}
-        }
-        request_str = json.dumps(request)
-        self.process.stdin.write(request_str + '\n')
-        self.process.stdin.flush()
         
-        try:
-            response = self.response_queue.get(timeout=30)
-            return json.loads(response)
-        except queue.Empty:
-            return {"error": "Timeout waiting for response"}
-        except json.JSONDecodeError as e:
-            return {"error": f"Invalid JSON: {e}"}
-    
-    def send_notification(self, method: str, params: dict = None):
-        """Send a JSON-RPC notification (no response expected)."""
-        notification = {
-            "jsonrpc": "2.0",
-            "method": method,
-            "params": params or {}
-        }
-        self.process.stdin.write(json.dumps(notification) + '\n')
-        self.process.stdin.flush()
-    
-    def initialize(self) -> dict:
-        """Initialize the MCP session."""
-        response = self.send_request("initialize", {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "path-resolution-docker-test", "version": "1.0"}
-        })
-        self.send_notification("notifications/initialized")
-        time.sleep(0.5)
-        return response
-    
-    def call_tool(self, name: str, arguments: dict) -> dict:
-        """Call an MCP tool."""
-        return self.send_request("tools/call", {
-            "name": name,
-            "arguments": arguments
-        })
-    
-    def stop(self):
-        """Stop the Docker container."""
-        if self.process:
-            try:
-                self.process.terminate()
-                self.process.wait(timeout=5)
-            except Exception:
-                self.process.kill()
-    
-    def get_stderr(self) -> str:
-        """Get any stderr output from the container."""
-        if self.process and self.process.stderr:
-            try:
-                return self.process.stderr.read()
-            except Exception:
-                return ""
-        return ""
+        details = f"Response: {result_text[:150]}..."
+        print_test(config.test_description, not has_error, details)
+        return not has_error
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
 
 
-def test_environment_setup(docker_image: str, test_data_path: str):
+def test_environment_setup(docker_image: str, test_data_path: str) -> bool:
     """Verify the test environment is correctly configured."""
     print_header("Test Environment Setup")
     
     checks = []
     
-    # Check Docker image exists
     result = subprocess.run(['docker', 'image', 'inspect', docker_image], capture_output=True)
     image_ok = result.returncode == 0
     checks.append(image_ok)
     print_test("Docker image exists", image_ok, f"Image: {docker_image}")
     
-    # Check test data path exists
     path_ok = os.path.exists(test_data_path)
     checks.append(path_ok)
     print_test("Test data path exists", path_ok, f"Path: {test_data_path}")
@@ -223,7 +121,7 @@ def test_environment_setup(docker_image: str, test_data_path: str):
     return all(checks)
 
 
-def test_docker_run_starts(docker_image: str, test_data_path: str):
+def test_docker_run_starts(docker_image: str, test_data_path: str) -> bool:
     """Verify docker run starts the MCP server with CS_MOUNT_PATH."""
     print_header("Test Docker Run Startup (with CS_MOUNT_PATH)")
     
@@ -240,6 +138,9 @@ def test_docker_run_starts(docker_image: str, test_data_path: str):
                 print(f"  stderr: {stderr[:200]}")
             return False
         
+        # Docker containers need extra time to initialize
+        time.sleep(1)
+        
         response = client.initialize()
         print_test("MCP server responds to initialize", "result" in response)
         return True
@@ -250,114 +151,33 @@ def test_docker_run_starts(docker_image: str, test_data_path: str):
         client.stop()
 
 
-def test_code_ownership_with_mount_path(docker_image: str, test_data_path: str):
-    """Test that code_ownership_for_path works with CS_MOUNT_PATH set."""
-    print_header("Test code_ownership_for_path (Docker Mode)")
-    
-    cmd = build_docker_command(test_data_path, docker_image)
-    client = MCPClient(cmd)
-    
-    # The file path as seen from the host (which gets translated via CS_MOUNT_PATH)
+def build_docker_tool_test_configs(test_data_path: str) -> list[tuple[str, ToolTestConfig]]:
+    """Build all Docker tool test configurations."""
     host_file_path = os.path.join(test_data_path, "TestFile.java")
     
-    try:
-        if not client.start():
-            print_test("Docker container started", False)
-            return False
-        print_test("Docker container started", True)
-        
-        client.initialize()
-        
-        tool_response = client.call_tool("code_ownership_for_path", {
-            "project_id": 1,
-            "path": host_file_path
-        })
-        result_text = extract_result_text(tool_response)
-        
-        # Should not have CS_MOUNT_PATH error (it's set in Docker mode)
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text and "not defined" in result_text
-        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
-                   f"Response: {result_text[:150]}...")
-        
-        return not has_mount_path_error
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
-
-
-def test_technical_debt_hotspots_with_mount_path(docker_image: str, test_data_path: str):
-    """Test that list_technical_debt_hotspots_for_project_file works with CS_MOUNT_PATH."""
-    print_header("Test list_technical_debt_hotspots_for_project_file (Docker Mode)")
-    
-    cmd = build_docker_command(test_data_path, docker_image)
-    client = MCPClient(cmd)
-    
-    host_file_path = os.path.join(test_data_path, "TestFile.java")
-    
-    try:
-        if not client.start():
-            print_test("Docker container started", False)
-            return False
-        print_test("Docker container started", True)
-        
-        client.initialize()
-        
-        tool_response = client.call_tool("list_technical_debt_hotspots_for_project_file", {
-            "project_id": 1,
-            "file_path": host_file_path
-        })
-        result_text = extract_result_text(tool_response)
-        
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text and "not defined" in result_text
-        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
-                   f"Response: {result_text[:150]}...")
-        
-        return not has_mount_path_error
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
-
-
-def test_technical_debt_goals_with_mount_path(docker_image: str, test_data_path: str):
-    """Test that list_technical_debt_goals_for_project_file works with CS_MOUNT_PATH."""
-    print_header("Test list_technical_debt_goals_for_project_file (Docker Mode)")
-    
-    cmd = build_docker_command(test_data_path, docker_image)
-    client = MCPClient(cmd)
-    
-    host_file_path = os.path.join(test_data_path, "TestFile.java")
-    
-    try:
-        if not client.start():
-            print_test("Docker container started", False)
-            return False
-        print_test("Docker container started", True)
-        
-        client.initialize()
-        
-        tool_response = client.call_tool("list_technical_debt_goals_for_project_file", {
-            "project_id": 1,
-            "file_path": host_file_path
-        })
-        result_text = extract_result_text(tool_response)
-        
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text and "not defined" in result_text
-        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
-                   f"Response: {result_text[:150]}...")
-        
-        return not has_mount_path_error
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
+    return [
+        ("code_ownership_for_path (Docker mode)", ToolTestConfig(
+            tool_name="code_ownership_for_path",
+            arguments={"project_id": 1, "path": host_file_path},
+            header="Test code_ownership_for_path (Docker Mode)",
+            forbidden_patterns=[MOUNT_PATH_NOT_DEFINED],
+            test_description="No CS_MOUNT_PATH error",
+        )),
+        ("list_technical_debt_hotspots_for_project_file (Docker mode)", ToolTestConfig(
+            tool_name="list_technical_debt_hotspots_for_project_file",
+            arguments={"project_id": 1, "file_path": host_file_path},
+            header="Test list_technical_debt_hotspots_for_project_file (Docker Mode)",
+            forbidden_patterns=[MOUNT_PATH_NOT_DEFINED],
+            test_description="No CS_MOUNT_PATH error",
+        )),
+        ("list_technical_debt_goals_for_project_file (Docker mode)", ToolTestConfig(
+            tool_name="list_technical_debt_goals_for_project_file",
+            arguments={"project_id": 1, "file_path": host_file_path},
+            header="Test list_technical_debt_goals_for_project_file (Docker Mode)",
+            forbidden_patterns=[MOUNT_PATH_NOT_DEFINED],
+            test_description="No CS_MOUNT_PATH error",
+        )),
+    ]
 
 
 def main():
@@ -370,7 +190,6 @@ def main():
     print("  Testing: docker run with CS_MOUNT_PATH set")
     print("="*60)
     
-    # Create test data if not provided
     if not test_data_path:
         print("\n  Creating temporary test data directory...")
         test_data_path = create_test_data()
@@ -380,36 +199,22 @@ def main():
     print(f"  Test data path: {test_data_path}")
     
     try:
+        # Run setup tests
         results = [
             ("Environment Setup", test_environment_setup(docker_image, test_data_path)),
             ("Docker Run Startup", test_docker_run_starts(docker_image, test_data_path)),
-            ("code_ownership_for_path (Docker mode)", 
-             test_code_ownership_with_mount_path(docker_image, test_data_path)),
-            ("list_technical_debt_hotspots_for_project_file (Docker mode)", 
-             test_technical_debt_hotspots_with_mount_path(docker_image, test_data_path)),
-            ("list_technical_debt_goals_for_project_file (Docker mode)", 
-             test_technical_debt_goals_with_mount_path(docker_image, test_data_path)),
         ]
         
-        print_header("Test Summary")
+        # Run tool tests from configuration
+        for name, config in build_docker_tool_test_configs(test_data_path):
+            passed = run_docker_tool_test(docker_image, test_data_path, config)
+            results.append((name, passed))
         
-        passed = sum(1 for _, p in results if p)
-        total = len(results)
-        
-        for name, result in results:
-            print(f"  {'\u2713 PASS' if result else '\u2717 FAIL'}: {name}")
-        
-        print(f"\n  Total: {passed}/{total} passed")
-        
-        if passed == total:
-            print("\n  All tests passed! \u2713")
-            return 0
-        print(f"\n  {total - passed} test(s) failed! \u2717")
-        return 1
+        return print_test_summary(results)
     
     finally:
         if cleanup_needed:
-            cleanup_test_data(test_data_path)
+            cleanup_test_dir(test_data_path)
 
 
 if __name__ == '__main__':

--- a/tests/path-resolution-integration/test_docker_run.py
+++ b/tests/path-resolution-integration/test_docker_run.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+Docker run path resolution integration test.
+
+This test runs on the HOST and tests the actual `docker run` command
+that users would use. It verifies that the MCP tools that require file 
+path resolution work correctly in Docker mode (with CS_MOUNT_PATH set).
+
+The tools tested are:
+- code_ownership_for_path
+- list_technical_debt_hotspots_for_project_file
+- list_technical_debt_goals_for_project_file
+
+Environment variables (should be set before running):
+- DOCKER_IMAGE: Docker image name to test (default: codescene-mcp)
+- TEST_DATA_PATH: Path to test data files (will create temp if not set)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import queue
+import time
+import shutil
+
+# MCP Protocol message IDs
+_msg_id = 0
+
+
+def next_msg_id():
+    global _msg_id
+    _msg_id += 1
+    return _msg_id
+
+
+def print_header(msg: str):
+    print(f"\n{'='*60}")
+    print(f"  {msg}")
+    print(f"{'='*60}\n")
+
+
+def print_test(name: str, passed: bool, details: str = ""):
+    status = "\u2713 PASS" if passed else "\u2717 FAIL"
+    print(f"  {status}: {name}")
+    if details:
+        for line in details.split('\n')[:5]:
+            print(f"         {line}")
+
+
+def extract_result_text(tool_response: dict) -> str:
+    """Extract the actual result text from MCP response format."""
+    if "result" not in tool_response:
+        return ""
+    result = tool_response["result"]
+    if not isinstance(result, dict):
+        return ""
+    content = result.get("content", [])
+    if content and isinstance(content, list):
+        return content[0].get("text", "")
+    structured = result.get("structuredContent", {})
+    return structured.get("result", "")
+
+
+def create_test_data():
+    """Create a temporary directory with test files."""
+    tmpdir = tempfile.mkdtemp(prefix="mcp-docker-path-test-")
+    
+    # Create test file
+    test_file = os.path.join(tmpdir, "TestFile.java")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("""public class TestFile {
+    public void hello() {
+        System.out.println("Hello");
+    }
+}
+""")
+    
+    return tmpdir
+
+
+def cleanup_test_data(tmpdir: str):
+    """Clean up the temporary directory."""
+    try:
+        shutil.rmtree(tmpdir)
+    except Exception:
+        pass
+
+
+def build_docker_command(test_data_path: str, docker_image: str):
+    """Build the docker run command with CS_MOUNT_PATH set."""
+    cmd = [
+        'docker', 'run', '-i', '--rm',
+        '-e', 'CS_MOUNT_PATH=/mount',
+        '-e', 'CS_ACCESS_TOKEN=test-token',
+        '-v', f'{test_data_path}:/mount:ro',
+    ]
+    cmd.append(docker_image)
+    return cmd
+
+
+class MCPClient:
+    """MCP client that communicates with a Docker container via stdio."""
+    
+    def __init__(self, command: list):
+        self.command = command
+        self.process = None
+        self.response_queue = queue.Queue()
+        self.reader_thread = None
+        
+    def start(self):
+        """Start the Docker container."""
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            bufsize=1
+        )
+        self.reader_thread = threading.Thread(target=self._read_responses, daemon=True)
+        self.reader_thread.start()
+        time.sleep(2)  # Docker containers take longer to start
+        return self.process.poll() is None
+    
+    def _read_responses(self):
+        """Read responses from the container in a background thread."""
+        try:
+            while self.process and self.process.poll() is None:
+                line = self.process.stdout.readline()
+                if line:
+                    self.response_queue.put(line.strip())
+        except Exception as e:
+            self.response_queue.put(f"ERROR: {e}")
+    
+    def send_request(self, method: str, params: dict = None) -> dict:
+        """Send a JSON-RPC request and wait for response."""
+        request = {
+            "jsonrpc": "2.0",
+            "id": next_msg_id(),
+            "method": method,
+            "params": params or {}
+        }
+        request_str = json.dumps(request)
+        self.process.stdin.write(request_str + '\n')
+        self.process.stdin.flush()
+        
+        try:
+            response = self.response_queue.get(timeout=30)
+            return json.loads(response)
+        except queue.Empty:
+            return {"error": "Timeout waiting for response"}
+        except json.JSONDecodeError as e:
+            return {"error": f"Invalid JSON: {e}"}
+    
+    def send_notification(self, method: str, params: dict = None):
+        """Send a JSON-RPC notification (no response expected)."""
+        notification = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or {}
+        }
+        self.process.stdin.write(json.dumps(notification) + '\n')
+        self.process.stdin.flush()
+    
+    def initialize(self) -> dict:
+        """Initialize the MCP session."""
+        response = self.send_request("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "path-resolution-docker-test", "version": "1.0"}
+        })
+        self.send_notification("notifications/initialized")
+        time.sleep(0.5)
+        return response
+    
+    def call_tool(self, name: str, arguments: dict) -> dict:
+        """Call an MCP tool."""
+        return self.send_request("tools/call", {
+            "name": name,
+            "arguments": arguments
+        })
+    
+    def stop(self):
+        """Stop the Docker container."""
+        if self.process:
+            try:
+                self.process.terminate()
+                self.process.wait(timeout=5)
+            except Exception:
+                self.process.kill()
+    
+    def get_stderr(self) -> str:
+        """Get any stderr output from the container."""
+        if self.process and self.process.stderr:
+            try:
+                return self.process.stderr.read()
+            except Exception:
+                return ""
+        return ""
+
+
+def test_environment_setup(docker_image: str, test_data_path: str):
+    """Verify the test environment is correctly configured."""
+    print_header("Test Environment Setup")
+    
+    checks = []
+    
+    # Check Docker image exists
+    result = subprocess.run(['docker', 'image', 'inspect', docker_image], capture_output=True)
+    image_ok = result.returncode == 0
+    checks.append(image_ok)
+    print_test("Docker image exists", image_ok, f"Image: {docker_image}")
+    
+    # Check test data path exists
+    path_ok = os.path.exists(test_data_path)
+    checks.append(path_ok)
+    print_test("Test data path exists", path_ok, f"Path: {test_data_path}")
+    
+    return all(checks)
+
+
+def test_docker_run_starts(docker_image: str, test_data_path: str):
+    """Verify docker run starts the MCP server with CS_MOUNT_PATH."""
+    print_header("Test Docker Run Startup (with CS_MOUNT_PATH)")
+    
+    cmd = build_docker_command(test_data_path, docker_image)
+    print(f"  Command: docker run -i ... {docker_image}")
+    
+    client = MCPClient(cmd)
+    try:
+        started = client.start()
+        print_test("Docker container started", started)
+        if not started:
+            stderr = client.get_stderr()
+            if stderr:
+                print(f"  stderr: {stderr[:200]}")
+            return False
+        
+        response = client.initialize()
+        print_test("MCP server responds to initialize", "result" in response)
+        return True
+    except Exception as e:
+        print_test("Docker run starts", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_code_ownership_with_mount_path(docker_image: str, test_data_path: str):
+    """Test that code_ownership_for_path works with CS_MOUNT_PATH set."""
+    print_header("Test code_ownership_for_path (Docker Mode)")
+    
+    cmd = build_docker_command(test_data_path, docker_image)
+    client = MCPClient(cmd)
+    
+    # The file path as seen from the host (which gets translated via CS_MOUNT_PATH)
+    host_file_path = os.path.join(test_data_path, "TestFile.java")
+    
+    try:
+        if not client.start():
+            print_test("Docker container started", False)
+            return False
+        print_test("Docker container started", True)
+        
+        client.initialize()
+        
+        tool_response = client.call_tool("code_ownership_for_path", {
+            "project_id": 1,
+            "path": host_file_path
+        })
+        result_text = extract_result_text(tool_response)
+        
+        # Should not have CS_MOUNT_PATH error (it's set in Docker mode)
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text and "not defined" in result_text
+        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
+                   f"Response: {result_text[:150]}...")
+        
+        return not has_mount_path_error
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_technical_debt_hotspots_with_mount_path(docker_image: str, test_data_path: str):
+    """Test that list_technical_debt_hotspots_for_project_file works with CS_MOUNT_PATH."""
+    print_header("Test list_technical_debt_hotspots_for_project_file (Docker Mode)")
+    
+    cmd = build_docker_command(test_data_path, docker_image)
+    client = MCPClient(cmd)
+    
+    host_file_path = os.path.join(test_data_path, "TestFile.java")
+    
+    try:
+        if not client.start():
+            print_test("Docker container started", False)
+            return False
+        print_test("Docker container started", True)
+        
+        client.initialize()
+        
+        tool_response = client.call_tool("list_technical_debt_hotspots_for_project_file", {
+            "project_id": 1,
+            "file_path": host_file_path
+        })
+        result_text = extract_result_text(tool_response)
+        
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text and "not defined" in result_text
+        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
+                   f"Response: {result_text[:150]}...")
+        
+        return not has_mount_path_error
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_technical_debt_goals_with_mount_path(docker_image: str, test_data_path: str):
+    """Test that list_technical_debt_goals_for_project_file works with CS_MOUNT_PATH."""
+    print_header("Test list_technical_debt_goals_for_project_file (Docker Mode)")
+    
+    cmd = build_docker_command(test_data_path, docker_image)
+    client = MCPClient(cmd)
+    
+    host_file_path = os.path.join(test_data_path, "TestFile.java")
+    
+    try:
+        if not client.start():
+            print_test("Docker container started", False)
+            return False
+        print_test("Docker container started", True)
+        
+        client.initialize()
+        
+        tool_response = client.call_tool("list_technical_debt_goals_for_project_file", {
+            "project_id": 1,
+            "file_path": host_file_path
+        })
+        result_text = extract_result_text(tool_response)
+        
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text and "not defined" in result_text
+        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
+                   f"Response: {result_text[:150]}...")
+        
+        return not has_mount_path_error
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def main():
+    docker_image = os.getenv('DOCKER_IMAGE', 'codescene-mcp')
+    test_data_path = os.getenv('TEST_DATA_PATH')
+    cleanup_needed = False
+    
+    print("\n" + "="*60)
+    print("  Docker Run Path Resolution Integration Tests")
+    print("  Testing: docker run with CS_MOUNT_PATH set")
+    print("="*60)
+    
+    # Create test data if not provided
+    if not test_data_path:
+        print("\n  Creating temporary test data directory...")
+        test_data_path = create_test_data()
+        cleanup_needed = True
+    
+    print(f"  Docker image: {docker_image}")
+    print(f"  Test data path: {test_data_path}")
+    
+    try:
+        results = [
+            ("Environment Setup", test_environment_setup(docker_image, test_data_path)),
+            ("Docker Run Startup", test_docker_run_starts(docker_image, test_data_path)),
+            ("code_ownership_for_path (Docker mode)", 
+             test_code_ownership_with_mount_path(docker_image, test_data_path)),
+            ("list_technical_debt_hotspots_for_project_file (Docker mode)", 
+             test_technical_debt_hotspots_with_mount_path(docker_image, test_data_path)),
+            ("list_technical_debt_goals_for_project_file (Docker mode)", 
+             test_technical_debt_goals_with_mount_path(docker_image, test_data_path)),
+        ]
+        
+        print_header("Test Summary")
+        
+        passed = sum(1 for _, p in results if p)
+        total = len(results)
+        
+        for name, result in results:
+            print(f"  {'\u2713 PASS' if result else '\u2717 FAIL'}: {name}")
+        
+        print(f"\n  Total: {passed}/{total} passed")
+        
+        if passed == total:
+            print("\n  All tests passed! \u2713")
+            return 0
+        print(f"\n  {total - passed} test(s) failed! \u2717")
+        return 1
+    
+    finally:
+        if cleanup_needed:
+            cleanup_test_data(test_data_path)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/path-resolution-integration/test_static_variant.py
+++ b/tests/path-resolution-integration/test_static_variant.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+"""
+Static binary variant path resolution integration test.
+
+This test verifies that the MCP tools that require file path resolution
+work correctly in static executable mode (without CS_MOUNT_PATH set).
+
+The tools tested are:
+- code_ownership_for_path
+- list_technical_debt_hotspots_for_project_file
+- list_technical_debt_goals_for_project_file
+
+These tools previously failed with "CS_MOUNT_PATH not defined" error when
+running in static executable mode. This test ensures they now work correctly
+by using git root detection for path resolution.
+
+Usage: python test_static_variant.py /path/to/cs-mcp
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import queue
+import time
+
+# MCP Protocol message IDs
+_msg_id = 0
+
+
+def next_msg_id():
+    global _msg_id
+    _msg_id += 1
+    return _msg_id
+
+
+def print_header(msg: str):
+    print(f"\n{'='*60}")
+    print(f"  {msg}")
+    print(f"{'='*60}\n")
+
+
+def print_test(name: str, passed: bool, details: str = ""):
+    status = "\u2713 PASS" if passed else "\u2717 FAIL"
+    print(f"  {status}: {name}")
+    if details:
+        for line in details.split('\n')[:5]:
+            print(f"         {line}")
+
+
+def extract_result_text(tool_response: dict) -> str:
+    """Extract the actual result text from MCP response format."""
+    if "result" not in tool_response:
+        return ""
+    result = tool_response["result"]
+    if not isinstance(result, dict):
+        return ""
+    content = result.get("content", [])
+    if content and isinstance(content, list):
+        return content[0].get("text", "")
+    structured = result.get("structuredContent", {})
+    return structured.get("result", "")
+
+
+class MCPClient:
+    """MCP client that communicates with the server via stdio."""
+    
+    def __init__(self, command: list, env: dict = None):
+        self.command = command
+        self.env = env or os.environ.copy()
+        self.process = None
+        self.response_queue = queue.Queue()
+        self.reader_thread = None
+        
+    def start(self):
+        """Start the MCP server process."""
+        self.process = subprocess.Popen(
+            self.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env,
+            text=True,
+            encoding="utf-8",
+            bufsize=1
+        )
+        self.reader_thread = threading.Thread(target=self._read_responses, daemon=True)
+        self.reader_thread.start()
+        time.sleep(1)
+        return self.process.poll() is None
+    
+    def _read_responses(self):
+        """Read responses from the server in a background thread."""
+        try:
+            while self.process and self.process.poll() is None:
+                line = self.process.stdout.readline()
+                if line:
+                    self.response_queue.put(line.strip())
+        except Exception as e:
+            self.response_queue.put(f"ERROR: {e}")
+    
+    def send_request(self, method: str, params: dict = None) -> dict:
+        """Send a JSON-RPC request and wait for response."""
+        request = {
+            "jsonrpc": "2.0",
+            "id": next_msg_id(),
+            "method": method,
+            "params": params or {}
+        }
+        try:
+            self.process.stdin.write(json.dumps(request) + "\n")
+            self.process.stdin.flush()
+        except Exception as e:
+            return {"error": f"Failed to send request: {e}"}
+        try:
+            response_str = self.response_queue.get(timeout=30)
+            return json.loads(response_str)
+        except queue.Empty:
+            return {"error": "Timeout waiting for response"}
+        except json.JSONDecodeError as e:
+            return {"error": f"Invalid JSON response: {e}"}
+    
+    def send_notification(self, method: str, params: dict = None):
+        """Send a JSON-RPC notification (no response expected)."""
+        notification = {"jsonrpc": "2.0", "method": method}
+        if params:
+            notification["params"] = params
+        try:
+            self.process.stdin.write(json.dumps(notification) + "\n")
+            self.process.stdin.flush()
+        except Exception as e:
+            print(f"Failed to send notification: {e}")
+    
+    def call_tool(self, tool_name: str, arguments: dict) -> dict:
+        """Call an MCP tool."""
+        return self.send_request("tools/call", {"name": tool_name, "arguments": arguments})
+    
+    def initialize(self) -> dict:
+        """Initialize the MCP session and send initialized notification."""
+        response = self.send_request("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "path-resolution-test-client", "version": "1.0.0"}
+        })
+        time.sleep(0.2)
+        self.send_notification("notifications/initialized")
+        time.sleep(0.3)
+        return response
+    
+    def stop(self):
+        """Stop the MCP server process."""
+        if self.process:
+            try:
+                self.process.stdin.close()
+                self.process.terminate()
+                self.process.wait(timeout=5)
+            except Exception:
+                self.process.kill()
+    
+    def get_stderr(self) -> str:
+        """Get any stderr output from the server."""
+        if self.process and self.process.stderr:
+            try:
+                return self.process.stderr.read()
+            except Exception:
+                return ""
+        return ""
+
+
+def create_test_git_repo():
+    """Create a temporary git repository with a test file."""
+    tmpdir = tempfile.mkdtemp(prefix="mcp-path-test-")
+    
+    # Initialize git repo
+    subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmpdir, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True)
+    
+    # Create test file structure
+    src_dir = os.path.join(tmpdir, "src")
+    os.makedirs(src_dir)
+    
+    test_file = os.path.join(src_dir, "TestFile.java")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("""public class TestFile {
+    public void hello() {
+        System.out.println("Hello");
+    }
+}
+""")
+    
+    # Commit the file
+    subprocess.run(["git", "add", "."], cwd=tmpdir, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=tmpdir, capture_output=True)
+    
+    return tmpdir, test_file
+
+
+def cleanup_test_repo(tmpdir: str):
+    """Clean up the temporary git repository."""
+    import shutil
+    try:
+        shutil.rmtree(tmpdir)
+    except Exception:
+        pass
+
+
+def test_environment_setup(binary_path: str):
+    """Verify the test environment is correctly configured."""
+    print_header("Test Environment Setup")
+    
+    checks = []
+    
+    # Check binary
+    binary_ok = os.path.exists(binary_path) and os.access(binary_path, os.X_OK)
+    checks.append(binary_ok)
+    print_test("cs-mcp binary exists and is executable", binary_ok, f"Path: {binary_path}")
+    
+    # Check that CS_MOUNT_PATH is NOT set (we're testing static mode)
+    mount_path = os.getenv('CS_MOUNT_PATH')
+    no_mount_ok = mount_path is None
+    checks.append(no_mount_ok)
+    print_test("CS_MOUNT_PATH is NOT set (static mode)", no_mount_ok, 
+               f"Value: {mount_path}" if mount_path else "Not set (correct)")
+    
+    return all(checks)
+
+
+def test_mcp_server_starts(binary_path: str):
+    """Verify the MCP server starts successfully in static mode."""
+    print_header("Test MCP Server Startup (Static Mode)")
+    
+    # Ensure CS_MOUNT_PATH is not set
+    env = os.environ.copy()
+    env.pop('CS_MOUNT_PATH', None)
+    
+    client = MCPClient([binary_path], env=env)
+    
+    try:
+        started = client.start()
+        print_test("MCP server process started", started)
+        if not started:
+            return False
+        
+        response = client.initialize()
+        print_test("MCP server responds to initialize", "result" in response)
+        return True
+    except Exception as e:
+        print_test("MCP server starts", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_code_ownership_no_mount_path_error(binary_path: str, test_file: str):
+    """Test that code_ownership_for_path doesn't fail with CS_MOUNT_PATH error."""
+    print_header("Test code_ownership_for_path (Static Mode)")
+    
+    env = os.environ.copy()
+    env.pop('CS_MOUNT_PATH', None)
+    
+    client = MCPClient([binary_path], env=env)
+    
+    try:
+        if not client.start():
+            print_test("MCP server started", False)
+            return False
+        print_test("MCP server started", True)
+        
+        client.initialize()
+        
+        # Call code_ownership_for_path - it should NOT fail with "CS_MOUNT_PATH not defined"
+        tool_response = client.call_tool("code_ownership_for_path", {
+            "project_id": 1,
+            "path": test_file
+        })
+        result_text = extract_result_text(tool_response)
+        
+        # Check that we don't get the CS_MOUNT_PATH error
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text
+        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
+                   f"Response: {result_text[:150]}...")
+        
+        return not has_mount_path_error
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_technical_debt_hotspots_no_mount_path_error(binary_path: str, test_file: str):
+    """Test that list_technical_debt_hotspots_for_project_file doesn't fail with CS_MOUNT_PATH error."""
+    print_header("Test list_technical_debt_hotspots_for_project_file (Static Mode)")
+    
+    env = os.environ.copy()
+    env.pop('CS_MOUNT_PATH', None)
+    
+    client = MCPClient([binary_path], env=env)
+    
+    try:
+        if not client.start():
+            print_test("MCP server started", False)
+            return False
+        print_test("MCP server started", True)
+        
+        client.initialize()
+        
+        tool_response = client.call_tool("list_technical_debt_hotspots_for_project_file", {
+            "project_id": 1,
+            "file_path": test_file
+        })
+        result_text = extract_result_text(tool_response)
+        
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text
+        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
+                   f"Response: {result_text[:150]}...")
+        
+        return not has_mount_path_error
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_technical_debt_goals_no_mount_path_error(binary_path: str, test_file: str):
+    """Test that list_technical_debt_goals_for_project_file doesn't fail with CS_MOUNT_PATH error."""
+    print_header("Test list_technical_debt_goals_for_project_file (Static Mode)")
+    
+    env = os.environ.copy()
+    env.pop('CS_MOUNT_PATH', None)
+    
+    client = MCPClient([binary_path], env=env)
+    
+    try:
+        if not client.start():
+            print_test("MCP server started", False)
+            return False
+        print_test("MCP server started", True)
+        
+        client.initialize()
+        
+        tool_response = client.call_tool("list_technical_debt_goals_for_project_file", {
+            "project_id": 1,
+            "file_path": test_file
+        })
+        result_text = extract_result_text(tool_response)
+        
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text
+        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
+                   f"Response: {result_text[:150]}...")
+        
+        return not has_mount_path_error
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def create_test_file_no_git():
+    """Create a temporary file NOT in a git repository."""
+    tmpdir = tempfile.mkdtemp(prefix="mcp-no-git-test-")
+    
+    # Create test file structure (NO git init!)
+    src_dir = os.path.join(tmpdir, "src")
+    os.makedirs(src_dir)
+    
+    test_file = os.path.join(src_dir, "TestFile.java")
+    with open(test_file, "w", encoding="utf-8") as f:
+        f.write("""public class TestFile {
+    public void hello() {
+        System.out.println("Hello");
+    }
+}
+""")
+    
+    return tmpdir, test_file
+
+
+def test_code_ownership_no_git_repo(binary_path: str, test_file: str):
+    """Test that code_ownership_for_path works outside a git repository."""
+    print_header("Test code_ownership_for_path (No Git Repo)")
+    
+    env = os.environ.copy()
+    env.pop('CS_MOUNT_PATH', None)
+    
+    client = MCPClient([binary_path], env=env)
+    
+    try:
+        if not client.start():
+            print_test("MCP server started", False)
+            return False
+        print_test("MCP server started", True)
+        
+        client.initialize()
+        
+        tool_response = client.call_tool("code_ownership_for_path", {
+            "project_id": 1,
+            "path": test_file
+        })
+        result_text = extract_result_text(tool_response)
+        
+        # Should NOT have CS_MOUNT_PATH error
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text
+        # Should NOT have "not in a git repository" error
+        has_git_error = "not in a git repository" in result_text.lower()
+        
+        passed = not has_mount_path_error and not has_git_error
+        print_test("No CS_MOUNT_PATH or git repo error", passed, 
+                   f"Response: {result_text[:150]}...")
+        
+        return passed
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_code_ownership_relative_path(binary_path: str):
+    """Test that code_ownership_for_path works with a relative path."""
+    print_header("Test code_ownership_for_path (Relative Path)")
+    
+    env = os.environ.copy()
+    env.pop('CS_MOUNT_PATH', None)
+    
+    client = MCPClient([binary_path], env=env)
+    
+    try:
+        if not client.start():
+            print_test("MCP server started", False)
+            return False
+        print_test("MCP server started", True)
+        
+        client.initialize()
+        
+        # Use a relative path - should work without any git/mount requirements
+        tool_response = client.call_tool("code_ownership_for_path", {
+            "project_id": 1,
+            "path": "src/components/Button.tsx"
+        })
+        result_text = extract_result_text(tool_response)
+        
+        # Should NOT have CS_MOUNT_PATH error
+        has_mount_path_error = "CS_MOUNT_PATH" in result_text
+        # Should NOT have "not in a git repository" error
+        has_git_error = "not in a git repository" in result_text.lower()
+        
+        passed = not has_mount_path_error and not has_git_error
+        print_test("No CS_MOUNT_PATH or git repo error with relative path", passed, 
+                   f"Response: {result_text[:150]}...")
+        
+        return passed
+        
+    except Exception as e:
+        print_test("Tool invocation", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python test_static_variant.py /path/to/cs-mcp")
+        return 1
+    
+    binary_path = sys.argv[1]
+    
+    print("\n" + "="*60)
+    print("  Static Binary Path Resolution Integration Tests")
+    print("  Testing: cs-mcp binary without CS_MOUNT_PATH")
+    print("="*60)
+    
+    # Create test git repo
+    print("\n  Creating temporary git repository for testing...")
+    tmpdir, test_file = create_test_git_repo()
+    print(f"  Test repo: {tmpdir}")
+    print(f"  Test file: {test_file}")
+    
+    # Create test file outside git repo
+    print("\n  Creating temporary file outside git repo...")
+    no_git_tmpdir, no_git_test_file = create_test_file_no_git()
+    print(f"  Test dir: {no_git_tmpdir}")
+    print(f"  Test file: {no_git_test_file}")
+    
+    try:
+        results = [
+            ("Environment Setup", test_environment_setup(binary_path)),
+            ("MCP Server Startup", test_mcp_server_starts(binary_path)),
+            # Tests with file inside git repo
+            ("code_ownership_for_path (in git repo)", 
+             test_code_ownership_no_mount_path_error(binary_path, test_file)),
+            ("list_technical_debt_hotspots_for_project_file (in git repo)", 
+             test_technical_debt_hotspots_no_mount_path_error(binary_path, test_file)),
+            ("list_technical_debt_goals_for_project_file (in git repo)", 
+             test_technical_debt_goals_no_mount_path_error(binary_path, test_file)),
+            # Tests outside git repo - should also work now
+            ("code_ownership_for_path (no git repo)", 
+             test_code_ownership_no_git_repo(binary_path, no_git_test_file)),
+            ("code_ownership_for_path (relative path)", 
+             test_code_ownership_relative_path(binary_path)),
+        ]
+        
+        print_header("Test Summary")
+        
+        passed = sum(1 for _, p in results if p)
+        total = len(results)
+        
+        for name, result in results:
+            print(f"  {'\u2713 PASS' if result else '\u2717 FAIL'}: {name}")
+        
+        print(f"\n  Total: {passed}/{total} passed")
+        
+        if passed == total:
+            print("\n  All tests passed! \u2713")
+            return 0
+        print(f"\n  {total - passed} test(s) failed! \u2717")
+        return 1
+    
+    finally:
+        cleanup_test_repo(tmpdir)
+        cleanup_test_repo(no_git_tmpdir)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/path-resolution-integration/test_static_variant.py
+++ b/tests/path-resolution-integration/test_static_variant.py
@@ -17,208 +17,38 @@ by using git root detection for path resolution.
 Usage: python test_static_variant.py /path/to/cs-mcp
 """
 
-import json
 import os
-import subprocess
 import sys
-import tempfile
-import threading
-import queue
-import time
 
-# MCP Protocol message IDs
-_msg_id = 0
-
-
-def next_msg_id():
-    global _msg_id
-    _msg_id += 1
-    return _msg_id
-
-
-def print_header(msg: str):
-    print(f"\n{'='*60}")
-    print(f"  {msg}")
-    print(f"{'='*60}\n")
+from mcp_test_utils import (
+    MCPClient,
+    ToolTestConfig,
+    cleanup_test_dir,
+    create_static_mode_env,
+    create_test_file_no_git,
+    create_test_git_repo,
+    print_header,
+    print_test,
+    print_test_summary,
+    run_tool_test,
+)
 
 
-def print_test(name: str, passed: bool, details: str = ""):
-    status = "\u2713 PASS" if passed else "\u2717 FAIL"
-    print(f"  {status}: {name}")
-    if details:
-        for line in details.split('\n')[:5]:
-            print(f"         {line}")
+# Common forbidden patterns for path resolution tests
+MOUNT_PATH_ERROR = "CS_MOUNT_PATH"
+GIT_REPO_ERROR = "not in a git repository"
 
 
-def extract_result_text(tool_response: dict) -> str:
-    """Extract the actual result text from MCP response format."""
-    if "result" not in tool_response:
-        return ""
-    result = tool_response["result"]
-    if not isinstance(result, dict):
-        return ""
-    content = result.get("content", [])
-    if content and isinstance(content, list):
-        return content[0].get("text", "")
-    structured = result.get("structuredContent", {})
-    return structured.get("result", "")
-
-
-class MCPClient:
-    """MCP client that communicates with the server via stdio."""
-    
-    def __init__(self, command: list, env: dict = None):
-        self.command = command
-        self.env = env or os.environ.copy()
-        self.process = None
-        self.response_queue = queue.Queue()
-        self.reader_thread = None
-        
-    def start(self):
-        """Start the MCP server process."""
-        self.process = subprocess.Popen(
-            self.command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=self.env,
-            text=True,
-            encoding="utf-8",
-            bufsize=1
-        )
-        self.reader_thread = threading.Thread(target=self._read_responses, daemon=True)
-        self.reader_thread.start()
-        time.sleep(1)
-        return self.process.poll() is None
-    
-    def _read_responses(self):
-        """Read responses from the server in a background thread."""
-        try:
-            while self.process and self.process.poll() is None:
-                line = self.process.stdout.readline()
-                if line:
-                    self.response_queue.put(line.strip())
-        except Exception as e:
-            self.response_queue.put(f"ERROR: {e}")
-    
-    def send_request(self, method: str, params: dict = None) -> dict:
-        """Send a JSON-RPC request and wait for response."""
-        request = {
-            "jsonrpc": "2.0",
-            "id": next_msg_id(),
-            "method": method,
-            "params": params or {}
-        }
-        try:
-            self.process.stdin.write(json.dumps(request) + "\n")
-            self.process.stdin.flush()
-        except Exception as e:
-            return {"error": f"Failed to send request: {e}"}
-        try:
-            response_str = self.response_queue.get(timeout=30)
-            return json.loads(response_str)
-        except queue.Empty:
-            return {"error": "Timeout waiting for response"}
-        except json.JSONDecodeError as e:
-            return {"error": f"Invalid JSON response: {e}"}
-    
-    def send_notification(self, method: str, params: dict = None):
-        """Send a JSON-RPC notification (no response expected)."""
-        notification = {"jsonrpc": "2.0", "method": method}
-        if params:
-            notification["params"] = params
-        try:
-            self.process.stdin.write(json.dumps(notification) + "\n")
-            self.process.stdin.flush()
-        except Exception as e:
-            print(f"Failed to send notification: {e}")
-    
-    def call_tool(self, tool_name: str, arguments: dict) -> dict:
-        """Call an MCP tool."""
-        return self.send_request("tools/call", {"name": tool_name, "arguments": arguments})
-    
-    def initialize(self) -> dict:
-        """Initialize the MCP session and send initialized notification."""
-        response = self.send_request("initialize", {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {},
-            "clientInfo": {"name": "path-resolution-test-client", "version": "1.0.0"}
-        })
-        time.sleep(0.2)
-        self.send_notification("notifications/initialized")
-        time.sleep(0.3)
-        return response
-    
-    def stop(self):
-        """Stop the MCP server process."""
-        if self.process:
-            try:
-                self.process.stdin.close()
-                self.process.terminate()
-                self.process.wait(timeout=5)
-            except Exception:
-                self.process.kill()
-    
-    def get_stderr(self) -> str:
-        """Get any stderr output from the server."""
-        if self.process and self.process.stderr:
-            try:
-                return self.process.stderr.read()
-            except Exception:
-                return ""
-        return ""
-
-
-def create_test_git_repo():
-    """Create a temporary git repository with a test file."""
-    tmpdir = tempfile.mkdtemp(prefix="mcp-path-test-")
-    
-    # Initialize git repo
-    subprocess.run(["git", "init"], cwd=tmpdir, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=tmpdir, capture_output=True)
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmpdir, capture_output=True)
-    
-    # Create test file structure
-    src_dir = os.path.join(tmpdir, "src")
-    os.makedirs(src_dir)
-    
-    test_file = os.path.join(src_dir, "TestFile.java")
-    with open(test_file, "w", encoding="utf-8") as f:
-        f.write("""public class TestFile {
-    public void hello() {
-        System.out.println("Hello");
-    }
-}
-""")
-    
-    # Commit the file
-    subprocess.run(["git", "add", "."], cwd=tmpdir, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=tmpdir, capture_output=True)
-    
-    return tmpdir, test_file
-
-
-def cleanup_test_repo(tmpdir: str):
-    """Clean up the temporary git repository."""
-    import shutil
-    try:
-        shutil.rmtree(tmpdir)
-    except Exception:
-        pass
-
-
-def test_environment_setup(binary_path: str):
+def test_environment_setup(binary_path: str) -> bool:
     """Verify the test environment is correctly configured."""
     print_header("Test Environment Setup")
     
     checks = []
     
-    # Check binary
     binary_ok = os.path.exists(binary_path) and os.access(binary_path, os.X_OK)
     checks.append(binary_ok)
     print_test("cs-mcp binary exists and is executable", binary_ok, f"Path: {binary_path}")
     
-    # Check that CS_MOUNT_PATH is NOT set (we're testing static mode)
     mount_path = os.getenv('CS_MOUNT_PATH')
     no_mount_ok = mount_path is None
     checks.append(no_mount_ok)
@@ -228,14 +58,11 @@ def test_environment_setup(binary_path: str):
     return all(checks)
 
 
-def test_mcp_server_starts(binary_path: str):
+def test_mcp_server_starts(binary_path: str) -> bool:
     """Verify the MCP server starts successfully in static mode."""
     print_header("Test MCP Server Startup (Static Mode)")
     
-    # Ensure CS_MOUNT_PATH is not set
-    env = os.environ.copy()
-    env.pop('CS_MOUNT_PATH', None)
-    
+    env = create_static_mode_env()
     client = MCPClient([binary_path], env=env)
     
     try:
@@ -254,217 +81,48 @@ def test_mcp_server_starts(binary_path: str):
         client.stop()
 
 
-def test_code_ownership_no_mount_path_error(binary_path: str, test_file: str):
-    """Test that code_ownership_for_path doesn't fail with CS_MOUNT_PATH error."""
-    print_header("Test code_ownership_for_path (Static Mode)")
-    
-    env = os.environ.copy()
-    env.pop('CS_MOUNT_PATH', None)
-    
-    client = MCPClient([binary_path], env=env)
-    
-    try:
-        if not client.start():
-            print_test("MCP server started", False)
-            return False
-        print_test("MCP server started", True)
-        
-        client.initialize()
-        
-        # Call code_ownership_for_path - it should NOT fail with "CS_MOUNT_PATH not defined"
-        tool_response = client.call_tool("code_ownership_for_path", {
-            "project_id": 1,
-            "path": test_file
-        })
-        result_text = extract_result_text(tool_response)
-        
-        # Check that we don't get the CS_MOUNT_PATH error
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text
-        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
-                   f"Response: {result_text[:150]}...")
-        
-        return not has_mount_path_error
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
-
-
-def test_technical_debt_hotspots_no_mount_path_error(binary_path: str, test_file: str):
-    """Test that list_technical_debt_hotspots_for_project_file doesn't fail with CS_MOUNT_PATH error."""
-    print_header("Test list_technical_debt_hotspots_for_project_file (Static Mode)")
-    
-    env = os.environ.copy()
-    env.pop('CS_MOUNT_PATH', None)
-    
-    client = MCPClient([binary_path], env=env)
-    
-    try:
-        if not client.start():
-            print_test("MCP server started", False)
-            return False
-        print_test("MCP server started", True)
-        
-        client.initialize()
-        
-        tool_response = client.call_tool("list_technical_debt_hotspots_for_project_file", {
-            "project_id": 1,
-            "file_path": test_file
-        })
-        result_text = extract_result_text(tool_response)
-        
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text
-        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
-                   f"Response: {result_text[:150]}...")
-        
-        return not has_mount_path_error
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
-
-
-def test_technical_debt_goals_no_mount_path_error(binary_path: str, test_file: str):
-    """Test that list_technical_debt_goals_for_project_file doesn't fail with CS_MOUNT_PATH error."""
-    print_header("Test list_technical_debt_goals_for_project_file (Static Mode)")
-    
-    env = os.environ.copy()
-    env.pop('CS_MOUNT_PATH', None)
-    
-    client = MCPClient([binary_path], env=env)
-    
-    try:
-        if not client.start():
-            print_test("MCP server started", False)
-            return False
-        print_test("MCP server started", True)
-        
-        client.initialize()
-        
-        tool_response = client.call_tool("list_technical_debt_goals_for_project_file", {
-            "project_id": 1,
-            "file_path": test_file
-        })
-        result_text = extract_result_text(tool_response)
-        
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text
-        print_test("No CS_MOUNT_PATH error", not has_mount_path_error, 
-                   f"Response: {result_text[:150]}...")
-        
-        return not has_mount_path_error
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
-
-
-def create_test_file_no_git():
-    """Create a temporary file NOT in a git repository."""
-    tmpdir = tempfile.mkdtemp(prefix="mcp-no-git-test-")
-    
-    # Create test file structure (NO git init!)
-    src_dir = os.path.join(tmpdir, "src")
-    os.makedirs(src_dir)
-    
-    test_file = os.path.join(src_dir, "TestFile.java")
-    with open(test_file, "w", encoding="utf-8") as f:
-        f.write("""public class TestFile {
-    public void hello() {
-        System.out.println("Hello");
-    }
-}
-""")
-    
-    return tmpdir, test_file
-
-
-def test_code_ownership_no_git_repo(binary_path: str, test_file: str):
-    """Test that code_ownership_for_path works outside a git repository."""
-    print_header("Test code_ownership_for_path (No Git Repo)")
-    
-    env = os.environ.copy()
-    env.pop('CS_MOUNT_PATH', None)
-    
-    client = MCPClient([binary_path], env=env)
-    
-    try:
-        if not client.start():
-            print_test("MCP server started", False)
-            return False
-        print_test("MCP server started", True)
-        
-        client.initialize()
-        
-        tool_response = client.call_tool("code_ownership_for_path", {
-            "project_id": 1,
-            "path": test_file
-        })
-        result_text = extract_result_text(tool_response)
-        
-        # Should NOT have CS_MOUNT_PATH error
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text
-        # Should NOT have "not in a git repository" error
-        has_git_error = "not in a git repository" in result_text.lower()
-        
-        passed = not has_mount_path_error and not has_git_error
-        print_test("No CS_MOUNT_PATH or git repo error", passed, 
-                   f"Response: {result_text[:150]}...")
-        
-        return passed
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
-
-
-def test_code_ownership_relative_path(binary_path: str):
-    """Test that code_ownership_for_path works with a relative path."""
-    print_header("Test code_ownership_for_path (Relative Path)")
-    
-    env = os.environ.copy()
-    env.pop('CS_MOUNT_PATH', None)
-    
-    client = MCPClient([binary_path], env=env)
-    
-    try:
-        if not client.start():
-            print_test("MCP server started", False)
-            return False
-        print_test("MCP server started", True)
-        
-        client.initialize()
-        
-        # Use a relative path - should work without any git/mount requirements
-        tool_response = client.call_tool("code_ownership_for_path", {
-            "project_id": 1,
-            "path": "src/components/Button.tsx"
-        })
-        result_text = extract_result_text(tool_response)
-        
-        # Should NOT have CS_MOUNT_PATH error
-        has_mount_path_error = "CS_MOUNT_PATH" in result_text
-        # Should NOT have "not in a git repository" error
-        has_git_error = "not in a git repository" in result_text.lower()
-        
-        passed = not has_mount_path_error and not has_git_error
-        print_test("No CS_MOUNT_PATH or git repo error with relative path", passed, 
-                   f"Response: {result_text[:150]}...")
-        
-        return passed
-        
-    except Exception as e:
-        print_test("Tool invocation", False, str(e))
-        return False
-    finally:
-        client.stop()
+def build_tool_test_configs(git_test_file: str, no_git_test_file: str) -> list[tuple[str, ToolTestConfig]]:
+    """Build all tool test configurations."""
+    return [
+        # Tests with files inside git repo
+        ("code_ownership_for_path (in git repo)", ToolTestConfig(
+            tool_name="code_ownership_for_path",
+            arguments={"project_id": 1, "path": git_test_file},
+            header="Test code_ownership_for_path (In Git Repo)",
+            forbidden_patterns=[MOUNT_PATH_ERROR],
+            test_description="No CS_MOUNT_PATH error",
+        )),
+        ("list_technical_debt_hotspots_for_project_file (in git repo)", ToolTestConfig(
+            tool_name="list_technical_debt_hotspots_for_project_file",
+            arguments={"project_id": 1, "file_path": git_test_file},
+            header="Test list_technical_debt_hotspots_for_project_file (In Git Repo)",
+            forbidden_patterns=[MOUNT_PATH_ERROR],
+            test_description="No CS_MOUNT_PATH error",
+        )),
+        ("list_technical_debt_goals_for_project_file (in git repo)", ToolTestConfig(
+            tool_name="list_technical_debt_goals_for_project_file",
+            arguments={"project_id": 1, "file_path": git_test_file},
+            header="Test list_technical_debt_goals_for_project_file (In Git Repo)",
+            forbidden_patterns=[MOUNT_PATH_ERROR],
+            test_description="No CS_MOUNT_PATH error",
+        )),
+        # Tests outside git repo
+        ("code_ownership_for_path (no git repo)", ToolTestConfig(
+            tool_name="code_ownership_for_path",
+            arguments={"project_id": 1, "path": no_git_test_file},
+            header="Test code_ownership_for_path (No Git Repo)",
+            forbidden_patterns=[MOUNT_PATH_ERROR, GIT_REPO_ERROR],
+            test_description="No CS_MOUNT_PATH or git repo error",
+        )),
+        # Test with relative path
+        ("code_ownership_for_path (relative path)", ToolTestConfig(
+            tool_name="code_ownership_for_path",
+            arguments={"project_id": 1, "path": "src/components/Button.tsx"},
+            header="Test code_ownership_for_path (Relative Path)",
+            forbidden_patterns=[MOUNT_PATH_ERROR, GIT_REPO_ERROR],
+            test_description="No CS_MOUNT_PATH or git repo error with relative path",
+        )),
+    ]
 
 
 def main():
@@ -481,9 +139,9 @@ def main():
     
     # Create test git repo
     print("\n  Creating temporary git repository for testing...")
-    tmpdir, test_file = create_test_git_repo()
-    print(f"  Test repo: {tmpdir}")
-    print(f"  Test file: {test_file}")
+    git_tmpdir, git_test_file = create_test_git_repo()
+    print(f"  Test repo: {git_tmpdir}")
+    print(f"  Test file: {git_test_file}")
     
     # Create test file outside git repo
     print("\n  Creating temporary file outside git repo...")
@@ -492,42 +150,23 @@ def main():
     print(f"  Test file: {no_git_test_file}")
     
     try:
+        # Run setup tests
         results = [
             ("Environment Setup", test_environment_setup(binary_path)),
             ("MCP Server Startup", test_mcp_server_starts(binary_path)),
-            # Tests with file inside git repo
-            ("code_ownership_for_path (in git repo)", 
-             test_code_ownership_no_mount_path_error(binary_path, test_file)),
-            ("list_technical_debt_hotspots_for_project_file (in git repo)", 
-             test_technical_debt_hotspots_no_mount_path_error(binary_path, test_file)),
-            ("list_technical_debt_goals_for_project_file (in git repo)", 
-             test_technical_debt_goals_no_mount_path_error(binary_path, test_file)),
-            # Tests outside git repo - should also work now
-            ("code_ownership_for_path (no git repo)", 
-             test_code_ownership_no_git_repo(binary_path, no_git_test_file)),
-            ("code_ownership_for_path (relative path)", 
-             test_code_ownership_relative_path(binary_path)),
         ]
         
-        print_header("Test Summary")
+        # Run tool tests from configuration
+        env = create_static_mode_env()
+        for name, config in build_tool_test_configs(git_test_file, no_git_test_file):
+            passed = run_tool_test(command=[binary_path], env=env, config=config)
+            results.append((name, passed))
         
-        passed = sum(1 for _, p in results if p)
-        total = len(results)
-        
-        for name, result in results:
-            print(f"  {'\u2713 PASS' if result else '\u2717 FAIL'}: {name}")
-        
-        print(f"\n  Total: {passed}/{total} passed")
-        
-        if passed == total:
-            print("\n  All tests passed! \u2713")
-            return 0
-        print(f"\n  {total - passed} test(s) failed! \u2717")
-        return 1
+        return print_test_summary(results)
     
     finally:
-        cleanup_test_repo(tmpdir)
-        cleanup_test_repo(no_git_tmpdir)
+        cleanup_test_dir(git_tmpdir)
+        cleanup_test_dir(no_git_tmpdir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Fixes an issue where using path related MCP tools failed with `CS_MOUNT_PATH` required error in static executable variant of the MCP server
- Adds integration tests to make sure this problem never comes back to haunt us