### PR TITLE
Update Homebrew formula to 1.1.1

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.1.0"
+  version "1.1.1"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "17651ba10a9620a5832438d15fbeda9c9b78ec4b2f5c760db86968fceede514f"
+      sha256 "92f333c460f948dd74357e128f8151f98e2433a8436e97851423f47e3792ef0f"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "79a47d7c6aa56c8be688563efcc09d349d85117303cf93f6f6fb07d8edebf064"
+      sha256 "5db56768f979c902193c65347381a41c930033fa3138e60d01063f63e46b69a9"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "c8835497bf5dfc42c19dbf2f4ab8a46a2ae9b314c310f42e5241676418014525"
+      sha256 "82edb49bd523b197b80cea651d8f7d92e9e91890892d36e49ead5caa1993019b"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "4d624ffcac633f18955054568abf7d40750383c8e42db2ef4475dc3be1975bbb"
+      sha256 "26e39c2dc4b7ca55b37255e5feae4d31d4eb5b67ab8994266a6fe01d3aec1301"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.1.1.

## Checksums
- macOS ARM64: `92f333c460f948dd74357e128f8151f98e2433a8436e97851423f47e3792ef0f`
- macOS AMD64: `5db56768f979c902193c65347381a41c930033fa3138e60d01063f63e46b69a9`
- Linux ARM64: `82edb49bd523b197b80cea651d8f7d92e9e91890892d36e49ead5caa1993019b`
- Linux AMD64: `26e39c2dc4b7ca55b37255e5feae4d31d4eb5b67ab8994266a6fe01d3aec1301`