### PR TITLE
Fix Rust analytics tracking request compatibility

### DIFF
--- a/rust/src/tracking.rs
+++ b/rust/src/tracking.rs
@@ -58,25 +58,33 @@ fn build_tracking_body(te: &mut TrackingEvent) -> Value {
 async fn send_event(mut te: TrackingEvent, client: &dyn HttpClient) -> Result<(), String> {
     let body = build_tracking_body(&mut te);
     let token = std::env::var("CS_ACCESS_TOKEN").unwrap_or_default();
+    let mut headers = HashMap::from([
+        ("Content-Type".to_string(), "application/json".to_string()),
+        ("Accept".to_string(), "application/json".to_string()),
+        (
+            "User-Agent".to_string(),
+            format!("codescene-mcp/{}", env!("CS_MCP_VERSION")),
+        ),
+    ]);
+    if !token.is_empty() {
+        headers.insert("Authorization".to_string(), format!("Bearer {token}"));
+    }
 
     let request = HttpRequest {
         method: Method::Post,
         url: te.url.clone(),
-        headers: HashMap::from([
-            ("Authorization".to_string(), format!("Bearer {token}")),
-            ("Content-Type".to_string(), "application/json".to_string()),
-        ]),
+        headers,
         body: Some(serde_json::to_string(&body).unwrap_or_default()),
         timeout_secs: 10,
     };
 
-    client.send(request).await?;
+    let _response = client.send(request).await?;
     Ok(())
 }
 
 fn tracking_url() -> String {
     if let Ok(url) = std::env::var("CS_TRACKING_URL") {
-        return url;
+        return normalize_tracking_override(&url);
     }
 
     let api_url = std::env::var("CS_ONPREM_URL")
@@ -86,8 +94,21 @@ fn tracking_url() -> String {
     format!("{api_url}/v2/analytics/track")
 }
 
+fn normalize_tracking_override(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    if trimmed.ends_with("/v2/analytics/track") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/v2/analytics/track")
+    }
+}
+
 fn is_disabled() -> bool {
-    std::env::var("CS_DISABLE_TRACKING")
+    flag_enabled("CS_DISABLE_TRACKING")
+}
+
+fn flag_enabled(name: &str) -> bool {
+    std::env::var(name)
         .map(|v| !v.is_empty() && v != "0" && v.to_lowercase() != "false")
         .unwrap_or(false)
 }
@@ -157,8 +178,16 @@ mod tests {
     #[test]
     fn tracking_url_override() {
         let _lock = config::lock_test_env();
-        std::env::set_var("CS_TRACKING_URL", "http://custom-tracking/track");
-        assert_eq!(tracking_url(), "http://custom-tracking/track");
+        std::env::set_var("CS_TRACKING_URL", "http://custom-tracking");
+        assert_eq!(tracking_url(), "http://custom-tracking/v2/analytics/track");
+        std::env::remove_var("CS_TRACKING_URL");
+    }
+
+    #[test]
+    fn tracking_url_override_with_full_path_keeps_path() {
+        let _lock = config::lock_test_env();
+        std::env::set_var("CS_TRACKING_URL", "http://custom-tracking/v2/analytics/track");
+        assert_eq!(tracking_url(), "http://custom-tracking/v2/analytics/track");
         std::env::remove_var("CS_TRACKING_URL");
     }
 
@@ -236,12 +265,17 @@ mod tests {
             reqs[0].headers.get("Authorization").unwrap(),
             "Bearer test-tok"
         );
+        assert_eq!(reqs[0].headers.get("Accept").unwrap(), "application/json");
+        assert!(reqs[0]
+            .headers
+            .get("User-Agent")
+            .is_some_and(|v| v.starts_with("codescene-mcp/")));
 
         std::env::remove_var("CS_ACCESS_TOKEN");
     }
 
     #[tokio::test]
-    async fn send_event_uses_empty_bearer_when_no_token() {
+    async fn send_event_omits_authorization_when_no_token() {
         let _lock = config::lock_test_env();
         std::env::remove_var("CS_ACCESS_TOKEN");
 
@@ -259,7 +293,16 @@ mod tests {
         let _ = send_event(te, &mock).await;
 
         let reqs = captured.lock().unwrap();
-        assert_eq!(reqs[0].headers.get("Authorization").unwrap(), "Bearer ");
+        assert!(reqs[0].headers.get("Authorization").is_none());
+        assert_eq!(
+            reqs[0].headers.get("Content-Type").unwrap(),
+            "application/json"
+        );
+        assert_eq!(reqs[0].headers.get("Accept").unwrap(), "application/json");
+        assert!(reqs[0]
+            .headers
+            .get("User-Agent")
+            .is_some_and(|v| v.starts_with("codescene-mcp/")));
     }
 
     #[tokio::test]

--- a/rust/src/tracking.rs
+++ b/rust/src/tracking.rs
@@ -238,14 +238,29 @@ mod tests {
         assert_eq!(body["event-properties"], "not-an-object");
     }
 
-    #[tokio::test]
-    async fn send_event_posts_to_correct_url() {
-        let _lock = config::lock_test_env();
-        std::env::set_var("CS_ACCESS_TOKEN", "test-tok");
+    async fn send_event_and_capture_request(
+        token: Option<&str>,
+        te: TrackingEvent,
+    ) -> crate::http::HttpRequest {
+        match token {
+            Some(value) => std::env::set_var("CS_ACCESS_TOKEN", value),
+            None => std::env::remove_var("CS_ACCESS_TOKEN"),
+        }
 
         let mock = MockHttpClient::always(HttpResponse::ok(""));
         let captured = mock.captured_requests.clone();
 
+        let result = send_event(te, &mock).await;
+        assert!(result.is_ok());
+
+        let reqs = captured.lock().unwrap();
+        assert_eq!(reqs.len(), 1);
+        reqs[0].clone()
+    }
+
+    #[tokio::test]
+    async fn send_event_posts_to_correct_url() {
+        let _lock = config::lock_test_env();
         let te = TrackingEvent {
             url: "http://track.test/v2/analytics/track".to_string(),
             event: "mcp-review".to_string(),
@@ -254,19 +269,16 @@ mod tests {
             version: "1.0.0",
             properties: json!({"key": "val"}),
         };
-        let result = send_event(te, &mock).await;
-        assert!(result.is_ok());
+        let req = send_event_and_capture_request(Some("test-tok"), te).await;
 
-        let reqs = captured.lock().unwrap();
-        assert_eq!(reqs.len(), 1);
-        assert_eq!(reqs[0].url, "http://track.test/v2/analytics/track");
-        assert_eq!(reqs[0].method, Method::Post);
+        assert_eq!(req.url, "http://track.test/v2/analytics/track");
+        assert_eq!(req.method, Method::Post);
         assert_eq!(
-            reqs[0].headers.get("Authorization").unwrap(),
+            req.headers.get("Authorization").unwrap(),
             "Bearer test-tok"
         );
-        assert_eq!(reqs[0].headers.get("Accept").unwrap(), "application/json");
-        assert!(reqs[0]
+        assert_eq!(req.headers.get("Accept").unwrap(), "application/json");
+        assert!(req
             .headers
             .get("User-Agent")
             .is_some_and(|v| v.starts_with("codescene-mcp/")));
@@ -277,11 +289,6 @@ mod tests {
     #[tokio::test]
     async fn send_event_omits_authorization_when_no_token() {
         let _lock = config::lock_test_env();
-        std::env::remove_var("CS_ACCESS_TOKEN");
-
-        let mock = MockHttpClient::always(HttpResponse::ok(""));
-        let captured = mock.captured_requests.clone();
-
         let te = TrackingEvent {
             url: "http://t/track".to_string(),
             event: "mcp-e".to_string(),
@@ -290,16 +297,15 @@ mod tests {
             version: "1.0.0",
             properties: json!({}),
         };
-        let _ = send_event(te, &mock).await;
+        let req = send_event_and_capture_request(None, te).await;
 
-        let reqs = captured.lock().unwrap();
-        assert!(reqs[0].headers.get("Authorization").is_none());
+        assert!(req.headers.get("Authorization").is_none());
         assert_eq!(
-            reqs[0].headers.get("Content-Type").unwrap(),
+            req.headers.get("Content-Type").unwrap(),
             "application/json"
         );
-        assert_eq!(reqs[0].headers.get("Accept").unwrap(), "application/json");
-        assert!(reqs[0]
+        assert_eq!(req.headers.get("Accept").unwrap(), "application/json");
+        assert!(req
             .headers
             .get("User-Agent")
             .is_some_and(|v| v.starts_with("codescene-mcp/")));


### PR DESCRIPTION
This pull request improves the robustness and correctness of tracking event HTTP requests, particularly around header construction and tracking URL overrides. It also enhances test coverage to ensure proper behavior in these areas.

**Improvements to HTTP request headers:**

* Refactored header construction in `send_event` to always include `Content-Type`, `Accept`, and a versioned `User-Agent` header, and to include the `Authorization` header only if a token is set.
* Updated tests to verify the presence and correctness of these headers, ensuring `Authorization` is omitted when no token is set, and that the `User-Agent` is correctly formatted. [[1]](diffhunk://#diff-c65d62bcbe674b4b4db59f3c52e987584fb3c45d1eaa060ebf07909bdf5e0530R268-R278) [[2]](diffhunk://#diff-c65d62bcbe674b4b4db59f3c52e987584fb3c45d1eaa060ebf07909bdf5e0530L262-R305)

**Enhancements to tracking URL handling:**

* Added the `normalize_tracking_override` function to ensure that the tracking URL override always ends with `/v2/analytics/track`, regardless of user input.
* Expanded tests to cover both cases: when the override is a base URL and when it already includes the full path.

**Other improvements:**

* Refactored the tracking disable check to use a new `flag_enabled` helper for improved clarity and reuse.