### PR TITLE
Build and publish MCPB release bundle

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -332,11 +332,126 @@ jobs:
     needs: [build-exe-unix, build-exe-windows-amd64]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install MCPB CLI
+        run: npm install -g @anthropic-ai/mcpb
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: ./all-binaries
           merge-multiple: true
+
+      - name: Build cross-platform MCPB bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          STAGING_DIR="./mcpb-staging"
+          rm -rf "$STAGING_DIR"
+          mkdir -p "$STAGING_DIR/bin/darwin" "$STAGING_DIR/bin/linux" "$STAGING_DIR/bin/win32"
+
+          unzip -q "./all-binaries/cs-mcp-macos-amd64.zip" -d "$STAGING_DIR/bin/darwin"
+          mv "$STAGING_DIR/bin/darwin/cs-mcp-macos-amd64" "$STAGING_DIR/bin/darwin/cs-mcp-amd64"
+
+          unzip -q "./all-binaries/cs-mcp-macos-aarch64.zip" -d "$STAGING_DIR/bin/darwin"
+          mv "$STAGING_DIR/bin/darwin/cs-mcp-macos-aarch64" "$STAGING_DIR/bin/darwin/cs-mcp-aarch64"
+
+          unzip -q "./all-binaries/cs-mcp-linux-amd64.zip" -d "$STAGING_DIR/bin/linux"
+          mv "$STAGING_DIR/bin/linux/cs-mcp-linux-amd64" "$STAGING_DIR/bin/linux/cs-mcp-amd64"
+
+          unzip -q "./all-binaries/cs-mcp-linux-aarch64.zip" -d "$STAGING_DIR/bin/linux"
+          mv "$STAGING_DIR/bin/linux/cs-mcp-linux-aarch64" "$STAGING_DIR/bin/linux/cs-mcp-aarch64"
+
+          cp "./all-binaries/cs-mcp-windows-amd64.exe" "$STAGING_DIR/bin/win32/cs-mcp.exe"
+
+          cat > "$STAGING_DIR/bin/darwin/cs-mcp" <<'EOF'
+          #!/usr/bin/env sh
+          set -eu
+          arch="$(uname -m)"
+          case "$arch" in
+            arm64|aarch64)
+              exec "$(dirname "$0")/cs-mcp-aarch64" "$@"
+              ;;
+            x86_64|amd64)
+              exec "$(dirname "$0")/cs-mcp-amd64" "$@"
+              ;;
+            *)
+              echo "Unsupported macOS architecture: $arch" >&2
+              exit 1
+              ;;
+          esac
+          EOF
+
+          cat > "$STAGING_DIR/bin/linux/cs-mcp" <<'EOF'
+          #!/usr/bin/env sh
+          set -eu
+          arch="$(uname -m)"
+          case "$arch" in
+            arm64|aarch64)
+              exec "$(dirname "$0")/cs-mcp-aarch64" "$@"
+              ;;
+            x86_64|amd64)
+              exec "$(dirname "$0")/cs-mcp-amd64" "$@"
+              ;;
+            *)
+              echo "Unsupported Linux architecture: $arch" >&2
+              exit 1
+              ;;
+          esac
+          EOF
+
+          chmod +x "$STAGING_DIR/bin/darwin/cs-mcp" "$STAGING_DIR/bin/linux/cs-mcp"
+          chmod +x "$STAGING_DIR/bin/darwin/cs-mcp-aarch64" "$STAGING_DIR/bin/darwin/cs-mcp-amd64"
+          chmod +x "$STAGING_DIR/bin/linux/cs-mcp-aarch64" "$STAGING_DIR/bin/linux/cs-mcp-amd64"
+
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          source = Path("manifest.json")
+          target = Path("mcpb-staging/manifest.json")
+
+          manifest = json.loads(source.read_text())
+          manifest["manifest_version"] = "0.3"
+          manifest["server"] = {
+            "type": "binary",
+            "entry_point": "bin/darwin/cs-mcp",
+            "mcp_config": {
+              "command": "${__dirname}/bin/darwin/cs-mcp",
+              "args": [],
+              "env": {},
+              "platform_overrides": {
+                "linux": {
+                  "command": "${__dirname}/bin/linux/cs-mcp"
+                },
+                "win32": {
+                  "command": "${__dirname}/bin/win32/cs-mcp.exe"
+                }
+              }
+            }
+          }
+          manifest["compatibility"] = {
+            "platforms": ["darwin", "linux", "win32"]
+          }
+
+          target.write_text(json.dumps(manifest, indent=2) + "\n")
+          PY
+
+          mcpb pack "$STAGING_DIR" "./all-binaries/codehealth-mcp-${{ github.ref_name }}.mcpb"
+
+      - name: Upload MCPB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: codehealth-mcp-mcpb
+          path: ./all-binaries/codehealth-mcp-${{ github.ref_name }}.mcpb
 
       - name: Upload to Existing Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -351,6 +351,8 @@ jobs:
 
       - name: Build cross-platform MCPB bundle
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
@@ -414,6 +416,7 @@ jobs:
 
           python3 - <<'PY'
           import json
+          import os
           from pathlib import Path
 
           source = Path("manifest.json")
@@ -421,6 +424,9 @@ jobs:
 
           manifest = json.loads(source.read_text())
           manifest["manifest_version"] = "0.3"
+          tag = os.environ.get("RELEASE_TAG", "")
+          if tag.startswith("MCP-"):
+            manifest["version"] = tag[len("MCP-"):]
           manifest["server"] = {
             "type": "binary",
             "entry_point": "bin/darwin/cs-mcp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6b9d2f0efe2258b23767f1f9e0054cfbcac9c2d6f81a031214143096d7864f"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
 dependencies = [
  "async-trait",
  "base64",
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d95d7ed26ad8306352b0d5f05b593222b272790564589790d210aa15caa9e"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 # MCP SDK
-rmcp = { version = "1", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "1.3", features = ["server", "macros", "transport-io"] }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt", "io-std", "sync", "time", "process", "fs"] }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,47 @@
+{
+  "manifest_version": "0.3",
+  "name": "codehealth-mcp",
+  "version": "1.1.2",
+  "description": "CodeScene's Code Health analysis as local AI-friendly tools.",
+  "author": {
+    "name": "CodeScene",
+    "url": "https://codescene.com"
+  },
+  "homepage": "https://github.com/codescene-oss/codescene-mcp-server",
+  "documentation": "https://github.com/codescene-oss/codescene-mcp-server",
+  "support": "https://github.com/codescene-oss/codescene-mcp-server/issues",
+  "server": {
+    "type": "binary",
+    "entry_point": "bin/darwin/cs-mcp",
+    "mcp_config": {
+      "command": "${__dirname}/bin/darwin/cs-mcp",
+      "args": [],
+      "env": {},
+      "platform_overrides": {
+        "linux": {
+          "command": "${__dirname}/bin/linux/cs-mcp"
+        },
+        "win32": {
+          "command": "${__dirname}/bin/win32/cs-mcp.exe"
+        }
+      }
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "linux",
+      "win32"
+    ]
+  },
+  "keywords": [
+    "codehealth",
+    "uplift",
+    "analyze"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/codescene-oss/codescene-mcp-server/tree/main"
+  }
+}

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -19,6 +19,7 @@ impl ServerHandler for CodeSceneServer {
                 .enable_resources()
                 .build(),
         )
+        .with_protocol_version(protocol_version_2025_11_25())
         .with_server_info(Implementation::new(
             "codescene-mcp-server",
             env!("CS_MCP_VERSION"),
@@ -113,6 +114,10 @@ impl ServerHandler for CodeSceneServer {
     }
 }
 
+fn protocol_version_2025_11_25() -> rmcp::model::ProtocolVersion {
+    serde_json::from_str("\"2025-11-25\"").expect("valid MCP protocol version literal")
+}
+
 pub(crate) fn resolve_resource_content(uri: &str) -> Result<&'static str, ErrorData> {
     if uri == resources::HOW_IT_WORKS_URI {
         Ok(resources::HOW_IT_WORKS)
@@ -171,4 +176,14 @@ pub(crate) fn extract_md_title(content: &str) -> &str {
         }
     }
     "Untitled"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_version_is_2025_11_25() {
+        assert_eq!(protocol_version_2025_11_25().as_str(), "2025-11-25");
+    }
 }


### PR DESCRIPTION
Generate a single cross-platform binary MCPB artifact during tagged releases and upload it alongside existing binaries. Pin the server protocol version to 2025-11-25 so Claude tool calls remain connected after initialization.