### PR TITLE
Update Homebrew formula to 0.1.5

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.1.3"
+  version "0.1.5"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "b2f315d30fbe15cae2d3667a04e6c2ef2bbcad3f4d862baf0c975acc1e2c6b75"
+      sha256 "d101dca77406c21bd3722c9efc90c526adc3717b3b5bd5d4f2ba93b584d81ef8"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "aeb63826d52c116cd729dc0d2b5623335698b77623f6460691e63bfa4d2767cd"
+      sha256 "3d50090214de24947301e6cc683d65b03a3e4fbe339231fd05b4d7d0e1d899c9"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "8da5b8cfa05358001c1828a957d4927675599bfdcd84be24acc75f43a5e8ab2d"
+      sha256 "f4dfbfa22746730f866a15023e72f39baaaffdc91743d3d14c94c52c8bbab2e2"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "8ba99e03de320db4ce342fbdcfad3d08d0489aadd9c37e85fba3db95e13679ce"
+      sha256 "6b4e032d99c6a88b3bf7455c09c620befc8e04e0c95f315c48ef240f08c1b44b"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.1.5.

## Checksums
- macOS ARM64: `d101dca77406c21bd3722c9efc90c526adc3717b3b5bd5d4f2ba93b584d81ef8`
- macOS AMD64: `3d50090214de24947301e6cc683d65b03a3e4fbe339231fd05b4d7d0e1d899c9`
- Linux ARM64: `f4dfbfa22746730f866a15023e72f39baaaffdc91743d3d14c94c52c8bbab2e2`
- Linux AMD64: `6b4e032d99c6a88b3bf7455c09c620befc8e04e0c95f315c48ef240f08c1b44b`