### PR TITLE
Update Homebrew formula to 1.1.7

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.1.6"
+  version "1.1.7"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "7f1d1b8385a8df419667ba360c9f9aff352cf2eb3b6e2c774a471524244c021e"
+      sha256 "dd75ef7c762feb31628cd2bc593063db0f3bd3d5da6d710457809f9be96f4e29"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "c000a98d1bc332dc6eb8890ac64ebf22c4036ddde8ed343160392cf3bf9f2d44"
+      sha256 "8a3cdc1c2ff7d385920c8697aa07e66f181cb8ab7ec14f90426b17265e452a96"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "44afced03537da498d06f685a1000ac7d44dfd900a77cfac875246a70146605c"
+      sha256 "81db617a812282587481799844d7fd29a1a8a56e4a9af755153b94c5797be2bc"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "84e81d3e6ba04460c741099ae313d395a43fd82f946e84ec67ce185915f60285"
+      sha256 "dc1f74cee115bd08041d5c79821c3a7e3e4fe86f9b0aaa192d91dd9c27bc50b3"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.1.7.

## Checksums
- macOS ARM64: `dd75ef7c762feb31628cd2bc593063db0f3bd3d5da6d710457809f9be96f4e29`
- macOS AMD64: `8a3cdc1c2ff7d385920c8697aa07e66f181cb8ab7ec14f90426b17265e452a96`
- Linux ARM64: `81db617a812282587481799844d7fd29a1a8a56e4a9af755153b94c5797be2bc`
- Linux AMD64: `dc1f74cee115bd08041d5c79821c3a7e3e4fe86f9b0aaa192d91dd9c27bc50b3`