### PR TITLE
Update Homebrew formula to 0.0.36

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.0.35"
+  version "0.0.36"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "0dbf309bc155e95682f7ce058a01a9f82cb4a73dc046c3ae7e79cdc9adfc6966"
+      sha256 "d6ae02329086b59aafa9fa1a3c3729070706197ef4429f93bb51cb1763b5a399"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "0714d34985a9f081b4794b163d0782e3a2603d9d1042b97aaea7673c22b4922d"
+      sha256 "2f43eae9e6814e154f6f42f85429d512539efc1f1fa797717ae8d2de6d3f5b64"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "c4d3225a3a29557354433c7f241e01751fbdfaeb15d2987dcc03caee5e51235c"
+      sha256 "e5e0a86c119b5e108b6b13cfee9d40754a83a365b35af7c3834f696829fb8c48"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "75d01025673a0f0986d942fc143e5f422648a5c2f38331d0eb61fc341ab86d9f"
+      sha256 "cd91bcc341b911ed2eb3daaf17fd5a61d3a7913e9174e2861c8c13587d664d06"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.0.36.

## Checksums
- macOS ARM64: `d6ae02329086b59aafa9fa1a3c3729070706197ef4429f93bb51cb1763b5a399`
- macOS AMD64: `2f43eae9e6814e154f6f42f85429d512539efc1f1fa797717ae8d2de6d3f5b64`
- Linux ARM64: `e5e0a86c119b5e108b6b13cfee9d40754a83a365b35af7c3834f696829fb8c48`
- Linux AMD64: `cd91bcc341b911ed2eb3daaf17fd5a61d3a7913e9174e2861c8c13587d664d06`