### PR TITLE
Update Homebrew formula to 1.1.6

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.1.5"
+  version "1.1.6"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "d9614735c769037c796de9e65100a2c40d697b3c33cf0fc89bb72122a8ee0339"
+      sha256 "7f1d1b8385a8df419667ba360c9f9aff352cf2eb3b6e2c774a471524244c021e"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "22cf80a52c2d85bceddd49bcebedf3aca55a54c7320319dccf350b8724dfaced"
+      sha256 "c000a98d1bc332dc6eb8890ac64ebf22c4036ddde8ed343160392cf3bf9f2d44"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "f4747a7e4c1461d400313a54531f83bec374dc70462ed6c4b78c18f9373a369b"
+      sha256 "44afced03537da498d06f685a1000ac7d44dfd900a77cfac875246a70146605c"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "0f0767d83eebd0abc369195c121b9494336bb996aa2cb3f05bee453197762303"
+      sha256 "84e81d3e6ba04460c741099ae313d395a43fd82f946e84ec67ce185915f60285"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.1.6.

## Checksums
- macOS ARM64: `7f1d1b8385a8df419667ba360c9f9aff352cf2eb3b6e2c774a471524244c021e`
- macOS AMD64: `c000a98d1bc332dc6eb8890ac64ebf22c4036ddde8ed343160392cf3bf9f2d44`
- Linux ARM64: `44afced03537da498d06f685a1000ac7d44dfd900a77cfac875246a70146605c`
- Linux AMD64: `84e81d3e6ba04460c741099ae313d395a43fd82f946e84ec67ce185915f60285`