### PR TITLE
Update Homebrew formula to 1.0.3

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.0.2"
+  version "1.0.3"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "7330660010ea37b035f0baf477a306fa332d3e5e4c07b665be8010b87f07b84d"
+      sha256 "71eb87b93a66017af7e05eb5a5c3a3124609ad6378bd8944a229bbe40018ccca"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "a53fee7b77320015f3e918e83a190f10d05712cd5861f30ddc32d381e37f780b"
+      sha256 "18696b7369f84f527a21b603b15cbbfb0c4ab2c94f6d2d4e096d779b42024feb"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "7330584002074d2826045585e1c5f0648057e6dde71b4c17ca1ded9d80f0adb6"
+      sha256 "d62819e5ae05d14a103323f834af93f8f844ec72472bcd60d2269e546205513c"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "4a4ea2d5d58893dad99378f3792708f8116a16b7b7fdf36c504cde8702a86513"
+      sha256 "14f0cdc5a57d4a4dc3832ce05d46451441cd5d53c622c4d89a96a42c8c553781"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.0.3.

## Checksums
- macOS ARM64: `71eb87b93a66017af7e05eb5a5c3a3124609ad6378bd8944a229bbe40018ccca`
- macOS AMD64: `18696b7369f84f527a21b603b15cbbfb0c4ab2c94f6d2d4e096d779b42024feb`
- Linux ARM64: `d62819e5ae05d14a103323f834af93f8f844ec72472bcd60d2269e546205513c`
- Linux AMD64: `14f0cdc5a57d4a4dc3832ce05d46451441cd5d53c622c4d89a96a42c8c553781`