### PR TITLE
Update Homebrew formula to 0.3.4

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.3.3"
+  version "0.3.4"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "52c3363383afa54ce87f63e73f6edf0220b3ee2b101d26ff806114bc8dee0fad"
+      sha256 "ff47db7550c5960a610ce270890f6fdbf30ff398bc2205f59aaeec6882845322"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "b5e3ee67ac8f7474caa4b7c38b5adac909f81d56ac392ae3af8ac53a244d20f8"
+      sha256 "5d00bf35f0c38826fa5e8ba124c2d41e34bc57b0636a3de12e4b6a97e5e793b4"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "d968167ac6275ad5d5feec4b9a65910a9cebca5e540efc8bc0dbe3830b26cc31"
+      sha256 "38a2c567a24bfd0c29e95f614948215d25283ba412d164b5eaea43335a58795b"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "d80df8887f580d8b914b86f2f8127533da68fef04aedd047e387d56f61bfe484"
+      sha256 "eb5a45f17100fb0e68b93b56048b433dfbf9bc1bc513e3a7fd1659a3199d79c1"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 0.3.4.

## Checksums
- macOS ARM64: `ff47db7550c5960a610ce270890f6fdbf30ff398bc2205f59aaeec6882845322`
- macOS AMD64: `5d00bf35f0c38826fa5e8ba124c2d41e34bc57b0636a3de12e4b6a97e5e793b4`
- Linux ARM64: `38a2c567a24bfd0c29e95f614948215d25283ba412d164b5eaea43335a58795b`
- Linux AMD64: `eb5a45f17100fb0e68b93b56048b433dfbf9bc1bc513e3a7fd1659a3199d79c1`