### PR TITLE
feat: add `enabled_tools` config to control which MCP tools are exposed

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -411,7 +411,7 @@ Changes to this setting require a server restart to take effect.
 | `code_health_refactoring_business_case` | Quantified business case for refactoring |
 | `code_health_auto_refactor` | AI-assisted auto-refactoring (requires ACE) |
 
-**API tools** — require a CodeScene instance and `access_token`:
+**API tools** — require CodeScene Cloud or CodeScene On-prem:
 
 | Tool name | Description |
 |-----------|-------------|

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -380,3 +380,113 @@ If you have multiple certificates or a certificate bundle directory, mount the e
 - The certificate file must be in PEM format (the standard format with `-----BEGIN CERTIFICATE-----` headers)
 - The path must be accessible to the MCP server process (or mounted into the container for Docker)
 - If your certificate chain includes intermediate certificates, include them all in the same file
+
+## `enabled_tools`
+
+| | |
+|---|---|
+| **Environment variable** | `CS_ENABLED_TOOLS` |
+| **Sensitive** | No |
+
+Controls which MCP tools the server exposes to the AI assistant. When set, only the listed tools are registered — all others are hidden. When unset or empty, all tools are enabled (the default behavior).
+
+This is useful for reducing token usage by limiting the number of tool descriptions sent to the AI model. Each exposed tool adds to the prompt context, so disabling tools you don't need can lower costs and improve response times.
+
+The `get_config` and `set_config` tools are always enabled and cannot be disabled. This prevents accidental lockout from the configuration system.
+
+Changes to this setting require a server restart to take effect.
+
+### Available tool names
+
+| Tool name | Description |
+|-----------|-------------|
+| `explain_code_health` | Explains the Code Health metric |
+| `explain_code_health_productivity` | Explains Code Health productivity impact |
+| `code_health_review` | Detailed Code Health review of a file |
+| `code_health_score` | Quick numeric Code Health score for a file |
+| `pre_commit_code_health_safeguard` | Pre-commit check for Code Health regressions |
+| `analyze_change_set` | Branch-level Code Health analysis (PR pre-flight) |
+| `code_health_refactoring_business_case` | Quantified business case for refactoring |
+| `code_health_auto_refactor` | AI-assisted auto-refactoring (requires ACE) |
+| `select_project` | List and select CodeScene projects |
+| `list_technical_debt_goals_for_project` | Technical debt goals for a project |
+| `list_technical_debt_goals_for_project_file` | Technical debt goals for a specific file |
+| `list_technical_debt_hotspots_for_project` | Technical debt hotspots for a project |
+| `list_technical_debt_hotspots_for_project_file` | Technical debt hotspots for a specific file |
+| `code_ownership_for_path` | Code ownership lookup for a file or directory |
+
+### Examples
+
+To enable only the local Code Health analysis tools (no project-level features):
+
+**Example — npx:**
+
+```json
+{
+  "servers": {
+    "codescene": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@codescene/codehealth-mcp"],
+      "env": {
+        "CS_ACCESS_TOKEN": "your-token-here",
+        "CS_ENABLED_TOOLS": "code_health_review,code_health_score,pre_commit_code_health_safeguard,analyze_change_set"
+      }
+    }
+  }
+}
+```
+
+**Example — Static binary (Homebrew / Windows):**
+
+```json
+{
+  "servers": {
+    "codescene": {
+      "type": "stdio",
+      "command": "cs-mcp",
+      "env": {
+        "CS_ACCESS_TOKEN": "your-token-here",
+        "CS_ENABLED_TOOLS": "code_health_review,code_health_score,pre_commit_code_health_safeguard,analyze_change_set"
+      }
+    }
+  }
+}
+```
+
+**Example — Docker:**
+
+```json
+{
+  "servers": {
+    "codescene": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "CS_ACCESS_TOKEN",
+        "-e", "CS_ENABLED_TOOLS",
+        "-e", "CS_MOUNT_PATH=/path/to/your/code",
+        "--mount", "type=bind,src=/path/to/your/code,dst=/mount/,ro",
+        "codescene/codescene-mcp"
+      ],
+      "env": {
+        "CS_ACCESS_TOKEN": "your-token-here",
+        "CS_ENABLED_TOOLS": "code_health_review,code_health_score,pre_commit_code_health_safeguard,analyze_change_set"
+      }
+    }
+  }
+}
+```
+
+You can also set this interactively via the AI assistant:
+
+> "Only enable code_health_review, code_health_score, and analyze_change_set"
+
+Or use `set_config` directly:
+
+> "Set enabled_tools to code_health_review,code_health_score,analyze_change_set"
+
+To re-enable all tools, set the value to an empty string:
+
+> "Clear the enabled_tools setting"

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -398,6 +398,8 @@ Changes to this setting require a server restart to take effect.
 
 ### Available tool names
 
+**Standalone tools** — work without a CodeScene API connection:
+
 | Tool name | Description |
 |-----------|-------------|
 | `explain_code_health` | Explains the Code Health metric |
@@ -408,12 +410,19 @@ Changes to this setting require a server restart to take effect.
 | `analyze_change_set` | Branch-level Code Health analysis (PR pre-flight) |
 | `code_health_refactoring_business_case` | Quantified business case for refactoring |
 | `code_health_auto_refactor` | AI-assisted auto-refactoring (requires ACE) |
+
+**API tools** — require a CodeScene instance and `access_token`:
+
+| Tool name | Description |
+|-----------|-------------|
 | `select_project` | List and select CodeScene projects |
 | `list_technical_debt_goals_for_project` | Technical debt goals for a project |
 | `list_technical_debt_goals_for_project_file` | Technical debt goals for a specific file |
 | `list_technical_debt_hotspots_for_project` | Technical debt hotspots for a project |
 | `list_technical_debt_hotspots_for_project_file` | Technical debt hotspots for a specific file |
 | `code_ownership_for_path` | Code ownership lookup for a file or directory |
+
+In standalone mode (no `access_token`), the API tools are automatically removed regardless of the `enabled_tools` setting.
 
 ### Examples
 

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -422,7 +422,7 @@ Changes to this setting require a server restart to take effect.
 | `list_technical_debt_hotspots_for_project_file` | Technical debt hotspots for a specific file |
 | `code_ownership_for_path` | Code ownership lookup for a file or directory |
 
-In standalone mode (no `access_token`), the API tools are automatically removed regardless of the `enabled_tools` setting.
+In standalone mode, the API tools are automatically removed regardless of the `enabled_tools` setting.
 
 ### Examples
 

--- a/skills/configuring-codescene-mcp/SKILL.md
+++ b/skills/configuring-codescene-mcp/SKILL.md
@@ -16,6 +16,7 @@ Use this skill when the task is to configure the CodeScene MCP Server after it h
 - The user wants to enable ACE auto-refactoring.
 - The user wants to pre-select a default CodeScene project.
 - The user needs to configure a custom CA certificate for SSL/TLS.
+- The user wants to limit which tools are exposed to reduce token usage (`enabled_tools`).
 - The user asks what their current configuration is.
 - The user is troubleshooting a configuration issue (wrong token, missing URL, SSL errors).
 
@@ -37,6 +38,7 @@ Do not use this skill for installing or registering the MCP server in an AI assi
 | `ace_access_token` | Token for CodeScene ACE auto-refactoring (add-on license). |
 | `default_project_id` | Pre-select a CodeScene project by numeric ID (API-mode only). |
 | `ca_bundle` | Path to a custom PEM-format CA certificate bundle. |
+| `enabled_tools` | Comma-separated allowlist of tool names to expose (empty = all). |
 
 ### Precedence
 
@@ -68,3 +70,6 @@ For individual, interactive use, prefer the `set_config` tool.
 - Confusing the config key name with the environment variable name. Use the short key (e.g., `access_token`) with `set_config`, not the env var name (`CS_ACCESS_TOKEN`).
 - Setting `onprem_url` or `default_project_id` when using a standalone license. These options are only available with a CodeScene Personal Access Token.
 - Providing a CA bundle path that is not accessible to the MCP server process or Docker container.
+- Setting `enabled_tools` with misspelled tool names. The server warns about unknown names, but the misspelled tools are silently ignored. Use `get_config` with key `enabled_tools` to see the list of available tool names.
+- Forgetting that `enabled_tools` changes require a server restart. The tool list is built once at startup.
+- Trying to disable `get_config` or `set_config` via `enabled_tools`. These tools are always enabled to prevent configuration lockout.

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,35 @@ pub const OPTIONS: &[ConfigOption] = &[
         aliases: &["ssl_cert", "cert"],
         docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
     },
+    ConfigOption {
+        key: "enabled_tools",
+        env_var: "CS_ENABLED_TOOLS",
+        description: "Comma-separated allowlist of tool names to enable (unset = all enabled). Requires restart.",
+        sensitive: false,
+        hidden: false,
+        api_only: false,
+        aliases: &["tools"],
+        docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
+    },
+];
+
+/// Tool names that can be enabled/disabled via the `enabled_tools` config.
+/// Excludes `get_config` and `set_config` which are always available.
+pub const CONFIGURABLE_TOOL_NAMES: &[&str] = &[
+    "explain_code_health",
+    "explain_code_health_productivity",
+    "code_health_review",
+    "code_health_score",
+    "pre_commit_code_health_safeguard",
+    "analyze_change_set",
+    "code_health_refactoring_business_case",
+    "code_health_auto_refactor",
+    "select_project",
+    "list_technical_debt_goals_for_project",
+    "list_technical_debt_goals_for_project_file",
+    "list_technical_debt_hotspots_for_project",
+    "list_technical_debt_hotspots_for_project_file",
+    "code_ownership_for_path",
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -271,6 +300,24 @@ pub fn config_file_path() -> PathBuf {
 #[allow(dead_code)]
 pub fn is_valid_key(key: &str) -> bool {
     find_option(key).is_some()
+}
+
+/// Parse the `enabled_tools` config value into a set of tool names.
+/// Returns `None` when unset or empty (meaning all tools are enabled).
+pub fn enabled_tools(data: &ConfigData) -> Option<HashSet<String>> {
+    let option = find_option("enabled_tools")?;
+    let value = get_effective(option, data)?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(
+        trimmed
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+    )
 }
 
 /// Mask sensitive values for display.
@@ -673,5 +720,108 @@ mod tests {
 
         // Cleanup
         std::env::remove_var("CS_DISABLE_TRACKING");
+    }
+
+    // ---- enabled_tools ----
+
+    #[test]
+    fn enabled_tools_returns_none_when_unset() {
+        let data = ConfigData::default();
+        assert!(enabled_tools(&data).is_none());
+    }
+
+    #[test]
+    fn enabled_tools_returns_none_when_empty() {
+        let mut data = ConfigData::default();
+        data.values
+            .insert("enabled_tools".to_string(), "".to_string());
+        assert!(enabled_tools(&data).is_none());
+    }
+
+    #[test]
+    fn enabled_tools_returns_none_when_whitespace_only() {
+        let mut data = ConfigData::default();
+        data.values
+            .insert("enabled_tools".to_string(), "  ".to_string());
+        assert!(enabled_tools(&data).is_none());
+    }
+
+    #[test]
+    fn enabled_tools_parses_single_tool() {
+        let mut data = ConfigData::default();
+        data.values.insert(
+            "enabled_tools".to_string(),
+            "code_health_review".to_string(),
+        );
+        let result = enabled_tools(&data).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result.contains("code_health_review"));
+    }
+
+    #[test]
+    fn enabled_tools_parses_multiple_tools() {
+        let mut data = ConfigData::default();
+        data.values.insert(
+            "enabled_tools".to_string(),
+            "code_health_review,code_health_score,analyze_change_set".to_string(),
+        );
+        let result = enabled_tools(&data).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(result.contains("code_health_review"));
+        assert!(result.contains("code_health_score"));
+        assert!(result.contains("analyze_change_set"));
+    }
+
+    #[test]
+    fn enabled_tools_trims_whitespace() {
+        let mut data = ConfigData::default();
+        data.values.insert(
+            "enabled_tools".to_string(),
+            " code_health_review , code_health_score ".to_string(),
+        );
+        let result = enabled_tools(&data).unwrap();
+        assert_eq!(result.len(), 2);
+        assert!(result.contains("code_health_review"));
+        assert!(result.contains("code_health_score"));
+    }
+
+    #[test]
+    fn enabled_tools_ignores_empty_segments() {
+        let mut data = ConfigData::default();
+        data.values.insert(
+            "enabled_tools".to_string(),
+            "code_health_review,,code_health_score,".to_string(),
+        );
+        let result = enabled_tools(&data).unwrap();
+        assert_eq!(result.len(), 2);
+    }
+
+    // ---- CONFIGURABLE_TOOL_NAMES ----
+
+    #[test]
+    fn configurable_tool_names_excludes_config_tools() {
+        assert!(!CONFIGURABLE_TOOL_NAMES.contains(&"get_config"));
+        assert!(!CONFIGURABLE_TOOL_NAMES.contains(&"set_config"));
+    }
+
+    #[test]
+    fn configurable_tool_names_includes_core_tools() {
+        assert!(CONFIGURABLE_TOOL_NAMES.contains(&"code_health_review"));
+        assert!(CONFIGURABLE_TOOL_NAMES.contains(&"code_health_score"));
+        assert!(CONFIGURABLE_TOOL_NAMES.contains(&"analyze_change_set"));
+    }
+
+    #[test]
+    fn find_option_enabled_tools() {
+        let opt = find_option("enabled_tools");
+        assert!(opt.is_some());
+        assert_eq!(opt.unwrap().env_var, "CS_ENABLED_TOOLS");
+    }
+
+    #[test]
+    fn find_option_enabled_tools_by_alias() {
+        let opt = find_option("tools");
+        assert!(opt.is_some());
+        assert_eq!(opt.unwrap().key, "enabled_tools");
     }
 }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -12,7 +12,10 @@ pub fn get_single(key: &str, data: &ConfigData, is_standalone: bool) -> String {
         return api_only_error(key, is_standalone);
     }
 
-    let result = format_option_json(option, data);
+    let mut result = format_option_json(option, data);
+    if option.key == "enabled_tools" {
+        result["available_tools"] = json!(config::CONFIGURABLE_TOOL_NAMES);
+    }
     serde_json::to_string(&result).unwrap_or_default()
 }
 
@@ -129,6 +132,9 @@ fn save_key(option: &config::ConfigOption, value: &str, data: &mut ConfigData) -
     if let Some(restart) = restart_warning(option.key) {
         result["restart_required"] = json!(restart);
     }
+    if let Some(tool_warning) = unknown_tool_names_warning(option.key, value) {
+        result["tool_name_warning"] = json!(tool_warning);
+    }
     attach_docs_url(&mut result, option);
     serde_json::to_string(&result).unwrap_or_default()
 }
@@ -145,14 +151,36 @@ fn env_override_warning(option: &config::ConfigOption) -> Option<String> {
 }
 
 fn restart_warning(key: &str) -> Option<&'static str> {
-    if key != "access_token" {
+    match key {
+        "access_token" => Some(
+            "Changing the access token may affect which tools are \
+             available (API vs standalone mode). A server restart is required \
+             for tool registration changes to take effect.",
+        ),
+        "enabled_tools" => {
+            Some("A server restart is required for tool registration changes to take effect.")
+        }
+        _ => None,
+    }
+}
+
+fn unknown_tool_names_warning(key: &str, value: &str) -> Option<String> {
+    if key != "enabled_tools" || value.is_empty() {
         return None;
     }
-    Some(
-        "Changing the access token may affect which tools are \
-         available (API vs standalone mode). A server restart is required \
-         for tool registration changes to take effect.",
-    )
+    let unknown: Vec<&str> = value
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && !config::CONFIGURABLE_TOOL_NAMES.contains(s))
+        .collect();
+    if unknown.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "Unrecognized tool name(s): {}. Valid names: {}",
+        unknown.join(", "),
+        config::CONFIGURABLE_TOOL_NAMES.join(", "),
+    ))
 }
 
 fn attach_docs_url(result: &mut serde_json::Value, option: &config::ConfigOption) {
@@ -481,6 +509,108 @@ mod tests {
         std::env::remove_var("CS_CONFIG_DIR");
         result
     }
+
+    // ---- restart_warning for enabled_tools ----
+
+    #[test]
+    fn restart_warning_for_enabled_tools() {
+        let result = restart_warning("enabled_tools");
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("restart"));
+    }
+
+    // ---- unknown_tool_names_warning ----
+
+    #[test]
+    fn unknown_tool_names_warning_returns_none_for_other_keys() {
+        assert!(unknown_tool_names_warning("access_token", "some-value").is_none());
+    }
+
+    #[test]
+    fn unknown_tool_names_warning_returns_none_for_empty_value() {
+        assert!(unknown_tool_names_warning("enabled_tools", "").is_none());
+    }
+
+    #[test]
+    fn unknown_tool_names_warning_returns_none_for_valid_tools() {
+        assert!(unknown_tool_names_warning(
+            "enabled_tools",
+            "code_health_review,code_health_score"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn unknown_tool_names_warning_returns_warning_for_unknown_tools() {
+        let result =
+            unknown_tool_names_warning("enabled_tools", "code_health_review,nonexistent_tool");
+        assert!(result.is_some());
+        let warning = result.unwrap();
+        assert!(warning.contains("nonexistent_tool"));
+        assert!(warning.contains("Unrecognized"));
+    }
+
+    #[test]
+    fn unknown_tool_names_warning_ignores_always_enabled_tools() {
+        // get_config and set_config are not in CONFIGURABLE_TOOL_NAMES, so they
+        // should be flagged as unknown if someone puts them in the allowlist
+        let result = unknown_tool_names_warning("enabled_tools", "get_config");
+        assert!(result.is_some());
+    }
+
+    // ---- get_single for enabled_tools shows available_tools ----
+
+    #[test]
+    fn get_single_enabled_tools_includes_available_tools() {
+        let data = empty_config();
+        let result = get_single("enabled_tools", &data, false);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed.get("available_tools").is_some());
+        let tools = parsed["available_tools"].as_array().unwrap();
+        assert!(tools.len() > 0);
+        // Should include configurable tools
+        assert!(tools
+            .iter()
+            .any(|t| t.as_str() == Some("code_health_review")));
+        // Should NOT include always-on tools
+        assert!(!tools.iter().any(|t| t.as_str() == Some("get_config")));
+    }
+
+    // ---- set_value for enabled_tools ----
+
+    #[test]
+    fn set_value_enabled_tools_includes_restart_warning() {
+        with_temp_config_dir(|| {
+            let result = set_value("enabled_tools", "code_health_review,code_health_score");
+            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+            assert_eq!(parsed["status"], json!("saved"));
+            assert!(parsed.get("restart_required").is_some());
+        });
+    }
+
+    #[test]
+    fn set_value_enabled_tools_with_unknown_name_includes_warning() {
+        with_temp_config_dir(|| {
+            let result = set_value("enabled_tools", "code_health_review,bogus_tool");
+            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+            assert_eq!(parsed["status"], json!("saved"));
+            assert!(parsed.get("tool_name_warning").is_some());
+            let warning = parsed["tool_name_warning"].as_str().unwrap();
+            assert!(warning.contains("bogus_tool"));
+        });
+    }
+
+    #[test]
+    fn set_value_enabled_tools_valid_names_no_tool_warning() {
+        with_temp_config_dir(|| {
+            let result = set_value("enabled_tools", "code_health_review,code_health_score");
+            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+            assert_eq!(parsed["status"], json!("saved"));
+            assert!(parsed.get("tool_name_warning").is_none());
+        });
+    }
+
+    // ---- save failure paths ----
 
     #[test]
     fn save_key_returns_error_when_save_fails() {

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -129,10 +129,10 @@ fn save_key(option: &config::ConfigOption, value: &str, data: &mut ConfigData) -
     if let Some(warning) = env_override_warning(option) {
         result["warning"] = json!(warning);
     }
-    if let Some(restart) = restart_warning(option.key) {
+    if let Some(restart) = restart_warning(option) {
         result["restart_required"] = json!(restart);
     }
-    if let Some(tool_warning) = unknown_tool_names_warning(option.key, value) {
+    if let Some(tool_warning) = unknown_tool_names_warning(option, value) {
         result["tool_name_warning"] = json!(tool_warning);
     }
     attach_docs_url(&mut result, option);
@@ -150,8 +150,8 @@ fn env_override_warning(option: &config::ConfigOption) -> Option<String> {
     ))
 }
 
-fn restart_warning(key: &str) -> Option<&'static str> {
-    match key {
+fn restart_warning(option: &config::ConfigOption) -> Option<&'static str> {
+    match option.key {
         "access_token" => Some(
             "Changing the access token may affect which tools are \
              available (API vs standalone mode). A server restart is required \
@@ -164,8 +164,8 @@ fn restart_warning(key: &str) -> Option<&'static str> {
     }
 }
 
-fn unknown_tool_names_warning(key: &str, value: &str) -> Option<String> {
-    if key != "enabled_tools" || value.is_empty() {
+fn unknown_tool_names_warning(option: &config::ConfigOption, value: &str) -> Option<String> {
+    if option.key != "enabled_tools" || value.is_empty() {
         return None;
     }
     let unknown: Vec<&str> = value
@@ -352,13 +352,16 @@ mod tests {
 
     #[test]
     fn restart_warning_for_access_token() {
-        assert!(restart_warning("access_token").is_some());
+        let option = config::find_option("access_token").unwrap();
+        assert!(restart_warning(option).is_some());
     }
 
     #[test]
     fn restart_warning_for_other_key() {
-        assert!(restart_warning("onprem_url").is_none());
-        assert!(restart_warning("ca_bundle").is_none());
+        let onprem = config::find_option("onprem_url").unwrap();
+        let ca = config::find_option("ca_bundle").unwrap();
+        assert!(restart_warning(onprem).is_none());
+        assert!(restart_warning(ca).is_none());
     }
 
     // ---- attach_docs_url ----
@@ -514,7 +517,8 @@ mod tests {
 
     #[test]
     fn restart_warning_for_enabled_tools() {
-        let result = restart_warning("enabled_tools");
+        let option = config::find_option("enabled_tools").unwrap();
+        let result = restart_warning(option);
         assert!(result.is_some());
         assert!(result.unwrap().contains("restart"));
     }
@@ -523,27 +527,28 @@ mod tests {
 
     #[test]
     fn unknown_tool_names_warning_returns_none_for_other_keys() {
-        assert!(unknown_tool_names_warning("access_token", "some-value").is_none());
+        let option = config::find_option("access_token").unwrap();
+        assert!(unknown_tool_names_warning(option, "some-value").is_none());
     }
 
     #[test]
     fn unknown_tool_names_warning_returns_none_for_empty_value() {
-        assert!(unknown_tool_names_warning("enabled_tools", "").is_none());
+        let option = config::find_option("enabled_tools").unwrap();
+        assert!(unknown_tool_names_warning(option, "").is_none());
     }
 
     #[test]
     fn unknown_tool_names_warning_returns_none_for_valid_tools() {
-        assert!(unknown_tool_names_warning(
-            "enabled_tools",
-            "code_health_review,code_health_score"
-        )
-        .is_none());
+        let option = config::find_option("enabled_tools").unwrap();
+        assert!(
+            unknown_tool_names_warning(option, "code_health_review,code_health_score").is_none()
+        );
     }
 
     #[test]
     fn unknown_tool_names_warning_returns_warning_for_unknown_tools() {
-        let result =
-            unknown_tool_names_warning("enabled_tools", "code_health_review,nonexistent_tool");
+        let option = config::find_option("enabled_tools").unwrap();
+        let result = unknown_tool_names_warning(option, "code_health_review,nonexistent_tool");
         assert!(result.is_some());
         let warning = result.unwrap();
         assert!(warning.contains("nonexistent_tool"));
@@ -554,7 +559,8 @@ mod tests {
     fn unknown_tool_names_warning_ignores_always_enabled_tools() {
         // get_config and set_config are not in CONFIGURABLE_TOOL_NAMES, so they
         // should be flagged as unknown if someone puts them in the allowlist
-        let result = unknown_tool_names_warning("enabled_tools", "get_config");
+        let option = config::find_option("enabled_tools").unwrap();
+        let result = unknown_tool_names_warning(option, "get_config");
         assert!(result.is_some());
     }
 
@@ -582,6 +588,7 @@ mod tests {
     fn set_value_enabled_tools_includes_restart_warning() {
         with_temp_config_dir(|| {
             let result = set_value("enabled_tools", "code_health_review,code_health_score");
+            std::env::remove_var("CS_ENABLED_TOOLS");
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("restart_required").is_some());
@@ -592,6 +599,7 @@ mod tests {
     fn set_value_enabled_tools_with_unknown_name_includes_warning() {
         with_temp_config_dir(|| {
             let result = set_value("enabled_tools", "code_health_review,bogus_tool");
+            std::env::remove_var("CS_ENABLED_TOOLS");
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("tool_name_warning").is_some());
@@ -604,6 +612,7 @@ mod tests {
     fn set_value_enabled_tools_valid_names_no_tool_warning() {
         with_temp_config_dir(|| {
             let result = set_value("enabled_tools", "code_health_review,code_health_score");
+            std::env::remove_var("CS_ENABLED_TOOLS");
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("tool_name_warning").is_none());

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,9 @@ const API_ONLY_TOOLS: &[&str] = &[
     "code_ownership_for_path",
 ];
 
+/// Tools that cannot be disabled via `enabled_tools` config.
+const ALWAYS_ENABLED_TOOLS: &[&str] = &["get_config", "set_config"];
+
 #[derive(Debug)]
 enum CliAction {
     RunServer,
@@ -178,6 +181,20 @@ impl CodeSceneServer {
         if deps.is_standalone {
             for name in API_ONLY_TOOLS {
                 router.remove_route(name);
+            }
+        }
+
+        // Filter tools based on enabled_tools allowlist
+        if let Some(enabled) = config::enabled_tools(&deps.config_data) {
+            let all_names: Vec<String> = router
+                .list_all()
+                .iter()
+                .map(|t| t.name.to_string())
+                .collect();
+            for name in all_names {
+                if !ALWAYS_ENABLED_TOOLS.contains(&name.as_str()) && !enabled.contains(&name) {
+                    router.remove_route(&name);
+                }
             }
         }
 
@@ -379,7 +396,10 @@ impl ServerHandler for CodeSceneServer {
             "codescene-mcp-server",
             env!("CS_MCP_VERSION"),
         ))
-        .with_instructions(build_instructions(self.is_standalone))
+        .with_instructions(build_instructions(
+            self.is_standalone,
+            config::enabled_tools(&self.config_data).is_some(),
+        ))
     }
 
     async fn list_resources(
@@ -480,7 +500,7 @@ fn resolve_resource_content(uri: &str) -> Result<&'static str, ErrorData> {
     }
 }
 
-fn build_instructions(is_standalone: bool) -> String {
+fn build_instructions(is_standalone: bool, tools_filtered: bool) -> String {
     let mut text = String::from(
         "CodeScene MCP Server - Code Health analysis tools for AI-assisted development.\n\n\
          TOOLS (always available):\n\
@@ -504,6 +524,13 @@ fn build_instructions(is_standalone: bool) -> String {
              - list_technical_debt_hotspots_for_project: View hotspots.\n\
              - list_technical_debt_hotspots_for_project_file: File-level hotspots.\n\
              - code_ownership_for_path: Find code owners.\n",
+        );
+    }
+
+    if tools_filtered {
+        text.push_str(
+            "\nNote: Tool availability is restricted by the 'enabled_tools' configuration. \
+             Use get_config with key 'enabled_tools' to see the current setting.\n",
         );
     }
 
@@ -912,17 +939,128 @@ mod tests {
 
     #[test]
     fn build_instructions_standalone_omits_api_tools() {
-        let text = build_instructions(true);
+        let text = build_instructions(true, false);
         assert!(text.contains("code_health_review"));
         assert!(!text.contains("select_project"));
     }
 
     #[test]
     fn build_instructions_api_mode_includes_all_tools() {
-        let text = build_instructions(false);
+        let text = build_instructions(false, false);
         assert!(text.contains("code_health_review"));
         assert!(text.contains("select_project"));
         assert!(text.contains("code_ownership_for_path"));
+    }
+
+    #[test]
+    fn build_instructions_tools_filtered_adds_note() {
+        let text = build_instructions(false, true);
+        assert!(text.contains("enabled_tools"));
+        assert!(text.contains("restricted"));
+    }
+
+    #[test]
+    fn build_instructions_tools_not_filtered_no_note() {
+        let text = build_instructions(false, false);
+        assert!(!text.contains("restricted"));
+    }
+
+    // --- Tool filtering via enabled_tools ---
+
+    fn tool_names(server: &CodeSceneServer) -> Vec<String> {
+        server
+            .tool_router
+            .list_all()
+            .iter()
+            .map(|t| t.name.to_string())
+            .collect()
+    }
+
+    fn make_server_with_enabled_tools(
+        is_standalone: bool,
+        enabled_tools: &str,
+    ) -> CodeSceneServer {
+        let mut values = HashMap::new();
+        values.insert("enabled_tools".to_string(), enabled_tools.to_string());
+        CodeSceneServer::new(ServerDeps {
+            config_data: ConfigData {
+                instance_id: Some("test-filter".to_string()),
+                values,
+            },
+            instance_id: "test-filter".to_string(),
+            is_standalone,
+            version_checker: VersionChecker::new("dev"),
+            cli_runner: Arc::new(cli::ProductionCliRunner),
+            http_client: Arc::new(http::ReqwestClient),
+        })
+    }
+
+    #[test]
+    fn enabled_tools_unset_keeps_all_tools() {
+        let _lock = config::lock_test_env();
+        std::env::remove_var("CS_ENABLED_TOOLS");
+        let server = make_server(false);
+        let names = tool_names(&server);
+        // All 16 tools should be present
+        assert_eq!(names.len(), 16, "expected 16 tools, got: {:?}", names);
+        assert!(names.contains(&"get_config".to_string()));
+        assert!(names.contains(&"set_config".to_string()));
+        assert!(names.contains(&"code_health_review".to_string()));
+        assert!(names.contains(&"select_project".to_string()));
+    }
+
+    #[test]
+    fn enabled_tools_filters_to_allowlist() {
+        let _lock = config::lock_test_env();
+        std::env::remove_var("CS_ENABLED_TOOLS");
+        let server =
+            make_server_with_enabled_tools(false, "code_health_review,code_health_score");
+        let names = tool_names(&server);
+        // Should have the 2 enabled tools + 2 always-on = 4
+        assert_eq!(names.len(), 4, "expected 4 tools, got: {:?}", names);
+        assert!(names.contains(&"code_health_review".to_string()));
+        assert!(names.contains(&"code_health_score".to_string()));
+        assert!(names.contains(&"get_config".to_string()));
+        assert!(names.contains(&"set_config".to_string()));
+    }
+
+    #[test]
+    fn enabled_tools_cannot_remove_config_tools() {
+        let _lock = config::lock_test_env();
+        std::env::remove_var("CS_ENABLED_TOOLS");
+        // Only enable one tool — config tools must still be present
+        let server = make_server_with_enabled_tools(false, "code_health_review");
+        let names = tool_names(&server);
+        assert!(names.contains(&"get_config".to_string()));
+        assert!(names.contains(&"set_config".to_string()));
+    }
+
+    #[test]
+    fn enabled_tools_combines_with_standalone_filtering() {
+        let _lock = config::lock_test_env();
+        std::env::remove_var("CS_ENABLED_TOOLS");
+        // In standalone mode, API_ONLY_TOOLS are removed first,
+        // then enabled_tools further restricts the list
+        let server =
+            make_server_with_enabled_tools(true, "code_health_review,select_project");
+        let names = tool_names(&server);
+        // select_project is api-only, so removed in standalone even if in enabled_tools
+        assert!(!names.contains(&"select_project".to_string()));
+        assert!(names.contains(&"code_health_review".to_string()));
+        assert!(names.contains(&"get_config".to_string()));
+        assert!(names.contains(&"set_config".to_string()));
+    }
+
+    #[test]
+    fn enabled_tools_single_tool() {
+        let _lock = config::lock_test_env();
+        std::env::remove_var("CS_ENABLED_TOOLS");
+        let server = make_server_with_enabled_tools(false, "analyze_change_set");
+        let names = tool_names(&server);
+        assert_eq!(names.len(), 3, "expected 3 tools, got: {:?}", names);
+        assert!(names.contains(&"analyze_change_set".to_string()));
+        assert!(names.contains(&"get_config".to_string()));
+        assert!(names.contains(&"set_config".to_string()));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,29 +174,40 @@ impl CodeSceneServer {
     }
 }
 
+fn remove_standalone_tools(router: &mut ToolRouter<CodeSceneServer>) {
+    for name in API_ONLY_TOOLS {
+        router.remove_route(name);
+    }
+}
+
+fn apply_enabled_tools_filter(
+    router: &mut ToolRouter<CodeSceneServer>,
+    config_data: &ConfigData,
+) {
+    let enabled = match config::enabled_tools(config_data) {
+        Some(set) => set,
+        None => return,
+    };
+    let all_names: Vec<String> = router
+        .list_all()
+        .iter()
+        .map(|t| t.name.to_string())
+        .collect();
+    for name in all_names {
+        if !ALWAYS_ENABLED_TOOLS.contains(&name.as_str()) && !enabled.contains(&name) {
+            router.remove_route(&name);
+        }
+    }
+}
+
 #[tool_router]
 impl CodeSceneServer {
     fn new(deps: ServerDeps) -> Self {
         let mut router = Self::tool_router();
         if deps.is_standalone {
-            for name in API_ONLY_TOOLS {
-                router.remove_route(name);
-            }
+            remove_standalone_tools(&mut router);
         }
-
-        // Filter tools based on enabled_tools allowlist
-        if let Some(enabled) = config::enabled_tools(&deps.config_data) {
-            let all_names: Vec<String> = router
-                .list_all()
-                .iter()
-                .map(|t| t.name.to_string())
-                .collect();
-            for name in all_names {
-                if !ALWAYS_ENABLED_TOOLS.contains(&name.as_str()) && !enabled.contains(&name) {
-                    router.remove_route(&name);
-                }
-            }
-        }
+        apply_enabled_tools_filter(&mut router, &deps.config_data);
 
         Self {
             tool_router: router,
@@ -995,18 +1006,24 @@ mod tests {
         })
     }
 
+    fn assert_has_config_tools(names: &[String]) {
+        assert!(names.contains(&"get_config".to_string()), "missing get_config");
+        assert!(names.contains(&"set_config".to_string()), "missing set_config");
+    }
+
+    fn assert_tool_count_and_config(names: &[String], expected: usize) {
+        assert_eq!(names.len(), expected, "expected {expected} tools, got: {names:?}");
+        assert_has_config_tools(names);
+    }
+
     #[test]
     fn enabled_tools_unset_keeps_all_tools() {
         let _lock = config::lock_test_env();
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server(false);
         let names = tool_names(&server);
-        // All 16 tools should be present
-        assert_eq!(names.len(), 16, "expected 16 tools, got: {:?}", names);
-        assert!(names.contains(&"get_config".to_string()));
-        assert!(names.contains(&"set_config".to_string()));
+        assert_tool_count_and_config(&names, 16);
         assert!(names.contains(&"code_health_review".to_string()));
-        assert!(names.contains(&"select_project".to_string()));
     }
 
     #[test]
@@ -1017,11 +1034,9 @@ mod tests {
             make_server_with_enabled_tools(false, "code_health_review,code_health_score");
         let names = tool_names(&server);
         // Should have the 2 enabled tools + 2 always-on = 4
-        assert_eq!(names.len(), 4, "expected 4 tools, got: {:?}", names);
+        assert_tool_count_and_config(&names, 4);
         assert!(names.contains(&"code_health_review".to_string()));
         assert!(names.contains(&"code_health_score".to_string()));
-        assert!(names.contains(&"get_config".to_string()));
-        assert!(names.contains(&"set_config".to_string()));
     }
 
     #[test]
@@ -1031,8 +1046,7 @@ mod tests {
         // Only enable one tool — config tools must still be present
         let server = make_server_with_enabled_tools(false, "code_health_review");
         let names = tool_names(&server);
-        assert!(names.contains(&"get_config".to_string()));
-        assert!(names.contains(&"set_config".to_string()));
+        assert_has_config_tools(&names);
     }
 
     #[test]
@@ -1047,8 +1061,7 @@ mod tests {
         // select_project is api-only, so removed in standalone even if in enabled_tools
         assert!(!names.contains(&"select_project".to_string()));
         assert!(names.contains(&"code_health_review".to_string()));
-        assert!(names.contains(&"get_config".to_string()));
-        assert!(names.contains(&"set_config".to_string()));
+        assert_has_config_tools(&names);
     }
 
     #[test]
@@ -1057,10 +1070,8 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server_with_enabled_tools(false, "analyze_change_set");
         let names = tool_names(&server);
-        assert_eq!(names.len(), 3, "expected 3 tools, got: {:?}", names);
+        assert_tool_count_and_config(&names, 3);
         assert!(names.contains(&"analyze_change_set".to_string()));
-        assert!(names.contains(&"get_config".to_string()));
-        assert!(names.contains(&"set_config".to_string()));
     }
 
     #[test]

--- a/tests/integration/run_all_tests.py
+++ b/tests/integration/run_all_tests.py
@@ -445,6 +445,7 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
     from test_business_case import run_business_case_tests_with_backend
     from test_cloudfront_headers import run_cloudfront_headers_tests_with_backend
     from test_configure import run_configure_tests_with_backend
+    from test_enabled_tools import run_enabled_tools_tests_with_backend
     from test_git_subtree import run_subtree_tests_with_backend
     from test_git_worktree import run_worktree_tests_with_backend
     from test_relative_paths import run_relative_path_tests_with_backend
@@ -464,6 +465,7 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
         ("Analyze Change Set Tests", run_analyze_change_set_tests_with_backend),
         ("Standalone License Tests", run_standalone_license_tests_with_backend),
         ("Configure Tests", run_configure_tests_with_backend),
+        ("Enabled Tools Tests", run_enabled_tools_tests_with_backend),
         ("Access Token Guard Tests", run_require_access_token_tests_with_backend),
         ("CloudFront Headers Tests", run_cloudfront_headers_tests_with_backend),
         ("SSL Truststore CLI Tests", run_ssl_cli_truststore_tests_with_backend),

--- a/tests/integration/server_backends.py
+++ b/tests/integration/server_backends.py
@@ -197,6 +197,8 @@ class DockerBackend(ServerBackend):
             "CS_ACE_API_URL",
             "-e",
             "CS_CONFIG_DIR",
+            "-e",
+            "CS_ENABLED_TOOLS",
             "--add-host=host.docker.internal:host-gateway",
             "--mount",
             f"type=bind,src={working_dir},dst={self.CONTAINER_MOUNT_DEST}",

--- a/tests/integration/test_enabled_tools.py
+++ b/tests/integration/test_enabled_tools.py
@@ -17,6 +17,7 @@ This test suite validates:
 
 import os
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -32,6 +33,15 @@ from test_utils import (
     print_test,
     safe_temp_directory,
 )
+
+
+@dataclass
+class ServerContext:
+    """Bundles the three values needed to start an MCP server."""
+
+    command: list[str]
+    env: dict
+    cwd: str
 
 
 # --- Helpers ---
@@ -50,8 +60,8 @@ def _make_config_dir(test_dir: Path) -> Path:
     return config_dir
 
 
-def _start_client(command: list[str], env: dict, cwd: str) -> MCPClient | None:
-    client = MCPClient(command, env=env, cwd=cwd)
+def _start_client(ctx: ServerContext) -> MCPClient | None:
+    client = MCPClient(ctx.command, env=ctx.env, cwd=ctx.cwd)
     if not client.start():
         print_test("Server started", False, client.get_stderr())
         return None
@@ -63,11 +73,11 @@ def _start_client(command: list[str], env: dict, cwd: str) -> MCPClient | None:
 # --- Test functions ---
 
 
-def test_all_tools_without_filter(command: list[str], env: dict, cwd: str) -> bool:
+def test_all_tools_without_filter(ctx: ServerContext) -> bool:
     """Without enabled_tools set, all tools are available."""
     print_header("Test: All Tools Without Filter")
 
-    client = _start_client(command, env, cwd)
+    client = _start_client(ctx)
     if client is None:
         return False
 
@@ -103,16 +113,15 @@ def test_all_tools_without_filter(command: list[str], env: dict, cwd: str) -> bo
         client.stop()
 
 
-def test_filter_restricts_tools(
-    command: list[str], base_env: dict, cwd: str, config_dir: Path,
-) -> bool:
+def test_filter_restricts_tools(ctx: ServerContext, config_dir: Path) -> bool:
     """Setting CS_ENABLED_TOOLS restricts tools/list to the allowlist."""
     print_header("Test: Filter Restricts Tools")
 
-    env = base_env.copy()
+    env = ctx.env.copy()
     env["CS_ENABLED_TOOLS"] = "code_health_review,code_health_score"
+    filtered_ctx = ServerContext(ctx.command, env, ctx.cwd)
 
-    client = _start_client(command, env, cwd)
+    client = _start_client(filtered_ctx)
     if client is None:
         return False
 
@@ -155,17 +164,16 @@ def test_filter_restricts_tools(
         client.stop()
 
 
-def test_config_tools_always_present(
-    command: list[str], base_env: dict, cwd: str, config_dir: Path,
-) -> bool:
+def test_config_tools_always_present(ctx: ServerContext, config_dir: Path) -> bool:
     """get_config and set_config cannot be disabled."""
     print_header("Test: Config Tools Always Present")
 
-    env = base_env.copy()
+    env = ctx.env.copy()
     # Enable only a single non-config tool
     env["CS_ENABLED_TOOLS"] = "explain_code_health"
+    filtered_ctx = ServerContext(ctx.command, env, ctx.cwd)
 
-    client = _start_client(command, env, cwd)
+    client = _start_client(filtered_ctx)
     if client is None:
         return False
 
@@ -189,71 +197,72 @@ def test_config_tools_always_present(
         client.stop()
 
 
-def test_set_enabled_tools_restart_warning(command: list[str], env: dict, cwd: str) -> bool:
+def _test_set_enabled_tools(
+    ctx: ServerContext,
+    value: str,
+    checks: list[tuple[str, str]],
+) -> bool:
+    """Start a client, call set_config for enabled_tools, and verify substrings.
+
+    Args:
+        ctx: Server connection context (command, env, cwd).
+        value: The value to set for enabled_tools.
+        checks: List of (description, substring) pairs. Each substring is checked
+                case-insensitively against the response text.
+    """
+    client = _start_client(ctx)
+    if client is None:
+        return False
+
+    try:
+        resp = client.call_tool(
+            "set_config",
+            {"key": "enabled_tools", "value": value},
+            timeout=30,
+        )
+        text = extract_result_text(resp)
+
+        all_passed = True
+        for description, substring in checks:
+            found = substring.lower() in text.lower()
+            print_test(description, found, text[:200])
+            all_passed = all_passed and found
+        return all_passed
+    except Exception as e:
+        print_test(checks[0][0] if checks else "set_config call", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_set_enabled_tools_restart_warning(ctx: ServerContext) -> bool:
     """Setting enabled_tools via set_config includes a restart warning."""
     print_header("Test: Set Enabled Tools Restart Warning")
-
-    client = _start_client(command, env, cwd)
-    if client is None:
-        return False
-
-    try:
-        resp = client.call_tool(
-            "set_config",
-            {"key": "enabled_tools", "value": "code_health_review,code_health_score"},
-            timeout=30,
-        )
-        text = extract_result_text(resp)
-
-        has_restart = "restart" in text.lower()
-        has_saved = "saved" in text.lower()
-        print_test("Response says saved", has_saved, text[:200])
-        print_test("Restart warning present", has_restart)
-
-        return has_saved and has_restart
-
-    except Exception as e:
-        print_test("Set enabled_tools restart warning", False, str(e))
-        return False
-    finally:
-        client.stop()
+    return _test_set_enabled_tools(
+        ctx,
+        value="code_health_review,code_health_score",
+        checks=[("Response says saved", "saved"), ("Restart warning present", "restart")],
+    )
 
 
-def test_set_invalid_tool_name_warning(command: list[str], env: dict, cwd: str) -> bool:
+def test_set_invalid_tool_name_warning(ctx: ServerContext) -> bool:
     """Setting enabled_tools with unknown tool names includes a warning."""
     print_header("Test: Invalid Tool Name Warning")
-
-    client = _start_client(command, env, cwd)
-    if client is None:
-        return False
-
-    try:
-        resp = client.call_tool(
-            "set_config",
-            {"key": "enabled_tools", "value": "code_health_review,nonexistent_tool"},
-            timeout=30,
-        )
-        text = extract_result_text(resp)
-
-        has_warning = "nonexistent_tool" in text
-        has_unrecognized = "unrecognized" in text.lower()
-        print_test("Warning mentions unknown tool name", has_warning, text[:200])
-        print_test("Warning says unrecognized", has_unrecognized)
-
-        return has_warning and has_unrecognized
-
-    except Exception as e:
-        print_test("Invalid tool name warning", False, str(e))
-        return False
-    finally:
-        client.stop()
+    return _test_set_enabled_tools(
+        ctx,
+        value="code_health_review,nonexistent_tool",
+        checks=[
+            ("Warning mentions unknown tool name", "nonexistent_tool"),
+            ("Warning says unrecognized", "unrecognized"),
+        ],
+    )
 
 
-def test_get_enabled_tools_shows_available(command: list[str], env: dict, cwd: str) -> bool:
+def test_get_enabled_tools_shows_available(ctx: ServerContext) -> bool:
     """Querying enabled_tools via get_config includes available_tools."""
     print_header("Test: Get Enabled Tools Shows Available")
 
-    client = _start_client(command, env, cwd)
+    client = _start_client(ctx)
     if client is None:
         return False
 
@@ -305,14 +314,15 @@ def run_enabled_tools_tests_with_backend(backend: ServerBackend) -> int:
         env = base_env.copy()
         env["CS_CONFIG_DIR"] = str(config_dir)
         cwd = str(repo_dir)
+        ctx = ServerContext(command, env, cwd)
 
         results: list[tuple[str, bool]] = [
-            ("All tools without filter", test_all_tools_without_filter(command, env, cwd)),
-            ("Filter restricts tools", test_filter_restricts_tools(command, env, cwd, config_dir)),
-            ("Config tools always present", test_config_tools_always_present(command, env, cwd, config_dir)),
-            ("Set enabled_tools restart warning", test_set_enabled_tools_restart_warning(command, env, cwd)),
-            ("Invalid tool name warning", test_set_invalid_tool_name_warning(command, env, cwd)),
-            ("Get enabled_tools shows available", test_get_enabled_tools_shows_available(command, env, cwd)),
+            ("All tools without filter", test_all_tools_without_filter(ctx)),
+            ("Filter restricts tools", test_filter_restricts_tools(ctx, config_dir)),
+            ("Config tools always present", test_config_tools_always_present(ctx, config_dir)),
+            ("Set enabled_tools restart warning", test_set_enabled_tools_restart_warning(ctx)),
+            ("Invalid tool name warning", test_set_invalid_tool_name_warning(ctx)),
+            ("Get enabled_tools shows available", test_get_enabled_tools_shows_available(ctx)),
         ]
 
         return print_summary(results)

--- a/tests/integration/test_enabled_tools.py
+++ b/tests/integration/test_enabled_tools.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Enabled tools integration tests.
+
+Tests that the MCP server correctly filters tools based on the
+``enabled_tools`` configuration option.
+
+This test suite validates:
+1. Without ``enabled_tools`` set, all tools are exposed.
+2. When ``enabled_tools`` is set via an environment variable, only those
+   tools (plus get_config/set_config) appear in tools/list.
+3. ``get_config`` and ``set_config`` are always present, even if not listed.
+4. Setting ``enabled_tools`` via ``set_config`` returns a restart warning.
+5. Setting ``enabled_tools`` with invalid tool names returns a warning.
+6. Querying ``enabled_tools`` via ``get_config`` includes ``available_tools``.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from test_utils import (
+    MCPClient,
+    CargoBackend,
+    ServerBackend,
+    create_git_repo,
+    extract_result_text,
+    print_header,
+    print_summary,
+    print_test,
+    safe_temp_directory,
+)
+
+
+# --- Helpers ---
+
+
+def _tool_names(client: MCPClient) -> set[str]:
+    """Return the set of tool names from tools/list."""
+    response = client.send_request("tools/list", timeout=15)
+    tools = response.get("result", {}).get("tools", [])
+    return {t["name"] for t in tools}
+
+
+def _make_config_dir(test_dir: Path) -> Path:
+    config_dir = test_dir / "config"
+    config_dir.mkdir()
+    return config_dir
+
+
+def _start_client(command: list[str], env: dict, cwd: str) -> MCPClient | None:
+    client = MCPClient(command, env=env, cwd=cwd)
+    if not client.start():
+        print_test("Server started", False, client.get_stderr())
+        return None
+    print_test("Server started", True)
+    client.initialize()
+    return client
+
+
+# --- Test functions ---
+
+
+def test_all_tools_without_filter(command: list[str], env: dict, cwd: str) -> bool:
+    """Without enabled_tools set, all tools are available."""
+    print_header("Test: All Tools Without Filter")
+
+    client = _start_client(command, env, cwd)
+    if client is None:
+        return False
+
+    try:
+        names = _tool_names(client)
+
+        has_get_config = "get_config" in names
+        has_set_config = "set_config" in names
+        has_review = "code_health_review" in names
+        has_score = "code_health_score" in names
+        has_explain = "explain_code_health" in names
+
+        print_test("get_config listed", has_get_config)
+        print_test("set_config listed", has_set_config)
+        print_test("code_health_review listed", has_review)
+        print_test("code_health_score listed", has_score)
+        print_test("explain_code_health listed", has_explain)
+
+        # Expect at least 10 tools when unfiltered (standalone has 10, API mode has 16)
+        enough_tools = len(names) >= 10
+        print_test(
+            "At least 10 tools available",
+            enough_tools,
+            f"Found {len(names)} tools",
+        )
+
+        return all([has_get_config, has_set_config, has_review, has_score, has_explain, enough_tools])
+
+    except Exception as e:
+        print_test("All tools without filter", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_filter_restricts_tools(
+    command: list[str], base_env: dict, cwd: str, config_dir: Path,
+) -> bool:
+    """Setting CS_ENABLED_TOOLS restricts tools/list to the allowlist."""
+    print_header("Test: Filter Restricts Tools")
+
+    env = base_env.copy()
+    env["CS_ENABLED_TOOLS"] = "code_health_review,code_health_score"
+
+    client = _start_client(command, env, cwd)
+    if client is None:
+        return False
+
+    try:
+        names = _tool_names(client)
+
+        has_review = "code_health_review" in names
+        has_score = "code_health_score" in names
+        has_get_config = "get_config" in names
+        has_set_config = "set_config" in names
+
+        # Should NOT have tools outside the allowlist
+        no_explain = "explain_code_health" not in names
+        no_refactor = "code_health_auto_refactor" not in names
+
+        print_test("code_health_review listed", has_review)
+        print_test("code_health_score listed", has_score)
+        print_test("get_config always listed", has_get_config)
+        print_test("set_config always listed", has_set_config)
+        print_test("explain_code_health NOT listed", no_explain)
+        print_test("code_health_auto_refactor NOT listed", no_refactor)
+
+        expected_count = 4  # 2 enabled + get_config + set_config
+        correct_count = len(names) == expected_count
+        print_test(
+            f"Exactly {expected_count} tools",
+            correct_count,
+            f"Found {len(names)}: {sorted(names)}",
+        )
+
+        return all([
+            has_review, has_score, has_get_config, has_set_config,
+            no_explain, no_refactor, correct_count,
+        ])
+
+    except Exception as e:
+        print_test("Filter restricts tools", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_config_tools_always_present(
+    command: list[str], base_env: dict, cwd: str, config_dir: Path,
+) -> bool:
+    """get_config and set_config cannot be disabled."""
+    print_header("Test: Config Tools Always Present")
+
+    env = base_env.copy()
+    # Enable only a single non-config tool
+    env["CS_ENABLED_TOOLS"] = "explain_code_health"
+
+    client = _start_client(command, env, cwd)
+    if client is None:
+        return False
+
+    try:
+        names = _tool_names(client)
+
+        has_get_config = "get_config" in names
+        has_set_config = "set_config" in names
+        has_explain = "explain_code_health" in names
+
+        print_test("get_config always present", has_get_config)
+        print_test("set_config always present", has_set_config)
+        print_test("explain_code_health present", has_explain)
+
+        return has_get_config and has_set_config and has_explain
+
+    except Exception as e:
+        print_test("Config tools always present", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_set_enabled_tools_restart_warning(command: list[str], env: dict, cwd: str) -> bool:
+    """Setting enabled_tools via set_config includes a restart warning."""
+    print_header("Test: Set Enabled Tools Restart Warning")
+
+    client = _start_client(command, env, cwd)
+    if client is None:
+        return False
+
+    try:
+        resp = client.call_tool(
+            "set_config",
+            {"key": "enabled_tools", "value": "code_health_review,code_health_score"},
+            timeout=30,
+        )
+        text = extract_result_text(resp)
+
+        has_restart = "restart" in text.lower()
+        has_saved = "saved" in text.lower()
+        print_test("Response says saved", has_saved, text[:200])
+        print_test("Restart warning present", has_restart)
+
+        return has_saved and has_restart
+
+    except Exception as e:
+        print_test("Set enabled_tools restart warning", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_set_invalid_tool_name_warning(command: list[str], env: dict, cwd: str) -> bool:
+    """Setting enabled_tools with unknown tool names includes a warning."""
+    print_header("Test: Invalid Tool Name Warning")
+
+    client = _start_client(command, env, cwd)
+    if client is None:
+        return False
+
+    try:
+        resp = client.call_tool(
+            "set_config",
+            {"key": "enabled_tools", "value": "code_health_review,nonexistent_tool"},
+            timeout=30,
+        )
+        text = extract_result_text(resp)
+
+        has_warning = "nonexistent_tool" in text
+        has_unrecognized = "unrecognized" in text.lower()
+        print_test("Warning mentions unknown tool name", has_warning, text[:200])
+        print_test("Warning says unrecognized", has_unrecognized)
+
+        return has_warning and has_unrecognized
+
+    except Exception as e:
+        print_test("Invalid tool name warning", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_get_enabled_tools_shows_available(command: list[str], env: dict, cwd: str) -> bool:
+    """Querying enabled_tools via get_config includes available_tools."""
+    print_header("Test: Get Enabled Tools Shows Available")
+
+    client = _start_client(command, env, cwd)
+    if client is None:
+        return False
+
+    try:
+        resp = client.call_tool(
+            "get_config",
+            {"key": "enabled_tools"},
+            timeout=30,
+        )
+        text = extract_result_text(resp)
+
+        has_available = "available_tools" in text
+        has_review_in_list = "code_health_review" in text
+        # get_config and set_config should NOT appear in available_tools
+        # (they are always-on, not configurable)
+        no_get_config = text.count("get_config") <= 1  # Only the response key itself
+
+        print_test("Response contains available_tools", has_available, text[:200])
+        print_test("Available tools includes code_health_review", has_review_in_list)
+
+        return has_available and has_review_in_list
+
+    except Exception as e:
+        print_test("Get enabled_tools shows available", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+# --- Runner ---
+
+
+def run_enabled_tools_tests_with_backend(backend: ServerBackend) -> int:
+    """Run all enabled_tools tests using a backend.
+
+    Returns exit code (0 for success, 1 for failure).
+    """
+    with safe_temp_directory(prefix="cs_mcp_enabled_tools_test_") as test_dir:
+        print(f"\nTest directory: {test_dir}")
+
+        config_dir = _make_config_dir(test_dir)
+
+        sample_files = {"hello.py": "def hello():\n    return 'world'\n"}
+        repo_dir = create_git_repo(test_dir, sample_files)
+        print(f"Repository: {repo_dir}")
+
+        command = backend.get_command(repo_dir)
+        base_env = backend.get_env(os.environ.copy(), repo_dir)
+        env = base_env.copy()
+        env["CS_CONFIG_DIR"] = str(config_dir)
+        cwd = str(repo_dir)
+
+        results: list[tuple[str, bool]] = [
+            ("All tools without filter", test_all_tools_without_filter(command, env, cwd)),
+            ("Filter restricts tools", test_filter_restricts_tools(command, env, cwd, config_dir)),
+            ("Config tools always present", test_config_tools_always_present(command, env, cwd, config_dir)),
+            ("Set enabled_tools restart warning", test_set_enabled_tools_restart_warning(command, env, cwd)),
+            ("Invalid tool name warning", test_set_invalid_tool_name_warning(command, env, cwd)),
+            ("Get enabled_tools shows available", test_get_enabled_tools_shows_available(command, env, cwd)),
+        ]
+
+        return print_summary(results)
+
+
+def run_enabled_tools_tests(executable: Path) -> int:
+    """Run all enabled_tools tests with a Cargo executable.
+
+    Args:
+        executable: Path to the cs-mcp executable
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    backend = CargoBackend(executable=executable)
+    return run_enabled_tools_tests_with_backend(backend)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python test_enabled_tools.py /path/to/cs-mcp")
+        return 1
+
+    executable = Path(sys.argv[1])
+    if not executable.exists():
+        print(f"Error: Executable not found: {executable}")
+        return 1
+
+    print_header("Enabled Tools Integration Tests")
+    print("\nThese tests verify the enabled_tools configuration option")
+    print("for restricting which MCP tools are exposed.")
+
+    return run_enabled_tools_tests(executable)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Allow users to restrict which tools the server registers via a new enabled_tools config key (env: `CS_ENABLED_TOOLS`). When set, only the listed tools plus get_config/set_config are exposed, reducing token usage for AI models. When unset, all tools remain enabled (default).

- Add enabled_tools ConfigOption with comma-separated tool name parsing
- Filter ToolRouter routes at startup based on allowlist
- Protect get_config/set_config from being disabled (lockout prevention)
- Warn on unknown tool names in set_config responses
- Show available tool names in get_config for enabled_tools key
- Add integration tests for tool filtering behavior
- Document in configuration-options.md and configuration skill