### PR TITLE
Update Homebrew formula to 1.0.2

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.0.1"
+  version "1.0.2"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "ef7ef2f4dcb2171f1ff5aef38bba359fc76f4064f147ca402f6f7ee1ca0dd016"
+      sha256 "7330660010ea37b035f0baf477a306fa332d3e5e4c07b665be8010b87f07b84d"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "094c41530e65ecf99925fa188f28e1c4f12577b43c98672b3e4b5db6f66eb732"
+      sha256 "a53fee7b77320015f3e918e83a190f10d05712cd5861f30ddc32d381e37f780b"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "2c097f1e3063e71c71d97abbd4a8430f29a6a227e79e07df723077a2860943a2"
+      sha256 "7330584002074d2826045585e1c5f0648057e6dde71b4c17ca1ded9d80f0adb6"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "3705dbe050ff3a8381a6f97c0d370cd41b76f217ca6a9a83d4ca445e50dd53c3"
+      sha256 "4a4ea2d5d58893dad99378f3792708f8116a16b7b7fdf36c504cde8702a86513"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.0.2.

## Checksums
- macOS ARM64: `7330660010ea37b035f0baf477a306fa332d3e5e4c07b665be8010b87f07b84d`
- macOS AMD64: `a53fee7b77320015f3e918e83a190f10d05712cd5861f30ddc32d381e37f780b`
- Linux ARM64: `7330584002074d2826045585e1c5f0648057e6dde71b4c17ca1ded9d80f0adb6`
- Linux AMD64: `4a4ea2d5d58893dad99378f3792708f8116a16b7b7fdf36c504cde8702a86513`