### PR TITLE
Update Homebrew formula to 1.1.2

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.1.1"
+  version "1.1.2"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "92f333c460f948dd74357e128f8151f98e2433a8436e97851423f47e3792ef0f"
+      sha256 "b5b88783d8844fba8e55f131ee969ecc006a0de511af242e86e9050ec59867f9"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "5db56768f979c902193c65347381a41c930033fa3138e60d01063f63e46b69a9"
+      sha256 "889cd9294e6b3af26dc85fe47ebfccfb5f85ec198cfe7d7db747991ede191545"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "82edb49bd523b197b80cea651d8f7d92e9e91890892d36e49ead5caa1993019b"
+      sha256 "34aeb63338ddceab5b940e038a2f2a7fe56be66339fc8654b4510c9d65f6df91"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "26e39c2dc4b7ca55b37255e5feae4d31d4eb5b67ab8994266a6fe01d3aec1301"
+      sha256 "5725ffcd3fcda6f3d75f47a54b3b466e303d9e67291fb5bdc132ae09bc98776f"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.1.2.

## Checksums
- macOS ARM64: `b5b88783d8844fba8e55f131ee969ecc006a0de511af242e86e9050ec59867f9`
- macOS AMD64: `889cd9294e6b3af26dc85fe47ebfccfb5f85ec198cfe7d7db747991ede191545`
- Linux ARM64: `34aeb63338ddceab5b940e038a2f2a7fe56be66339fc8654b4510c9d65f6df91`
- Linux AMD64: `5725ffcd3fcda6f3d75f47a54b3b466e303d9e67291fb5bdc132ae09bc98776f`