### PR TITLE
Add a new MCP tool, analyze_change_set, to act as a Pull Request pre-flight

### DIFF
--- a/.github/prompts/analyze_change_set.prompt.md
+++ b/.github/prompts/analyze_change_set.prompt.md
@@ -1,0 +1,19 @@
+---
+name: analyze_change_set
+description: Run a branch-level Code Health review of all changes compared to a base ref (PR pre-flight).
+argument-hint: Base ref to compare against (e.g. main, origin/main)
+tools:
+  - analyze_change_set
+---
+
+Run a branch-level Code Health analysis using **CodeScene MCP Server** with the MCP tool **analyze_change_set**. This reviews all committed changes on the current branch compared to the given base ref.
+
+After running the tool:
+
+1. Summarize the JSON output in clear, actionable language. Focus on the overall result indicated in the `quality_gates` field.
+2. Highlight any code smells or degradation introduced across the branch.
+3. Prioritize findings by severity and likelihood of increasing long-term maintenance cost.
+4. Provide practical recommendations for improvements before opening a PR.
+5. Code Health 10.0 is optimal. Do not allow regressions below 10.0, not even minor ones.
+
+Use concise language suitable for a PR pre-flight review. Avoid rewriting the code unless explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,19 +15,16 @@
 
 ## 1️⃣ Safeguard All AI-Generated or Modified Code (Mandatory)
 
-For any AI-touched code:
+Two tools enforce Code Health at different scopes:
 
-1. Run `pre_commit_code_health_safeguard`.
-2. Run `code_health_review` for detailed analysis if the safeguard reports a regression.
-3. If Code Health regresses or fails quality gates:
-   - Highlight the issue.
-   - Refactor before suggesting commit.
-   - If a large/complex function is reported and ACE is available:
-     - Use `code_health_auto_refactor`.
-     - Then refine incrementally.
-   - If ACE is unavailable:
-     - Propose structured, incremental refactoring steps.
-4. Do **not** mark changes as ready unless risks are explicitly accepted.
+- **`pre_commit_code_health_safeguard`** — uncommitted/staged files only. Run before each commit.
+- **`analyze_change_set`** — full branch vs base ref (PR pre-flight). Run before opening a PR.
+
+If either reports a regression:
+
+1. Run `code_health_review` for details.
+2. Refactor until Code Health is restored. Use `code_health_auto_refactor` (ACE) if available.
+3. Do **not** mark changes as ready unless risks are explicitly accepted.
 
 ---
 

--- a/src/analyze_change_set/__init__.py
+++ b/src/analyze_change_set/__init__.py
@@ -1,0 +1,4 @@
+from .change_set_analyzer import (
+    AnalyzeChangeSet,
+    AnalyzeChangeSetDeps,
+)

--- a/src/analyze_change_set/change_set_analyzer.py
+++ b/src/analyze_change_set/change_set_analyzer.py
@@ -1,0 +1,58 @@
+from collections.abc import Callable
+from typing import TypedDict
+
+from code_health_tools.delta_runner import run_delta_cli
+from utils import (
+    cs_cli_path,
+    get_platform_details,
+    track,
+    with_version_check,
+)
+
+
+class AnalyzeChangeSetDeps(TypedDict):
+    run_local_tool_fn: Callable[[list, str | None, dict | None], str]
+
+
+class AnalyzeChangeSet:
+    def __init__(self, mcp_instance, deps: AnalyzeChangeSetDeps):
+        self.deps = deps
+
+        mcp_instance.tool(self.analyze_change_set)
+
+    @track("analyze-change-set")
+    @with_version_check
+    def analyze_change_set(self, base_ref: str, git_repository_path: str) -> str:
+        """
+        Provides a branch-level Code Health review of all changes between the
+        current HEAD and the given base_ref. This is the equivalent of a local
+        PR pre-flight check: it analyzes every file that differs from the base
+        reference and reports Code Health improvements, degradations, and code
+        smells across the entire change set.
+
+        Use this tool before opening a pull request to catch Code Health
+        regressions early, while changes are still local.
+
+        Args:
+            base_ref: The git reference to compare against, typically the target
+                branch of the pull request (e.g. "main", "origin/main", "develop").
+            git_repository_path: The absolute path to the Git repository for the
+                current code base.
+
+        Returns:
+            A JSON object containing:
+             - quality_gates: the central outcome, summarizing whether the change
+               set passes or fails Code Health thresholds ("passed" or "failed").
+             - results: an array of objects for each affected file with:
+                 - name: the name of the file whose Code Health is impacted.
+                 - verdict: "improved", "degraded", or "stable".
+                 - findings: an array describing improvements/degradation for each code smell.
+        """
+        cli_command = [
+            cs_cli_path(get_platform_details()),
+            "delta",
+            base_ref,
+            "--output-format=json",
+        ]
+
+        return run_delta_cli(cli_command, git_repository_path, self.deps["run_local_tool_fn"])

--- a/src/analyze_change_set/test_change_set_analyzer.py
+++ b/src/analyze_change_set/test_change_set_analyzer.py
@@ -1,0 +1,157 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from fastmcp import FastMCP
+
+from .change_set_analyzer import AnalyzeChangeSet
+
+
+class TestAnalyzeChangeSet(unittest.TestCase):
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
+    def test_analyze_change_set_docker(self):
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            return json.dumps([{"name": "test.tsx"}])
+
+        self.instance = AnalyzeChangeSet(FastMCP("Test"), {"run_local_tool_fn": mock_run_local_tool})
+
+        expected = {
+            "results": [{"name": "test.tsx", "verdict": "unknown", "findings": []}],
+            "quality_gates": "passed",
+        }
+
+        result = self.instance.analyze_change_set("main", "/my/git/path")
+
+        self.assertEqual(json.dumps(expected), result)
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
+    def test_analyze_change_set_invalid_response(self):
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            return "string output"
+
+        self.instance = AnalyzeChangeSet(FastMCP("Test"), {"run_local_tool_fn": mock_run_local_tool})
+
+        expected = """Error: Invalid JSON input: Expecting value: line 1 column 1 (char 0)
+Input: string output"""
+        result = self.instance.analyze_change_set("main", "/my/git/path")
+
+        self.assertEqual(expected, result)
+
+    def test_analyze_change_set_local_binary(self):
+        """Test that local/native binary mode works without CS_MOUNT_PATH."""
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        captured_path = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_path.append(path)
+            return json.dumps([{"name": "test.tsx"}])
+
+        self.instance = AnalyzeChangeSet(FastMCP("Test"), {"run_local_tool_fn": mock_run_local_tool})
+
+        expected = {
+            "results": [{"name": "test.tsx", "verdict": "unknown", "findings": []}],
+            "quality_gates": "passed",
+        }
+
+        result = self.instance.analyze_change_set("main", "/my/local/git/path")
+
+        self.assertEqual(json.dumps(expected), result)
+        self.assertEqual(captured_path[-1], "/my/local/git/path")
+
+    def test_analyze_change_set_passes_base_ref_in_cli_command(self):
+        """Test that base_ref is included in the CLI command sent to the tool."""
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        captured_commands = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_commands.append(cli_command)
+            return json.dumps([{"name": "test.tsx"}])
+
+        self.instance = AnalyzeChangeSet(FastMCP("Test"), {"run_local_tool_fn": mock_run_local_tool})
+
+        self.instance.analyze_change_set("develop", "/my/local/git/path")
+
+        # The CLI command should contain the base_ref
+        cli_command = captured_commands[-1]
+        self.assertIn("develop", cli_command)
+        self.assertIn("delta", cli_command)
+        self.assertIn("--output-format=json", cli_command)
+
+    def test_analyze_change_set_empty_output_passes(self):
+        """Test that empty output (no code health impact) results in passed quality gates."""
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            return ""
+
+        self.instance = AnalyzeChangeSet(FastMCP("Test"), {"run_local_tool_fn": mock_run_local_tool})
+
+        expected = {"results": [], "quality_gates": "passed"}
+
+        result = self.instance.analyze_change_set("main", "/my/local/git/path")
+
+        self.assertEqual(json.dumps(expected), result)
+
+
+class TestAnalyzeChangeSetWorktree(unittest.TestCase):
+    """Tests for analyze_change_set git worktree support."""
+
+    def setUp(self):
+        self._env = dict(os.environ)
+        self.temp_dir = os.path.realpath(tempfile.mkdtemp())
+
+        # Write .git file pointing to main repo's worktrees
+        self.worktree_gitdir = "/path/to/main/.git/worktrees/feature"
+        with open(os.path.join(self.temp_dir, ".git"), "w") as f:
+            f.write(f"gitdir: {self.worktree_gitdir}")
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._env)
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_analyze_local_sets_git_dir_for_worktree(self):
+        """Test that local analysis sets GIT_DIR for worktree environments."""
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        captured_extra_env = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_extra_env.append(extra_env)
+            return json.dumps([{"name": "test.tsx"}])
+
+        instance = AnalyzeChangeSet(FastMCP("Test"), {"run_local_tool_fn": mock_run_local_tool})
+
+        instance.analyze_change_set("main", self.temp_dir)
+
+        self.assertEqual(len(captured_extra_env), 1)
+        extra_env = captured_extra_env[0]
+        self.assertIsNotNone(extra_env)
+        self.assertIn("GIT_DIR", extra_env)
+        self.assertEqual(self.worktree_gitdir, extra_env["GIT_DIR"])
+
+    def test_analyze_local_no_extra_env_for_regular_repo(self):
+        """Test that local analysis doesn't set GIT_DIR for regular repos."""
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        regular_repo = os.path.join(self.temp_dir, "regular")
+        os.makedirs(os.path.join(regular_repo, ".git"))
+
+        captured_extra_env = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_extra_env.append(extra_env)
+            return json.dumps([{"name": "test.tsx"}])
+
+        instance = AnalyzeChangeSet(FastMCP("Test"), {"run_local_tool_fn": mock_run_local_tool})
+
+        instance.analyze_change_set("main", regular_repo)
+
+        self.assertEqual(len(captured_extra_env), 1)
+        self.assertIsNone(captured_extra_env[0])

--- a/src/code_health_tools/delta_runner.py
+++ b/src/code_health_tools/delta_runner.py
@@ -1,0 +1,69 @@
+import json
+import os
+from collections.abc import Callable
+
+from code_health_tools.delta_analysis import analyze_delta_output
+from utils import (
+    adapt_mounted_file_path_inside_docker,
+    adapt_worktree_gitdir_for_docker,
+    run_cs_cli,
+)
+from utils.docker_path_adapter import get_worktree_gitdir
+
+
+def run_delta_cli(
+    cli_command: list,
+    git_repository_path: str,
+    run_local_tool_fn: Callable[[list, str | None, dict | None], str],
+) -> str:
+    """
+    Run a CodeScene delta CLI command and return parsed results as JSON.
+
+    Handles the Docker-vs-local dispatch, worktree detection, and output
+    parsing that is common to all delta-based tools.
+
+    Args:
+        cli_command: The full CLI command list (e.g. ["cs", "delta", "--output-format=json"]).
+        git_repository_path: Absolute path to the Git repository.
+        run_local_tool_fn: Callable that executes a CLI command with optional cwd and env.
+
+    Returns:
+        A JSON string with the parsed delta results.
+    """
+    if os.getenv("CS_MOUNT_PATH"):
+        return run_cs_cli(lambda: _run_on_docker(cli_command, git_repository_path, run_local_tool_fn))
+    else:
+        return run_cs_cli(lambda: _run_on_local(cli_command, git_repository_path, run_local_tool_fn))
+
+
+def _run_on_docker(
+    cli_command: list,
+    git_repository_path: str,
+    run_local_tool_fn: Callable,
+) -> str:
+    """Run a delta CLI command in a Docker environment with path translation."""
+    docker_path = adapt_mounted_file_path_inside_docker(git_repository_path)
+
+    worktree_gitdir = adapt_worktree_gitdir_for_docker(docker_path)
+    extra_env = {"GIT_DIR": worktree_gitdir} if worktree_gitdir else None
+
+    run_local_tool_fn(
+        ["git", "config", "--system", "--add", "safe.directory", docker_path],
+        None,
+        extra_env,
+    )
+    output = run_local_tool_fn(cli_command, docker_path, extra_env)
+    return json.dumps(analyze_delta_output(output))
+
+
+def _run_on_local(
+    cli_command: list,
+    git_repository_path: str,
+    run_local_tool_fn: Callable,
+) -> str:
+    """Run a delta CLI command in a local/native environment."""
+    gitdir = get_worktree_gitdir(git_repository_path)
+    extra_env = {"GIT_DIR": gitdir} if gitdir else None
+
+    output = run_local_tool_fn(cli_command, git_repository_path, extra_env)
+    return json.dumps(analyze_delta_output(output))

--- a/src/code_health_tools/test_delta_runner.py
+++ b/src/code_health_tools/test_delta_runner.py
@@ -1,0 +1,146 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from code_health_tools.delta_runner import run_delta_cli
+
+SAMPLE_CLI_COMMAND = ["cs", "delta", "--output-format=json"]
+
+SINGLE_FILE_OUTPUT = json.dumps([{"name": "test.tsx"}])
+SINGLE_FILE_EXPECTED = {
+    "results": [{"name": "test.tsx", "verdict": "unknown", "findings": []}],
+    "quality_gates": "passed",
+}
+
+
+def mock_run_returning(output):
+    """Create a mock run_local_tool_fn that returns a fixed output."""
+
+    def mock_run_local_tool(cli_command, path, extra_env=None):
+        return output
+
+    return mock_run_local_tool
+
+
+class TestRunDeltaCliDocker(unittest.TestCase):
+    """Tests for run_delta_cli in Docker mode (CS_MOUNT_PATH set)."""
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
+    def test_docker_returns_parsed_results(self):
+        result = run_delta_cli(SAMPLE_CLI_COMMAND, "/my/git/path", mock_run_returning(SINGLE_FILE_OUTPUT))
+
+        self.assertEqual(json.dumps(SINGLE_FILE_EXPECTED), result)
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
+    def test_docker_sets_safe_directory(self):
+        captured_calls = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_calls.append({"command": cli_command, "path": path, "extra_env": extra_env})
+            return SINGLE_FILE_OUTPUT
+
+        run_delta_cli(SAMPLE_CLI_COMMAND, "/my/git/path", mock_run_local_tool)
+
+        # First call should be git config safe.directory
+        self.assertEqual(len(captured_calls), 2)
+        self.assertEqual(captured_calls[0]["command"][0], "git")
+        self.assertIn("safe.directory", captured_calls[0]["command"])
+
+    @mock.patch.dict(os.environ, {"CS_MOUNT_PATH": "/my/git/path"})
+    def test_docker_invalid_json_returns_error(self):
+        result = run_delta_cli(SAMPLE_CLI_COMMAND, "/my/git/path", mock_run_returning("string output"))
+
+        self.assertTrue(result.startswith("Error:"))
+        self.assertIn("Invalid JSON input", result)
+
+
+class TestRunDeltaCliLocal(unittest.TestCase):
+    """Tests for run_delta_cli in local/native mode (no CS_MOUNT_PATH)."""
+
+    def setUp(self):
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+    def test_local_returns_parsed_results(self):
+        result = run_delta_cli(
+            SAMPLE_CLI_COMMAND, "/my/local/git/path", mock_run_returning(SINGLE_FILE_OUTPUT)
+        )
+
+        self.assertEqual(json.dumps(SINGLE_FILE_EXPECTED), result)
+
+    def test_local_passes_path_directly(self):
+        captured_paths = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_paths.append(path)
+            return SINGLE_FILE_OUTPUT
+
+        run_delta_cli(SAMPLE_CLI_COMMAND, "/my/local/git/path", mock_run_local_tool)
+
+        self.assertEqual(captured_paths[-1], "/my/local/git/path")
+
+    def test_local_empty_output_passes(self):
+        result = run_delta_cli(SAMPLE_CLI_COMMAND, "/some/path", mock_run_returning(""))
+
+        expected = {"results": [], "quality_gates": "passed"}
+        self.assertEqual(json.dumps(expected), result)
+
+    def test_local_invalid_json_returns_error(self):
+        result = run_delta_cli(SAMPLE_CLI_COMMAND, "/some/path", mock_run_returning("string output"))
+
+        self.assertTrue(result.startswith("Error:"))
+        self.assertIn("Invalid JSON input", result)
+
+
+class TestRunDeltaCliWorktree(unittest.TestCase):
+    """Tests for run_delta_cli git worktree support."""
+
+    def setUp(self):
+        self._env = dict(os.environ)
+        self.temp_dir = os.path.realpath(tempfile.mkdtemp())
+
+        self.worktree_gitdir = "/path/to/main/.git/worktrees/feature"
+        with open(os.path.join(self.temp_dir, ".git"), "w") as f:
+            f.write(f"gitdir: {self.worktree_gitdir}")
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self._env)
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_local_sets_git_dir_for_worktree(self):
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        captured_extra_env = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_extra_env.append(extra_env)
+            return SINGLE_FILE_OUTPUT
+
+        run_delta_cli(SAMPLE_CLI_COMMAND, self.temp_dir, mock_run_local_tool)
+
+        self.assertEqual(len(captured_extra_env), 1)
+        extra_env = captured_extra_env[0]
+        self.assertIsNotNone(extra_env)
+        self.assertIn("GIT_DIR", extra_env)
+        self.assertEqual(self.worktree_gitdir, extra_env["GIT_DIR"])
+
+    def test_local_no_extra_env_for_regular_repo(self):
+        os.environ.pop("CS_MOUNT_PATH", None)
+
+        regular_repo = os.path.join(self.temp_dir, "regular")
+        os.makedirs(os.path.join(regular_repo, ".git"))
+
+        captured_extra_env = []
+
+        def mock_run_local_tool(cli_command, path, extra_env=None):
+            captured_extra_env.append(extra_env)
+            return SINGLE_FILE_OUTPUT
+
+        run_delta_cli(SAMPLE_CLI_COMMAND, regular_repo, mock_run_local_tool)
+
+        self.assertEqual(len(captured_extra_env), 1)
+        self.assertIsNone(captured_extra_env[0])

--- a/src/cs_mcp_server.py
+++ b/src/cs_mcp_server.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from fastmcp import FastMCP
 from fastmcp.resources import FileResource
 
+from analyze_change_set import AnalyzeChangeSet
 from code_health_auto_refactor import AutoRefactor
 from code_health_refactoring_business_case import CodeHealthRefactoringBusinessCase
 from code_health_review import CodeHealthReview
@@ -188,6 +189,8 @@ if __name__ == "__main__":
 
     # tools
     PreCommitCodeHealthSafeguard(mcp, {"run_local_tool_fn": run_local_tool})
+
+    AnalyzeChangeSet(mcp, {"run_local_tool_fn": run_local_tool})
 
     CodeHealthRefactoringBusinessCase(mcp, {"analyze_code_fn": analyze_code})
 

--- a/tests/integration/run_all_tests.py
+++ b/tests/integration/run_all_tests.py
@@ -490,6 +490,7 @@ def run_all_tests_with_backend(backend: ServerBackend) -> int:
 
         # Run additional test modules
         from test_analytics_tracking import run_analytics_tracking_tests_with_backend
+        from test_analyze_change_set import run_analyze_change_set_tests_with_backend
         from test_bundled_docs import run_bundled_docs_tests_with_backend
         from test_business_case import run_business_case_tests_with_backend
         from test_git_subtree import run_subtree_tests_with_backend
@@ -504,6 +505,7 @@ def run_all_tests_with_backend(backend: ServerBackend) -> int:
         all_results.append(_run_test_module("Bundled Docs Tests", run_bundled_docs_tests_with_backend, backend))
         all_results.append(_run_test_module("Version Check Tests", run_version_check_tests_with_backend, backend))
         all_results.append(_run_test_module("Analytics Tracking Tests", run_analytics_tracking_tests_with_backend, backend))
+        all_results.append(_run_test_module("Analyze Change Set Tests", run_analyze_change_set_tests_with_backend, backend))
 
         return print_summary(all_results)
 

--- a/tests/integration/server_backends.py
+++ b/tests/integration/server_backends.py
@@ -316,6 +316,11 @@ class NuitkaBackend(ServerBackend):
         """Return environment without CS_MOUNT_PATH for native execution."""
         env = base_env.copy()
         env.pop("CS_MOUNT_PATH", None)
+        # Disable the version check by default so non-version-check tests
+        # don't make real HTTP calls to GitHub and don't get the "VERSION
+        # UPDATE AVAILABLE" banner prepended to tool responses.
+        # test_version_check.py overrides this after calling get_env().
+        env.setdefault("CS_DISABLE_VERSION_CHECK", "1")
         return env
 
     def cleanup(self) -> None:
@@ -408,7 +413,13 @@ class DockerBackend(ServerBackend):
 
     def get_env(self, base_env: dict[str, str], working_dir: Path) -> dict[str, str]:
         """Return environment for Docker execution."""
-        return base_env.copy()
+        env = base_env.copy()
+        # Disable the version check by default so non-version-check tests
+        # don't make real HTTP calls to GitHub and don't get the "VERSION
+        # UPDATE AVAILABLE" banner prepended to tool responses.
+        # test_version_check.py overrides this after calling get_env().
+        env.setdefault("CS_DISABLE_VERSION_CHECK", "1")
+        return env
 
     def cleanup(self) -> None:
         """No cleanup needed - containers use --rm."""

--- a/tests/integration/test_analyze_change_set.py
+++ b/tests/integration/test_analyze_change_set.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the analyze_change_set MCP tool.
+
+Tests that branch-level Code Health analysis correctly:
+- Passes when no code health decline exists on the current branch vs base_ref
+- Fails when a commit on the current branch introduces a code health decline
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fixtures import get_sample_files
+
+from test_utils import (
+    MCPClient,
+    NuitkaBackend,
+    ServerBackend,
+    create_git_repo,
+    extract_result_text,
+    print_header,
+    print_summary,
+    print_test,
+    safe_temp_directory,
+)
+
+# A clean change that should not degrade Code Health
+CLEAN_ADDITION = '''
+
+def calculate_median(items: list[float]) -> float:
+    """Calculate the median of all items."""
+    if not items:
+        return 0.0
+    sorted_items = sorted(items)
+    mid = len(sorted_items) // 2
+    if len(sorted_items) % 2 == 0:
+        return (sorted_items[mid - 1] + sorted_items[mid]) / 2
+    return sorted_items[mid]
+'''
+
+# A change that introduces a Complex Conditional code smell:
+# 3+ logical operators in a single conditional triggers the smell.
+DEGRADING_ADDITION = '''
+
+def validate_order(order, customer, inventory, config):
+    """Validate an order with complex business rules."""
+    if (order is not None and customer is not None and inventory is not None
+            and config is not None and order.get("items") and customer.get("id")
+            and inventory.get("stock") and config.get("enabled")
+            and order.get("total") > 0 and customer.get("active")
+            and not customer.get("banned") and config.get("allow_orders")):
+        return True
+    if (order is not None and order.get("priority") and customer is not None
+            and customer.get("vip") and inventory is not None
+            and inventory.get("reserved") and config is not None
+            and config.get("vip_enabled") and order.get("total") > 100
+            and not order.get("flagged") and customer.get("verified")
+            and config.get("allow_vip")):
+        return True
+    return False
+'''
+
+
+def create_feature_branch_with_file_change(repo_dir: Path, file_path: str, additional_code: str) -> None:
+    """
+    Create a feature branch and commit a code change.
+
+    Args:
+        repo_dir: Path to the git repository
+        file_path: Relative path to the file to modify
+        additional_code: Code to append to the file
+    """
+    subprocess.run(
+        ["git", "checkout", "-b", "feature"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+    )
+
+    full_path = repo_dir / file_path
+    original = full_path.read_text()
+    full_path.write_text(original + additional_code)
+
+    subprocess.run(["git", "add", "."], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "Feature branch change"],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+    )
+
+
+def parse_quality_gates(result_text: str) -> str | None:
+    """
+    Extract quality_gates from the tool's JSON response.
+
+    Returns:
+        "passed", "failed", or None if parsing fails.
+    """
+    try:
+        data = json.loads(result_text)
+        return data.get("quality_gates")
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _run_change_set_analysis(command: list[str], env: dict, repo_dir: Path) -> tuple[str, str | None]:
+    """
+    Run analyze_change_set against 'master' and return the raw result text and quality gates.
+
+    Returns:
+        Tuple of (result_text, quality_gates) where quality_gates may be None on parse failure.
+    """
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+
+    try:
+        if not client.start():
+            return ("", None)
+
+        client.initialize()
+
+        response = client.call_tool(
+            "analyze_change_set",
+            {"base_ref": "master", "git_repository_path": str(repo_dir)},
+            timeout=60,
+        )
+
+        result_text = extract_result_text(response)
+        return (result_text, parse_quality_gates(result_text))
+    finally:
+        client.stop()
+
+
+def _setup_repo_with_branch(test_dir: Path, subdir: str, code_change: str) -> Path:
+    """
+    Create a git repo and a feature branch with a code change.
+
+    Returns:
+        Path to the repository on the feature branch.
+    """
+    repo_dir = create_git_repo(test_dir / subdir, get_sample_files())
+    create_feature_branch_with_file_change(repo_dir, "src/utils/calculator.py", code_change)
+    return repo_dir
+
+
+def test_passes_on_clean_branch(command: list[str], env: dict, test_dir: Path) -> bool:
+    """Test that analyze_change_set passes when the branch has no code health decline."""
+    print_header("Test: Change Set Passes on Clean Branch")
+
+    repo_dir = _setup_repo_with_branch(test_dir, "clean", CLEAN_ADDITION)
+    result_text, quality_gates = _run_change_set_analysis(command, env, repo_dir)
+
+    has_content = len(result_text) > 10
+    print_test("Tool returned content", has_content, f"Length: {len(result_text)} chars")
+
+    gates_passed = quality_gates == "passed"
+    print_test("Quality gates passed (no degradation)", gates_passed, f"quality_gates: {quality_gates}")
+
+    return has_content and gates_passed
+
+
+def test_fails_on_degraded_branch(command: list[str], env: dict, test_dir: Path) -> bool:
+    """Test that analyze_change_set fails when a commit introduces a code health decline."""
+    print_header("Test: Change Set Fails on Degraded Branch")
+
+    repo_dir = _setup_repo_with_branch(test_dir, "degraded", DEGRADING_ADDITION)
+    result_text, quality_gates = _run_change_set_analysis(command, env, repo_dir)
+
+    gates_failed = quality_gates == "failed"
+    print_test("Quality gates failed (degradation detected)", gates_failed, f"quality_gates: {quality_gates}")
+
+    has_findings = "calculator.py" in result_text
+    print_test("Findings reference the degraded file", has_findings)
+
+    return gates_failed and has_findings
+
+
+def run_analyze_change_set_tests(executable: Path) -> int:
+    """
+    Run all analyze_change_set tests.
+
+    Args:
+        executable: Path to the cs-mcp executable
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    backend = NuitkaBackend(executable=executable)
+    return run_analyze_change_set_tests_with_backend(backend)
+
+
+def run_analyze_change_set_tests_with_backend(backend: ServerBackend) -> int:
+    """
+    Run all analyze_change_set tests using a backend.
+
+    Args:
+        backend: Server backend to use
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    with safe_temp_directory(prefix="cs_mcp_change_set_test_") as test_dir:
+        print(f"\nTest directory: {test_dir}")
+
+        command = backend.get_command(test_dir)
+        env = backend.get_env(os.environ.copy(), test_dir)
+
+        results = [
+            ("Clean Branch Passes", test_passes_on_clean_branch(command, env, test_dir)),
+            ("Degraded Branch Fails", test_fails_on_degraded_branch(command, env, test_dir)),
+        ]
+
+        return print_summary(results)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python test_analyze_change_set.py /path/to/cs-mcp")
+        return 1
+
+    executable = Path(sys.argv[1])
+    if not executable.exists():
+        print(f"Error: Executable not found: {executable}")
+        return 1
+
+    print_header("Analyze Change Set Integration Tests")
+
+    return run_analyze_change_set_tests(executable)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_version_check.py
+++ b/tests/integration/test_version_check.py
@@ -105,6 +105,9 @@ def run_version_check_tests_with_backend(backend: ServerBackend) -> int:
         command = backend.get_command(repo_dir)
         env = backend.get_env(os.environ.copy(), repo_dir)
 
+        # These tests need the version checker active, so remove the default
+        # disable that get_env() sets for non-version-check tests.
+        env.pop("CS_DISABLE_VERSION_CHECK", None)
         # Point version check at an unreachable address
         env["CS_VERSION_CHECK_URL"] = UNREACHABLE_VERSION_CHECK_URL
 
@@ -308,6 +311,9 @@ def test_version_info_appears_after_background_fetch(backend: ServerBackend, rep
 
     # Build env with the local URL override
     env = backend.get_env(os.environ.copy(), repo_dir)
+    # This test needs the version checker active, so remove the default
+    # disable that get_env() sets for non-version-check tests.
+    env.pop("CS_DISABLE_VERSION_CHECK", None)
     env["CS_VERSION_CHECK_URL"] = local_url
     command = backend.get_command(repo_dir)
 


### PR DESCRIPTION
This PR complements our existing pre-flight check with a new tool.
These two tools enforce Code Health at different scopes:

- **`pre_commit_code_health_safeguard`** — uncommitted/staged files only. Run before each commit.
- **`analyze_change_set`** — full branch vs base ref (PR pre-flight). Run before opening a PR.

Implements CS-6454 from the roadmap.