### PR TITLE
Update Homebrew formula to 0.3.1

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.3.0"
+  version "0.3.1"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "909ba96d4e94cd2f96a2d5b0e703534e14c94c3a767711f712002e6477e5b154"
+      sha256 "777b16930e180ce791987189fc2a3f03aed76ad8faa261e78343d827bfd29a80"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "d1d92b804cf967da2d5e6409e32751a1ade2142a1b62e3b1e6c7bbf1106bd3ff"
+      sha256 "e41743cfe1b818f8804f2964836081f8418801b178ea5d03a118264db268a579"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "d32016d1b41d889f3742d170ba288686123e63bfefed411428993cf783274ed6"
+      sha256 "fbaf96a3afe0ab22000ebb5514348f8b0247da029fbce86590b27c751117be7d"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "cee876866e4bedb7a9a13a7e3d69429b10c3d5ae06e1813d49d0735f2004c8e2"
+      sha256 "2cc751fae1995a47716166734e1ac0200073021e9d81a84c4a353807c36c06b2"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.3.1.

## Checksums
- macOS ARM64: `777b16930e180ce791987189fc2a3f03aed76ad8faa261e78343d827bfd29a80`
- macOS AMD64: `e41743cfe1b818f8804f2964836081f8418801b178ea5d03a118264db268a579`
- Linux ARM64: `fbaf96a3afe0ab22000ebb5514348f8b0247da029fbce86590b27c751117be7d`
- Linux AMD64: `2cc751fae1995a47716166734e1ac0200073021e9d81a84c4a353807c36c06b2`