### PR TITLE
Update Homebrew formula to 0.2.0

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.1.5"
+  version "0.2.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "d101dca77406c21bd3722c9efc90c526adc3717b3b5bd5d4f2ba93b584d81ef8"
+      sha256 "9d1d175c58228f63307c3a7d923712d078b221ca789099da205faa469b641b83"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "3d50090214de24947301e6cc683d65b03a3e4fbe339231fd05b4d7d0e1d899c9"
+      sha256 "397d0864233e58b44ff6b32bcaa0eb7afcff163bfe959c35d545e7d267b76c81"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "f4dfbfa22746730f866a15023e72f39baaaffdc91743d3d14c94c52c8bbab2e2"
+      sha256 "fc75967a802f496fbbe952e1e599ccf4522e4a1a7c9b9b2c39379fcfaacd9997"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "6b4e032d99c6a88b3bf7455c09c620befc8e04e0c95f315c48ef240f08c1b44b"
+      sha256 "663d4dfdac6a3802e032886348996d92d929dac526ecd5dea42df6a44d4ac31b"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.2.0.

## Checksums
- macOS ARM64: `9d1d175c58228f63307c3a7d923712d078b221ca789099da205faa469b641b83`
- macOS AMD64: `397d0864233e58b44ff6b32bcaa0eb7afcff163bfe959c35d545e7d267b76c81`
- Linux ARM64: `fc75967a802f496fbbe952e1e599ccf4522e4a1a7c9b9b2c39379fcfaacd9997`
- Linux AMD64: `663d4dfdac6a3802e032886348996d92d929dac526ecd5dea42df6a44d4ac31b`