### PR TITLE
Add PE metadata to Nuitka builds and skip integration tests without secrets

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -329,6 +329,8 @@ jobs:
           .\venv\Scripts\python -m nuitka --onefile `
             --assume-yes-for-downloads `
             --lto=yes `
+            --company-name="CodeScene AB" `
+            --product-name="CodeHealth MCP" `
             --noinclude-pytest-mode=nofollow `
             --noinclude-unittest-mode=nofollow `
             --noinclude-setuptools-mode=nofollow `
@@ -395,6 +397,8 @@ jobs:
   #       run: |
   #         .\venv\Scripts\python -m nuitka --onefile `
   #           --assume-yes-for-downloads `
+  #           --company-name="CodeScene AB" `
+  #           --product-name="CodeHealth MCP" `
   #           --include-data-dir=./src/docs=src/docs `
   #           --include-data-files=./cs.exe=cs `
   #           --output-filename=cs-mcp.exe `

--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -17,6 +17,14 @@ env:
   CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        run: echo "has-token=${{ secrets.CS_ACCESS_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
   # =============================================================================
   # Docker Integration Tests - Linux
   # =============================================================================
@@ -25,6 +33,8 @@ jobs:
   # - Linux Docker tests provide sufficient coverage for the Docker backend
   # - Static tests still run on macOS to validate core functionality
   docker-integration-linux:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-token == 'true'
     runs-on: ubuntu-22.04
     name: Docker Integration Tests (Linux)
     steps:

--- a/.github/workflows/integration-npm.yml
+++ b/.github/workflows/integration-npm.yml
@@ -17,7 +17,17 @@ env:
   CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        run: echo "has-token=${{ secrets.CS_ACCESS_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
   npm-integration-linux:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-token == 'true'
     runs-on: ubuntu-22.04
     name: NPM Integration Tests (Linux)
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,10 +17,20 @@ env:
   CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-token: ${{ steps.check.outputs.has-token }}
+    steps:
+      - id: check
+        run: echo "has-token=${{ secrets.CS_ACCESS_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
   # =============================================================================
   # Comprehensive Integration Tests - Linux
   # =============================================================================
   integration-linux:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-token == 'true'
     runs-on: ubuntu-22.04
     name: Integration Tests (Linux)
     steps:
@@ -47,6 +57,8 @@ jobs:
   # Comprehensive Integration Tests - macOS (Apple Silicon)
   # =============================================================================
   integration-macos:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-token == 'true'
     runs-on: macos-latest
     name: Integration Tests (macOS)
     steps:
@@ -73,6 +85,8 @@ jobs:
   # Comprehensive Integration Tests - Windows
   # =============================================================================
   integration-windows:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-token == 'true'
     runs-on: x64-windows-8core
     name: Integration Tests (Windows)
     steps:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ create-executable:
 	python3.13 -m nuitka --onefile \
 	--assume-yes-for-downloads \
 	--lto=yes \
+	--company-name="CodeScene AB" \
+	--product-name="CodeHealth MCP" \
 	--noinclude-pytest-mode=nofollow \
 	--noinclude-unittest-mode=nofollow \
 	--noinclude-setuptools-mode=nofollow \

--- a/scripts/build-linux-exe-inner.sh
+++ b/scripts/build-linux-exe-inner.sh
@@ -62,6 +62,8 @@ PY
 "${PYTHON_BIN}" -m nuitka --onefile \
   --assume-yes-for-downloads \
   --lto=yes \
+  --company-name="CodeScene AB" \
+  --product-name="CodeHealth MCP" \
   --noinclude-pytest-mode=nofollow \
   --noinclude-unittest-mode=nofollow \
   --noinclude-setuptools-mode=nofollow \


### PR DESCRIPTION
This pull request introduces improvements to the build and integration workflows, focusing on enhanced executable metadata and better handling of secrets for integration tests. The most important changes are grouped below:

**Executable Build Metadata Enhancements:**

* Added `--company-name="CodeScene AB"` and `--product-name="CodeHealth MCP"` parameters to Nuitka commands in `.github/workflows/build-exe.yml`, `Makefile`, and `scripts/build-linux-exe-inner.sh` to ensure generated executables have proper metadata. [[1]](diffhunk://#diff-e60e3a17adbd20bda8ab268c53c0534f8c29f3b45022af9636a4d61e6721e83eR332-R333) [[2]](diffhunk://#diff-e60e3a17adbd20bda8ab268c53c0534f8c29f3b45022af9636a4d61e6721e83eR400-R401) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R5-R6) [[4]](diffhunk://#diff-3f2c4809b25d1ed593fd6536a29ee4fc64dff142db16af70426b81b77ba37691R65-R66)

**Integration Workflow Secret Handling:**

* Introduced a `check-secrets` job in `.github/workflows/integration-docker.yml`, `.github/workflows/integration-npm.yml`, and `.github/workflows/integration-tests.yml` to detect if the `CS_ACCESS_TOKEN` secret is set and expose its presence as an output. [[1]](diffhunk://#diff-73f4d86236c77cf09fc8a2c59a774da5c45fdeb8daab171feba218585665c4a6R20-R27) [[2]](diffhunk://#diff-6b6ccf84c604c071908fcbc30206db7f411a651d4185c002a880b952b0e29f5cR20-R30) [[3]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R20-R33)
* Updated integration test jobs in all relevant workflow files to depend on `check-secrets` and only run if the token is present, preventing unnecessary failures when secrets are missing. [[1]](diffhunk://#diff-73f4d86236c77cf09fc8a2c59a774da5c45fdeb8daab171feba218585665c4a6R36-R37) [[2]](diffhunk://#diff-6b6ccf84c604c071908fcbc30206db7f411a651d4185c002a880b952b0e29f5cR20-R30) [[3]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R60-R61) [[4]](diffhunk://#diff-4761c5069b46ce96f49d74476da61f43ced3abc73d22254cd95a2be0e250a593R88-R89)