### PR TITLE
Update Homebrew formula to 0.0.37

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.0.36"
+  version "0.0.37"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "d6ae02329086b59aafa9fa1a3c3729070706197ef4429f93bb51cb1763b5a399"
+      sha256 "af5842420a70db261e607216596131326544ae209233ead12aa77bd78fb7d920"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "2f43eae9e6814e154f6f42f85429d512539efc1f1fa797717ae8d2de6d3f5b64"
+      sha256 "a00934977c3a719e3c50acd62565bf0b1960e7140f607eb1836020c98cdde7f4"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "e5e0a86c119b5e108b6b13cfee9d40754a83a365b35af7c3834f696829fb8c48"
+      sha256 "b9e31c0c802214a7f0eada759615ca069f9ebc2662e18119fa0456a39803ed6c"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "cd91bcc341b911ed2eb3daaf17fd5a61d3a7913e9174e2861c8c13587d664d06"
+      sha256 "1cd252ebd37cf75e1ced81fc8f2e9db82f7ec3b25a5af8fc41fa0d427e281c4f"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.0.37.

## Checksums
- macOS ARM64: `af5842420a70db261e607216596131326544ae209233ead12aa77bd78fb7d920`
- macOS AMD64: `a00934977c3a719e3c50acd62565bf0b1960e7140f607eb1836020c98cdde7f4`
- Linux ARM64: `b9e31c0c802214a7f0eada759615ca069f9ebc2662e18119fa0456a39803ed6c`
- Linux AMD64: `1cd252ebd37cf75e1ced81fc8f2e9db82f7ec3b25a5af8fc41fa0d427e281c4f`