### PR TITLE
CS-7025: exit cleanly when MCP client disconnects during handshake

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -447,15 +447,31 @@ async fn main() -> anyhow::Result<()> {
         http_client: Arc::new(http::ReqwestClient),
     });
 
-    let service = match server.serve(rmcp::transport::stdio()).await {
-        Ok(service) => service,
-        Err(err) => return handle_serve_error(err),
+    let Some(service) = serve_or_handle_disconnect(server, rmcp::transport::stdio()).await? else {
+        return Ok(());
     };
 
     tracing::info!("CodeScene MCP server ready");
 
     service.waiting().await?;
     Ok(())
+}
+
+pub(crate) async fn serve_or_handle_disconnect<T, E, A>(
+    server: CodeSceneServer,
+    transport: T,
+) -> anyhow::Result<Option<rmcp::service::RunningService<rmcp::service::RoleServer, CodeSceneServer>>>
+where
+    T: rmcp::transport::IntoTransport<rmcp::service::RoleServer, E, A>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    match server.serve(transport).await {
+        Ok(service) => Ok(Some(service)),
+        Err(err) => {
+            handle_serve_error(err)?;
+            Ok(None)
+        }
+    }
 }
 
 /// Convert a `serve()` error into the desired process exit behavior.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,9 @@ use std::sync::Arc;
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{
-    CallToolResult, Content,
-};
+use rmcp::model::{CallToolResult, Content};
 use rmcp::schemars::{self, JsonSchema};
+use rmcp::service::ServerInitializeError;
 use rmcp::{tool, tool_router, ErrorData, ServiceExt};
 use tracing_subscriber::EnvFilter;
 
@@ -110,8 +109,8 @@ pub(crate) async fn fetch_cli_version(cli_runner: &dyn cli::CliRunner) -> anyhow
     Ok(cli_runner.run(&["version"], None).await?)
 }
 
-pub(crate) fn inlined_schema_for<T: JsonSchema + 'static>() -> Arc<serde_json::Map<String, serde_json::Value>>
-{
+pub(crate) fn inlined_schema_for<T: JsonSchema + 'static>(
+) -> Arc<serde_json::Map<String, serde_json::Value>> {
     let mut settings = schemars::generate::SchemaSettings::draft2020_12();
     settings.inline_subschemas = true;
     settings.transforms = vec![Box::new(schemars::transform::AddNullable::default())];
@@ -182,10 +181,7 @@ fn remove_standalone_tools(router: &mut ToolRouter<CodeSceneServer>) {
     }
 }
 
-fn apply_enabled_tools_filter(
-    router: &mut ToolRouter<CodeSceneServer>,
-    config_data: &ConfigData,
-) {
+fn apply_enabled_tools_filter(router: &mut ToolRouter<CodeSceneServer>, config_data: &ConfigData) {
     let enabled = match config::enabled_tools(config_data) {
         Some(set) => set,
         None => return,
@@ -451,18 +447,38 @@ async fn main() -> anyhow::Result<()> {
         http_client: Arc::new(http::ReqwestClient),
     });
 
-    let service = server
-        .serve(rmcp::transport::stdio())
-        .await
-        .inspect_err(|e| {
-            if e.to_string().contains("initialize request") {
-                tracing::info!("No MCP initialize request received. If you ran `cs-mcp` directly in a terminal, run it through an MCP client instead.");
-            }
-            tracing::error!("serving error: {:?}", e);
-        })?;
+    let service = match server.serve(rmcp::transport::stdio()).await {
+        Ok(service) => service,
+        Err(err) => return handle_serve_error(err),
+    };
 
     tracing::info!("CodeScene MCP server ready");
 
     service.waiting().await?;
     Ok(())
+}
+
+/// Convert a `serve()` error into the desired process exit behavior.
+///
+/// MCP clients (e.g. VS Code, Zed) routinely close the server's stdin
+/// when the user closes the agent — sometimes before the MCP handshake
+/// has completed. That looks like a `ConnectionClosed` error during
+/// initialization, but is a normal shutdown from the client's
+/// perspective. Treat it as a clean exit so the client does not
+/// surface a "fatal error" dialog.
+fn handle_serve_error(err: ServerInitializeError) -> anyhow::Result<()> {
+    if let ServerInitializeError::ConnectionClosed(context) = &err {
+        tracing::info!(
+            "MCP client disconnected during initialization ({context}); shutting down cleanly"
+        );
+        if context.contains("initialize request") {
+            tracing::info!(
+                "No MCP initialize request received. If you ran `cs-mcp` directly in a terminal, run it through an MCP client instead."
+            );
+        }
+        return Ok(());
+    }
+
+    tracing::error!("serving error: {err:?}");
+    Err(err.into())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,6 +447,7 @@ async fn main() -> anyhow::Result<()> {
         http_client: Arc::new(http::ReqwestClient),
     });
 
+    // Covered by e2e test: test_shutdown_during_handshake.py
     let Some(service) = serve_or_handle_disconnect(server, rmcp::transport::stdio()).await? else {
         return Ok(());
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,7 +466,7 @@ async fn main() -> anyhow::Result<()> {
 /// initialization, but is a normal shutdown from the client's
 /// perspective. Treat it as a clean exit so the client does not
 /// surface a "fatal error" dialog.
-fn handle_serve_error(err: ServerInitializeError) -> anyhow::Result<()> {
+pub(crate) fn handle_serve_error(err: ServerInitializeError) -> anyhow::Result<()> {
     if let ServerInitializeError::ConnectionClosed(context) = &err {
         tracing::info!(
             "MCP client disconnected during initialization ({context}); shutting down cleanly"

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -193,6 +193,7 @@ pub(crate) fn assert_standalone_error(result: &CallToolResult) {
 mod tests {
     use std::collections::HashMap;
 
+    use rmcp::service::ServerInitializeError;
     use rmcp::ServerHandler;
 
     use super::*;
@@ -542,4 +543,28 @@ mod tests {
     fn extract_md_title_falls_back_to_resource() {
         assert_eq!(extract_md_title("no heading here"), "Untitled");
     }
+
+    #[test]
+    fn handle_serve_error_connection_closed_initialize_request_is_ok() {
+        let result = crate::handle_serve_error(ServerInitializeError::ConnectionClosed(
+            "initialize request".to_string(),
+        ));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn handle_serve_error_connection_closed_initialize_notification_is_ok() {
+        let result = crate::handle_serve_error(ServerInitializeError::ConnectionClosed(
+            "initialize notification".to_string(),
+        ));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn handle_serve_error_non_connection_closed_returns_err() {
+        let err = ServerInitializeError::Cancelled;
+        let result = crate::handle_serve_error(err);
+        assert!(result.is_err());
+    }
+
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -191,10 +191,16 @@ pub(crate) fn assert_standalone_error(result: &CallToolResult) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, VecDeque};
+    use std::io;
+    use std::sync::{Arc, Mutex};
 
+    use rmcp::model::{ClientJsonRpcMessage, ServerJsonRpcMessage};
     use rmcp::service::ServerInitializeError;
+    use rmcp::service::RoleServer;
+    use rmcp::transport::Transport;
     use rmcp::ServerHandler;
+    use serde_json::json;
 
     use super::*;
     use crate::config::{self, ConfigData};
@@ -204,6 +210,72 @@ mod tests {
         display_version, fetch_cli_version, help_text, parse_cli_args,
         resources, CliAction, API_ONLY_TOOLS,
     };
+
+    #[derive(Clone)]
+    struct ScriptedTransport {
+        incoming: Arc<Mutex<VecDeque<ClientJsonRpcMessage>>>,
+        sent: Arc<Mutex<Vec<ServerJsonRpcMessage>>>,
+    }
+
+    impl ScriptedTransport {
+        fn from_messages(messages: Vec<ClientJsonRpcMessage>) -> Self {
+            Self {
+                incoming: Arc::new(Mutex::new(VecDeque::from(messages))),
+                sent: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl Transport<RoleServer> for ScriptedTransport {
+        type Error = io::Error;
+
+        fn send(
+            &mut self,
+            item: ServerJsonRpcMessage,
+        ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+            let sent = self.sent.clone();
+            async move {
+                sent.lock().unwrap().push(item);
+                Ok(())
+            }
+        }
+
+        fn receive(
+            &mut self,
+        ) -> impl std::future::Future<Output = Option<ClientJsonRpcMessage>> + Send {
+            let next = self.incoming.lock().unwrap().pop_front();
+            std::future::ready(next)
+        }
+
+        fn close(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+            std::future::ready(Ok(()))
+        }
+    }
+
+    fn initialize_request_message() -> ClientJsonRpcMessage {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "unit-test-client",
+                    "version": "1.0.0"
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    fn initialized_notification_message() -> ClientJsonRpcMessage {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }))
+        .unwrap()
+    }
 
     #[test]
     fn api_only_tools_has_expected_entries() {
@@ -565,6 +637,35 @@ mod tests {
         let err = ServerInitializeError::Cancelled;
         let result = crate::handle_serve_error(err);
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn serve_or_handle_disconnect_returns_none_when_client_closes_early() {
+        let server = make_server(false);
+        let transport = ScriptedTransport::from_messages(vec![]);
+
+        let result = crate::serve_or_handle_disconnect(server, transport)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn serve_or_handle_disconnect_returns_service_on_successful_handshake() {
+        let server = make_server(false);
+        let transport = ScriptedTransport::from_messages(vec![
+            initialize_request_message(),
+            initialized_notification_message(),
+        ]);
+
+        let mut service = crate::serve_or_handle_disconnect(server, transport)
+            .await
+            .unwrap()
+            .expect("expected initialized service");
+
+        let close_result = service.close().await;
+        assert!(close_result.is_ok());
     }
 
 }

--- a/tests/integration/run_all_tests.py
+++ b/tests/integration/run_all_tests.py
@@ -450,6 +450,9 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
     from test_git_worktree import run_worktree_tests_with_backend
     from test_relative_paths import run_relative_path_tests_with_backend
     from test_require_access_token import run_require_access_token_tests_with_backend
+    from test_shutdown_during_handshake import (
+        run_shutdown_during_handshake_tests_with_backend,
+    )
     from test_standalone_license import run_standalone_license_tests_with_backend
     from test_ssl_cli_truststore import run_ssl_cli_truststore_tests_with_backend
     from test_version_check import run_version_check_tests_with_backend
@@ -467,6 +470,10 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
         ("Configure Tests", run_configure_tests_with_backend),
         ("Enabled Tools Tests", run_enabled_tools_tests_with_backend),
         ("Access Token Guard Tests", run_require_access_token_tests_with_backend),
+        (
+            "Shutdown During Handshake Tests",
+            run_shutdown_during_handshake_tests_with_backend,
+        ),
         ("CloudFront Headers Tests", run_cloudfront_headers_tests_with_backend),
         ("SSL Truststore CLI Tests", run_ssl_cli_truststore_tests_with_backend),
         ("Auto-Refactor Tests", run_auto_refactor_tests_with_backend),

--- a/tests/integration/test_output.py
+++ b/tests/integration/test_output.py
@@ -39,7 +39,8 @@ def _get_status_color(passed: bool) -> str:
 def _print_details(details: str) -> None:
     """Print test result details, limited to first 10 lines."""
     for line in details.split("\n")[:10]:
-        print(f"         {line}")
+        safe_line = line if not _needs_ascii_fallback() else line.encode("ascii", errors="replace").decode("ascii")
+        print(f"         {safe_line}")
 
 
 def print_header(msg: str) -> None:

--- a/tests/integration/test_shutdown_during_handshake.py
+++ b/tests/integration/test_shutdown_during_handshake.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Shutdown-during-handshake integration tests.
+
+Tests that the MCP server exits cleanly (exit code 0) when the client
+disconnects during the MCP initialization handshake. Some MCP clients
+(notably VS Code and Zed) tear down agents by closing the server's
+stdin before the handshake completes — for example when the client
+shuts down quickly after launch, or when the user closes the agent
+before any tool is invoked.
+
+When that happens, the server must NOT report a fatal error: the
+client surfaces a non-zero exit as a fatal crash dialog, e.g.:
+
+    .../cs-mcp has encountered a fatal error and was closed.
+
+This test suite validates:
+1. Closing stdin before any input results in exit code 0.
+2. Closing stdin after the initialize request but before the
+   notifications/initialized notification results in exit code 0.
+3. A full handshake followed by stdin close still results in exit
+   code 0 (sanity check that the happy path also stays clean).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from test_utils import (
+    CargoBackend,
+    ServerBackend,
+    print_header,
+    print_summary,
+    print_test,
+    safe_temp_directory,
+)
+
+# Hard upper bound for how long the server may take to exit after
+# stdin is closed. If exceeded, the test fails — a stuck server
+# process is just as bad as a crashing one.
+_EXIT_TIMEOUT_SECONDS = 10
+
+
+def _spawn_server(command: list[str], env: dict, cwd: str) -> subprocess.Popen:
+    """Start the MCP server with stdio pipes captured."""
+    return subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        bufsize=1,
+    )
+
+
+def _send_message(process: subprocess.Popen, message: dict) -> None:
+    """Write a single JSON-RPC message and flush."""
+    assert process.stdin is not None
+    process.stdin.write(json.dumps(message) + "\n")
+    process.stdin.flush()
+
+
+def _close_stdin_and_wait(process: subprocess.Popen) -> tuple[int | None, str]:
+    """Close stdin, wait for the process to exit, return (exit_code, stderr)."""
+    assert process.stdin is not None
+    process.stdin.close()
+    try:
+        process.wait(timeout=_EXIT_TIMEOUT_SECONDS)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+        return None, _drain_stderr(process)
+    return process.returncode, _drain_stderr(process)
+
+
+def _drain_stderr(process: subprocess.Popen) -> str:
+    """Read any remaining stderr output without blocking forever."""
+    if process.stderr is None:
+        return ""
+    try:
+        return process.stderr.read() or ""
+    except Exception:
+        return ""
+
+
+def _initialize_request() -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "shutdown-test", "version": "1.0.0"},
+        },
+    }
+
+
+def _initialized_notification() -> dict:
+    return {"jsonrpc": "2.0", "method": "notifications/initialized"}
+
+
+def _check_clean_exit(exit_code: int | None, stderr: str, scenario: str) -> bool:
+    """Assert the server exited cleanly within the timeout."""
+    if exit_code is None:
+        print_test(
+            f"Server exited within {_EXIT_TIMEOUT_SECONDS}s ({scenario})",
+            False,
+            "Server hung after stdin close and had to be killed",
+        )
+        return False
+    print_test(
+        f"Server exited within {_EXIT_TIMEOUT_SECONDS}s ({scenario})",
+        True,
+    )
+
+    is_clean = exit_code == 0
+    print_test(
+        f"Exit code is 0 ({scenario})",
+        is_clean,
+        (
+            f"Got exit code {exit_code}. Recent stderr:\n"
+            f"{_tail(stderr)}"
+        ),
+    )
+    return is_clean
+
+
+def _tail(text: str, max_lines: int = 10) -> str:
+    lines = text.strip().splitlines()
+    return "\n".join(lines[-max_lines:]) if lines else "<empty>"
+
+
+# --- Scenarios ---
+
+
+def test_stdin_closed_before_any_input(
+    command: list[str], env: dict, cwd: str
+) -> bool:
+    """
+    Closing stdin before sending any JSON-RPC message must exit cleanly.
+
+    This simulates a client that launches the server and immediately
+    disconnects (e.g. crashed, or shut down between launch and first
+    request).
+    """
+    print_header("Test: Stdin closed before any input")
+
+    process = _spawn_server(command, env, cwd)
+    # Give the server a moment to boot before we close stdin.
+    time.sleep(0.3)
+    exit_code, stderr = _close_stdin_and_wait(process)
+    return _check_clean_exit(exit_code, stderr, "no input")
+
+
+def test_stdin_closed_after_initialize_request(
+    command: list[str], env: dict, cwd: str
+) -> bool:
+    """
+    Closing stdin after the initialize request but before the
+    notifications/initialized notification must exit cleanly.
+
+    This is the exact scenario reported by VS Code / Zed users:
+    closing the agent during the handshake produced a "fatal error"
+    dialog because the server exited with code 1.
+    """
+    print_header("Test: Stdin closed mid-handshake")
+
+    process = _spawn_server(command, env, cwd)
+    _send_message(process, _initialize_request())
+    # Wait for the server to read the initialize request before we
+    # close stdin, so the server is in the "waiting for initialized
+    # notification" state when stdin closes.
+    time.sleep(0.5)
+    exit_code, stderr = _close_stdin_and_wait(process)
+    return _check_clean_exit(exit_code, stderr, "mid-handshake")
+
+
+def test_stdin_closed_after_full_handshake(
+    command: list[str], env: dict, cwd: str
+) -> bool:
+    """
+    Closing stdin after a complete handshake must still exit cleanly.
+
+    Sanity check: the bug fix must not regress the already-working
+    happy path where the client completes initialization and then
+    disconnects.
+    """
+    print_header("Test: Stdin closed after full handshake")
+
+    process = _spawn_server(command, env, cwd)
+    _send_message(process, _initialize_request())
+    time.sleep(0.3)
+    _send_message(process, _initialized_notification())
+    time.sleep(0.3)
+    exit_code, stderr = _close_stdin_and_wait(process)
+    return _check_clean_exit(exit_code, stderr, "post-handshake")
+
+
+# --- Runner ---
+
+
+def run_shutdown_during_handshake_tests_with_backend(backend: ServerBackend) -> int:
+    """Run the shutdown-during-handshake tests using a backend."""
+    with safe_temp_directory(prefix="cs_mcp_shutdown_handshake_test_") as test_dir:
+        print(f"\nTest directory: {test_dir}")
+
+        command = backend.get_command(test_dir)
+        env = backend.get_env(os.environ.copy(), test_dir)
+        cwd = str(test_dir)
+
+        results = [
+            (
+                "Stdin Closed Before Any Input",
+                test_stdin_closed_before_any_input(command, env, cwd),
+            ),
+            (
+                "Stdin Closed After Initialize Request",
+                test_stdin_closed_after_initialize_request(command, env, cwd),
+            ),
+            (
+                "Stdin Closed After Full Handshake",
+                test_stdin_closed_after_full_handshake(command, env, cwd),
+            ),
+        ]
+
+        return print_summary(results)
+
+
+def run_shutdown_during_handshake_tests(executable: Path) -> int:
+    """Run all shutdown-during-handshake tests with a Cargo executable."""
+    backend = CargoBackend(executable=executable)
+    return run_shutdown_during_handshake_tests_with_backend(backend)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python test_shutdown_during_handshake.py /path/to/cs-mcp")
+        return 1
+
+    executable = Path(sys.argv[1])
+    if not executable.exists():
+        print(f"Error: Executable not found: {executable}")
+        return 1
+
+    print_header("Shutdown-During-Handshake Integration Tests")
+    print(
+        "\nThese tests verify that the MCP server exits with code 0 when\n"
+        "the client closes stdin during the MCP initialization handshake.\n"
+        "Non-zero exit codes are surfaced by VS Code and Zed as a fatal\n"
+        "error dialog, even though the client itself triggered the close."
+    )
+
+    return run_shutdown_during_handshake_tests(executable)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
VS Code and Zed close the server's stdin when the user closes the agent. If that happens before the MCP handshake completes, `rmcp` returns `ServerInitializeError::ConnectionClosed` and `main()` previously propagated it with `?`, exiting with code 1. Clients surface non-zero exits as a fatal-error dialog, even though the client itself triggered the close.

Treat `ConnectionClosed` during the handshake as a normal shutdown: log at info level and return `Ok(())`. Other initialization errors still propagate.

Adds tests/integration/test_shutdown_during_handshake.py covering:
- Stdin closed before any input
- Stdin closed after initialize but before initialized notification
- Stdin closed after a full handshake (regression guard)