### PR TITLE
Update Homebrew formula to 0.3.0

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.2.1"
+  version "0.3.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "05b1cad13decdf44923208836c7d1f5c7b106be59c166e16c5bda91e3618e632"
+      sha256 "909ba96d4e94cd2f96a2d5b0e703534e14c94c3a767711f712002e6477e5b154"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "aea3aecf0c188efc7c2b9b24baf92179c3f7c84b2ae9a284e04a3f7a5151005d"
+      sha256 "d1d92b804cf967da2d5e6409e32751a1ade2142a1b62e3b1e6c7bbf1106bd3ff"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "f99fb9e11ca2d8bc27651717058d564c5930f967d8e7b549a2a55f60a2394eb2"
+      sha256 "d32016d1b41d889f3742d170ba288686123e63bfefed411428993cf783274ed6"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "57287577209060e95aedfecc8a5876f026120b902168e49441fc7507a74c48c2"
+      sha256 "cee876866e4bedb7a9a13a7e3d69429b10c3d5ae06e1813d49d0735f2004c8e2"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.3.0.

## Checksums
- macOS ARM64: `909ba96d4e94cd2f96a2d5b0e703534e14c94c3a767711f712002e6477e5b154`
- macOS AMD64: `d1d92b804cf967da2d5e6409e32751a1ade2142a1b62e3b1e6c7bbf1106bd3ff`
- Linux ARM64: `d32016d1b41d889f3742d170ba288686123e63bfefed411428993cf783274ed6`
- Linux AMD64: `cee876866e4bedb7a9a13a7e3d69429b10c3d5ae06e1813d49d0735f2004c8e2`