### PR TITLE
Update Homebrew formula to 1.0.0

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "0.3.7"
+  version "1.0.0"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "068f61937e3a977c162e7d0b6ee7d0f038fa16052ef6911e51cdf7d594ef3b3f"
+      sha256 "e83d2b01a8ece68b202c30938258deaffe1a058669d1de3d518b6e72f3c7fc6c"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "659a4eef39224b8649931f2cc53ab6a788f9bdd467c586898972bf353809fc75"
+      sha256 "0f7cff01b87c8eeafb8761320cf2f001a55c28c3ce2e71b4530342d02f71eba5"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "9032360c3e6a7f4218092814b2ea5b884d89f402f1c7d605518f33fde22d90d6"
+      sha256 "51595c8d02137659304f45e2cd131595ae955d29b65a964cbe2cbe1609b6dd38"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "95e95067a0922be66a8e63a92d31db88db0b88f38c562eead640fc098340edd0"
+      sha256 "2452d74f7142ed3151ed44f2f15cc7bedc835bbd39b38cc38e4294b430de22ce"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.0.0.

## Checksums
- macOS ARM64: `e83d2b01a8ece68b202c30938258deaffe1a058669d1de3d518b6e72f3c7fc6c`
- macOS AMD64: `0f7cff01b87c8eeafb8761320cf2f001a55c28c3ce2e71b4530342d02f71eba5`
- Linux ARM64: `51595c8d02137659304f45e2cd131595ae955d29b65a964cbe2cbe1609b6dd38`
- Linux AMD64: `2452d74f7142ed3151ed44f2f15cc7bedc835bbd39b38cc38e4294b430de22ce`