### PR TITLE
Update Claude Code plugin to 1.1.6

### DIFF
--- a/claude-code-plugin/.claude-plugin/plugin.json
+++ b/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codescene",
-  "description": "CodeScene Code Health analysis — review, refactor, and safeguard code quality with AI-friendly tools.",
-  "version": "1.1.2",
+  "description": "CodeScene Code Health analysis \u2014 review, refactor, and safeguard code quality with AI-friendly tools.",
+  "version": "1.1.6",
   "author": {
     "name": "CodeScene",
     "url": "https://codescene.com"

--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -25,6 +25,15 @@ Once installed, the following skills are available:
 <!-- SKILLS-TABLE:START -->
 | Skill | Description |
 |-------|-------------|
+| `/codescene:configuring-codescene-mcp` | Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, ACE tokens, default projects, or SSL certificates. |
+| `/codescene:explaining-code-health` | Use when a user asks what Code Health means, how to interpret scores, or why Code Health matters in daily development. |
+| `/codescene:guiding-refactoring-with-code-health` | Use when refactoring unhealthy code and needing Code Health findings to choose small safe steps and verify improvement. |
+| `/codescene:installing-and-activating-codescene-mcp` | Use when installing the CodeScene MCP Server binary or package, registering it in an AI assistant, or copying agent guidance files into a repository. |
+| `/codescene:making-the-business-case-for-code-health` | Use when a user asks for ROI, stakeholder justification, delivery impact, or defect-risk reduction from improving Code Health in a file. |
+| `/codescene:prioritizing-technical-debt` | Use when users with a CodeScene instance ask what to improve first across a project, which hotspots matter most, or how to rank refactoring candidates. |
+| `/codescene:risk-based-testing-with-code-health` | Use when a user asks what to test first based on CodeScene findings, especially for high-risk hotspots or pull-request change sets. |
+| `/codescene:routing-work-with-code-ownership` | Use when choosing reviewers, domain experts, or likely owners for a file or directory from CodeScene project data. |
+| `/codescene:safeguarding-ai-generated-code` | Use when AI-generated or AI-modified changes need a Code Health gate before commit, handoff, or pull request. |
 <!-- SKILLS-TABLE:END -->
 
 ## MCP Tools

--- a/claude-code-plugin/skills/README.md
+++ b/claude-code-plugin/skills/README.md
@@ -1,0 +1,25 @@
+# CodeScene MCP Skills
+
+This directory contains downloadable public skills for agents that use the CodeScene MCP Server.
+
+Each skill is organized as:
+
+```text
+skills/
+  skill-name/
+    SKILL.md
+```
+
+Available skills:
+
+- `installing-and-activating-codescene-mcp`: Install the MCP server binary or package and register it in an AI assistant.
+- `configuring-codescene-mcp`: View, set, or troubleshoot CodeScene MCP configuration using the built-in `get_config` and `set_config` tools.
+- `safeguarding-ai-generated-code`: Apply Code Health safeguards before commit or pull request.
+- `guiding-refactoring-with-code-health`: Use Code Health findings to plan and validate small refactors.
+- `making-the-business-case-for-code-health`: Quantify delivery and defect impact to justify refactoring work.
+- `prioritizing-technical-debt`: Use CodeScene project data to rank what to improve first.
+- `routing-work-with-code-ownership`: Use CodeScene ownership data to find likely reviewers and domain experts.
+- `explaining-code-health`: Explain Code Health concepts and why they matter.
+- `risk-based-testing-with-code-health`: Turn CodeScene risk signals into practical testing priorities for PRs and releases.
+
+These public skills are separate from the repo-local contributor skills under `.agents/skills`.

--- a/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: configuring-codescene-mcp
+description: Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, ACE tokens, default projects, or SSL certificates.
+---
+
+# Configuring CodeScene MCP
+
+## Overview
+
+Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `get_config` and `set_config` tools that let the AI assistant read and write configuration on the user's behalf. This is the easiest and recommended configuration method.
+
+## When to Use
+
+- The user wants to set or change their CodeScene access token.
+- The user needs to connect to a self-hosted CodeScene instance.
+- The user wants to enable ACE auto-refactoring.
+- The user wants to pre-select a default CodeScene project.
+- The user needs to configure a custom CA certificate for SSL/TLS.
+- The user wants to limit which tools are exposed to reduce token usage (`enabled_tools`).
+- The user asks what their current configuration is.
+- The user is troubleshooting a configuration issue (wrong token, missing URL, SSL errors).
+
+Do not use this skill for installing or registering the MCP server in an AI assistant. Use `installing-and-activating-codescene-mcp` for that.
+
+## Quick Reference
+
+- `get_config`: List all configuration options and their current values (sensitive values are masked).
+- `get_config` with a key: Read a single option by name.
+- `set_config`: Set a configuration value persistently.
+- `set_config` with an empty value: Delete a stored configuration value.
+
+### Configuration Options
+
+| Key | Purpose |
+|-----|---------|
+| `access_token` | CodeScene Personal Access Token or standalone MCP license token. |
+| `onprem_url` | Base URL for a self-hosted CodeScene instance (API-mode only). |
+| `ace_access_token` | Token for CodeScene ACE auto-refactoring (add-on license). |
+| `default_project_id` | Pre-select a CodeScene project by numeric ID (API-mode only). |
+| `ca_bundle` | Path to a custom PEM-format CA certificate bundle. |
+| `enabled_tools` | Comma-separated allowlist of tool names to expose (empty = all). |
+
+### Precedence
+
+Environment variables set by the MCP client always override values in the config file. If the user has set a value via an environment variable in their editor config, `set_config` will warn that the env var takes precedence and the stored value will not be used until the env var is removed.
+
+## Implementation
+
+1. Run `get_config` to see the current state of all options.
+2. Identify which option needs to change based on the user's request.
+3. Use `set_config` with the key and value to apply the change.
+4. Run `get_config` with that key to confirm the change took effect.
+5. If the user changed `access_token`, inform them that a server restart may be needed for tool registration changes to take effect.
+6. If `get_config` shows a value source of "client environment variable", explain that the env var in their editor's MCP configuration takes precedence and must be changed there instead.
+
+### When environment variables are appropriate
+
+Environment variables are still the right choice when:
+
+- The configuration is shared across a team or checked into a project (e.g., in `.vscode/mcp.json`).
+- The server runs in Docker and needs `CS_MOUNT_PATH` (which is not a config-tool option).
+- CI or automation pipelines inject secrets at runtime.
+
+For individual, interactive use, prefer the `set_config` tool.
+
+## Common Mistakes
+
+- Setting a value with `set_config` when the same key is already provided as an environment variable by the MCP client. The env var wins and the stored value is silently ignored.
+- Forgetting that `access_token` changes may require a server restart.
+- Confusing the config key name with the environment variable name. Use the short key (e.g., `access_token`) with `set_config`, not the env var name (`CS_ACCESS_TOKEN`).
+- Setting `onprem_url` or `default_project_id` when using a standalone license. These options are only available with a CodeScene Personal Access Token.
+- Providing a CA bundle path that is not accessible to the MCP server process or Docker container.
+- Setting `enabled_tools` with misspelled tool names. The server warns about unknown names, but the misspelled tools are silently ignored. Use `get_config` with key `enabled_tools` to see the list of available tool names.
+- Forgetting that `enabled_tools` changes require a server restart. The tool list is built once at startup.
+- Trying to disable `get_config` or `set_config` via `enabled_tools`. These tools are always enabled to prevent configuration lockout.

--- a/claude-code-plugin/skills/explaining-code-health/SKILL.md
+++ b/claude-code-plugin/skills/explaining-code-health/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: explaining-code-health
+description: Use when a user asks what Code Health means, how to interpret scores, or why Code Health matters in daily development.
+---
+
+# Explaining Code Health
+
+## Overview
+
+Use this skill when the task is educational or explanatory. The goal is to help users understand the meaning of Code Health and why it matters for maintainability, delivery speed, and defect risk.
+
+## When to Use
+
+- A user asks what Code Health is.
+- A user asks how to interpret scores or what a better score implies.
+- A stakeholder needs a concise explanation of why Code Health matters.
+
+Do not use this skill when the user needs a quantified ROI projection for a specific file. Use `making-the-business-case-for-code-health` for that.
+
+## Quick Reference
+
+- `explain_code_health`: Fundamentals of the Code Health model.
+- `explain_code_health_productivity`: Evidence and framing around speed, quality, and productivity.
+
+## Implementation
+
+1. Use `explain_code_health` for fundamentals.
+2. Use `explain_code_health_productivity` when the user also wants delivery or defect framing.
+3. Tailor the explanation to the current task, repository, or planning decision.
+4. Keep the explanation concrete and connect it to maintainability outcomes.
+
+## Common Mistakes
+
+- Using abstract language without connecting it to everyday engineering decisions.
+- Jumping to ROI claims when the user only asked for fundamentals.
+- Repeating documentation verbatim instead of tailoring it to the user’s context.

--- a/claude-code-plugin/skills/guiding-refactoring-with-code-health/SKILL.md
+++ b/claude-code-plugin/skills/guiding-refactoring-with-code-health/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: guiding-refactoring-with-code-health
+description: Use when refactoring unhealthy code and needing Code Health findings to choose small safe steps and verify improvement.
+---
+
+# Guiding Refactoring With Code Health
+
+## Overview
+
+Use Code Health as the control signal for refactoring. The agent should first understand why a file is hard to work with, establish a measurable baseline, then improve it in small structural steps and verify that each step helped. The goal is not just cleaner code, but code that is easier for both humans and agents to understand and modify safely.
+
+## When to Use
+
+- A file is hard to read, risky to change, or repeatedly attracts defects.
+- The user asks for refactoring help and wants an objective way to measure progress.
+- A safeguard or review points to complexity, size, low cohesion, or deep nesting.
+
+Do not use this skill when the task is to rank project-wide priorities. Use `prioritizing-technical-debt` for that.
+
+## Quick Reference
+
+- `code_health_review`: Detailed maintainability findings for a file.
+- `code_health_score`: Numeric baseline and trend check across refactoring iterations.
+
+## Implementation
+
+1. Run `code_health_review` on the target file.
+2. Record the current `code_health_score` so the refactoring starts from a measurable baseline.
+3. Identify the highest-leverage structural problems, such as excessive responsibilities, deep nesting, low cohesion, or hard-to-follow control flow.
+4. Propose 3 to 5 small structural refactor steps, not a single rewrite.
+5. After each meaningful step, re-run `code_health_review` to see whether the targeted structural problems were reduced.
+6. Use `code_health_score` as the compact checkpoint to confirm directional improvement across iterations.
+7. Stop only when the targeted structural issues are substantially reduced and the score has measurably improved, or when the user explicitly accepts a partial uplift.
+
+## Common Mistakes
+
+- Refactoring without a baseline review.
+- Refactoring without recording the initial score.
+- Making a large rewrite that hides whether things improved.
+- Counting cosmetic cleanup as meaningful progress when the structural problems remain.
+- Using score checks alone without re-running the detailed review.
+- Forgetting to re-measure after each meaningful step.

--- a/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: installing-and-activating-codescene-mcp
+description: Use when installing the CodeScene MCP Server binary or package, registering it in an AI assistant, or copying agent guidance files into a repository.
+---
+
+# Installing and Activating CodeScene MCP
+
+## Overview
+
+Use this skill when the task is to get the CodeScene MCP Server installed and registered with an AI assistant. The workflow has three parts: install the server, register it in the assistant, and copy the agent guidance files into the repository.
+
+For configuring the server after installation (access tokens, on-prem URLs, ACE, SSL), use the `configuring-codescene-mcp` skill instead.
+
+## When to Use
+
+- The user wants to install CodeScene MCP for the first time.
+- The user has the binary or package installed but has not registered it in an AI assistant.
+- The user wants a quick setup path for VS Code, GitHub Copilot, Claude Code, Docker, Homebrew, or Windows.
+
+Do not use this skill for configuring tokens, URLs, or other server options. Use `configuring-codescene-mcp` for that. Do not use this skill for refactoring, safeguards, or technical debt prioritization.
+
+## Quick Reference
+
+- Install using the method that matches the environment: `npx` or `npm`, Homebrew, Windows installer script, manual download, or Docker.
+- Register the server in the AI assistant so it launches `cs-mcp`.
+- Copy the appropriate agent guidance file into the repository: `docs/AGENTS-full.md` for CodeScene Core users, or `docs/AGENTS-standalone.md` for standalone license users. For Amazon Q, copy `.amazonq/rules` instead.
+- Copy any relevant skills from the CodeScene MCP skills catalogue at `https://github.com/codescene-oss/codescene-mcp-server/tree/main/skills`.
+- After installation, use `set_config` or ask the assistant to configure the access token and any other options.
+
+## Implementation
+
+1. Choose the installation method that fits the user environment:
+   - `npx @codescene/codehealth-mcp` or `npm install -g @codescene/codehealth-mcp`
+   - `brew tap codescene-oss/codescene-mcp-server https://github.com/codescene-oss/codescene-mcp-server && brew install cs-mcp`
+   - Windows PowerShell installer
+   - Manual binary download
+   - Docker image
+2. Verify that the `cs-mcp` command or container entrypoint is available.
+3. Register the server in the AI assistant:
+   - For VS Code or GitHub Copilot, add a `codescene` server entry in `settings.json` or `.vscode/mcp.json`.
+   - For Claude Code, add the MCP with `claude mcp add`.
+4. Configure the server by asking the assistant to set the access token (this uses the `set_config` tool under the hood). See the `configuring-codescene-mcp` skill for full details.
+5. Copy the appropriate agent guidance file to the repository: `docs/AGENTS-full.md` for CodeScene Core users, or `docs/AGENTS-standalone.md` for standalone license users. Rename it to `AGENTS.md` in the target repository so the agent picks it up automatically.
+6. If the user is on Amazon Q, copy `.amazonq/rules` instead of the AGENTS file.
+7. Copy any relevant skills from `https://github.com/codescene-oss/codescene-mcp-server/tree/main/skills` for safeguarding, refactoring, prioritization, or business-case workflows.
+
+## Common Mistakes
+
+- Installing the server but never registering it with the assistant.
+- Copying the setup files into the wrong repository.
+- Skipping the configuration step after installation. The server needs at least an access token to function.
+- Manually editing environment variables when `set_config` is simpler and persistent.

--- a/claude-code-plugin/skills/making-the-business-case-for-code-health/SKILL.md
+++ b/claude-code-plugin/skills/making-the-business-case-for-code-health/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: making-the-business-case-for-code-health
+description: Use when a user asks for ROI, stakeholder justification, delivery impact, or defect-risk reduction from improving Code Health in a file.
+---
+
+# Making the Business Case for Code Health
+
+## Overview
+
+Use this skill when the user needs quantified justification for refactoring work. The purpose is to convert current Code Health into a clear argument about delivery speed and defect reduction.
+
+## When to Use
+
+- A user asks for ROI, business value, or management justification.
+- The workflow needs evidence to prioritize refactoring work.
+- An engineering team needs a short case for why improving a file is worth the effort.
+
+Do not use this skill to explain Code Health fundamentals. Use `explaining-code-health` for that.
+
+## Quick Reference
+
+- `code_health_refactoring_business_case`: Generate modeled outcomes for one file.
+- `code_health_score`: Optional supporting baseline when the user wants the current score called out separately.
+
+## Implementation
+
+1. Run `code_health_refactoring_business_case` for the target file.
+2. Present the recommended target scenario.
+3. Summarize the optimistic and pessimistic outcomes as a bounded range, not a promise.
+4. Translate the output into a short investment rationale tied to delivery speed and defect reduction.
+5. If needed, pair the result with `code_health_score` or `code_health_review` to show why the file is a refactoring candidate.
+
+## Common Mistakes
+
+- Presenting modeled outcomes as guarantees.
+- Using this skill for project-wide ranking without first narrowing candidate files.
+- Explaining raw JSON instead of converting it into a short business argument.
+- Forgetting that the tool is file-scoped.

--- a/claude-code-plugin/skills/prioritizing-technical-debt/SKILL.md
+++ b/claude-code-plugin/skills/prioritizing-technical-debt/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: prioritizing-technical-debt
+description: Use when users with a CodeScene instance ask what to improve first across a project, which hotspots matter most, or how to rank refactoring candidates.
+---
+
+# Prioritizing Technical Debt
+
+## Overview
+
+Use this skill to bring high-level CodeScene project data into planning. The goal is to turn hotspots, goals, and file-level metrics into a ranked improvement plan rather than just listing raw results.
+
+## When to Use
+
+- The user asks what to improve first.
+- The workflow needs a ranked list of refactoring targets.
+- The user has a CodeScene instance and wants project-level guidance.
+
+Do not use this skill for single-file refactoring mechanics. Use `guiding-refactoring-with-code-health` for that.
+
+## Quick Reference
+
+- `select_project`: Establish the correct project context.
+- `list_technical_debt_hotspots_for_project`: Find high-impact hotspots.
+- `list_technical_debt_goals_for_project`: Find files with explicit debt goals.
+- `list_technical_debt_hotspots_for_project_file`: Drill into a shortlisted file.
+- `list_technical_debt_goals_for_project_file`: Drill into file-level goals.
+- `code_health_score`: Compare or validate shortlisted files.
+- `code_health_refactoring_business_case`: Add ROI framing when the user wants justification.
+
+## Implementation
+
+1. Run `select_project` if the project context is not already clear.
+2. Gather project hotspots and project goals.
+3. Shortlist candidates based on hotspot severity, churn, and explicit goals.
+4. Drill into the top files with the file-level hotspot and goal tools.
+5. Use `code_health_score` to support ranking.
+6. Return a ranked list, a small incremental plan for each top candidate, and business justification when relevant.
+
+## Common Mistakes
+
+- Skipping project selection and mixing data from the wrong project.
+- Dumping hotspots and goals without ranking or synthesis.
+- Using only one signal when hotspots and goals should be combined.
+- Reaching for ROI before identifying the most plausible candidates.

--- a/claude-code-plugin/skills/risk-based-testing-with-code-health/SKILL.md
+++ b/claude-code-plugin/skills/risk-based-testing-with-code-health/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: risk-based-testing-with-code-health
+description: Use when a user asks what to test first based on CodeScene findings, especially for high-risk hotspots or pull-request change sets.
+---
+
+# Risk-Based Testing With Code Health
+
+## Overview
+Use this skill when the goal is to turn CodeScene risk signals into practical testing priorities.
+The output should help testers and developers focus limited test time on the code most likely to produce defects.
+
+The primary signal is always the **current branch's change set** — what has actually changed is more immediately actionable than historical hotspots. Hotspots provide background context and catch systemic risk, but they should not displace focus from files the branch has already touched.
+
+## When to Use
+- A user asks where testing should focus based on CodeScene hotspots.
+- A user asks for a tester-friendly test plan from technical debt or code health findings.
+- A user wants pull-request risk translated into concrete test scenarios.
+- A release owner asks for risk-based regression scope before ship.
+
+Do not use this skill when the user only asks for conceptual definitions of Code Health.
+Use `explaining-code-health` for fundamentals.
+
+Do not use this skill when the user asks for quantified financial ROI of refactoring.
+Use `making-the-business-case-for-code-health` for ROI framing.
+
+## Minimum Inputs
+- `project_id` (CodeScene project identifier)
+- `base_ref` (for change-set analysis, e.g. `main` or `origin/main`)
+- `git_repository_path` (absolute local repository path)
+- Optional: business criticality hints from the user (for example: release-blocking areas, customer-facing commands)
+
+## Quick Reference
+- `list_technical_debt_hotspots_for_project`: Identify high-risk files using low Code Health and high historical churn.
+- `analyze_change_set`: Evaluate immediate risk in the current branch vs target base.
+- `code_health_score`: Inspect specific files in detail.
+- `code_ownership_for_path`: Route high-risk areas to likely reviewers/domain experts.
+- `list_technical_debt_goals_for_project`: Include existing debt goals when present.
+
+## Implementation
+1. **Analyse the current branch first**
+   - Run `analyze_change_set` against the target base ref. This is the primary source of truth.
+   - Identify which files were changed, whether Code Health degraded, and whether any quality gates failed.
+   - If no branch context exists (e.g. ad-hoc analysis), skip to step 2 and treat hotspots as the primary signal instead.
+
+2. **Add systemic context from hotspots**
+   - Run `list_technical_debt_hotspots_for_project` to surface high-churn, low-health files.
+   - Note which hotspots overlap with the change set — those are the highest combined risk.
+   - Hotspots with no overlap are background risk; include them but do not let them overshadow branch findings.
+   - If needed, run `code_health_score` on specific candidates for more detail.
+
+3. **Prioritize by combined risk**
+   - Change-set files with Code Health degradation or failed gates: always rank first.
+   - Change-set files that are also hotspots: rank second.
+   - Change-set files with healthy scores: rank third.
+   - Hotspots not in the change set: background context only.
+
+4. **Translate technical areas into business context**
+   - For each top area, explain:
+     - what user-facing capability it supports
+     - what failures would look like for a user/customer
+     - why it is risky now (with evidence)
+
+5. **Generate tester-ready scenarios**
+   - Provide concrete test charters:
+     - happy path
+     - edge cases
+     - negative/error handling paths
+     - platform/configuration matrix where relevant
+
+6. **Route ownership for action**
+   - Use `code_ownership_for_path` for top 3 risky files/areas.
+   - Suggest reviewers/test collaborators.
+
+## Required Output Schema
+Always return the following sections in order:
+
+1. **Top Risk Areas**
+   - Area name
+   - Business context
+   - Why risky now (with CodeScene evidence)
+   - Confidence and assumptions
+
+2. **Priority Test Charters**
+   - Scenario
+   - Expected behavior
+   - Failure signal
+   - Environment matrix (OS/RID/device/framework if relevant)
+   - Priority (`P0`, `P1`, `P2`)
+
+3. **Must-Pass Before Merge/Release**
+   - Minimal blocking checks
+   - Pass/fail recommendation criteria
+
+4. **Ownership and Routing**
+   - Suggested owner/reviewer per top risk area
+   - Next action handoff
+
+5. **Open Risks**
+   - Known unknowns
+   - Deferred tests and rationale
+
+## Quality Bar
+- Do not return only class/method names; always include business context.
+- Do not treat all low-score files as equally risky; include churn and change-set evidence.
+- Do not produce generic advice; include concrete test scenarios and expected outcomes.
+- Explicitly distinguish PR-local risk from systemic technical debt.
+
+## Common Mistakes
+- Listing hotspots without converting them into tester actions.
+- Treating hotspots as the primary signal when an active branch change set is available.
+- Running `list_technical_debt_hotspots_for_project` before `analyze_change_set` and letting the longer list crowd out branch findings.
+- Omitting expected outcomes, which makes tests non-verifiable.
+- Failing to identify who should own follow-up.
+- Using abstract language with no user/business impact framing.
+
+## Stop Conditions
+If required setup is missing (for example, project not selected, invalid repo path, missing base ref):
+- Stop and return a concise setup checklist.
+- Do not generate speculative risk rankings.
+
+## Example Trigger Phrases
+- "Where should QA focus first for this PR?"
+- "What should we regression test based on CodeScene?"
+- "Translate these hotspots into a practical test plan."
+- "Which high-risk areas are release blockers?"

--- a/claude-code-plugin/skills/routing-work-with-code-ownership/SKILL.md
+++ b/claude-code-plugin/skills/routing-work-with-code-ownership/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: routing-work-with-code-ownership
+description: Use when choosing reviewers, domain experts, or likely owners for a file or directory from CodeScene project data.
+---
+
+# Routing Work With Code Ownership
+
+## Overview
+
+Use CodeScene ownership data to route work to the right people. This skill helps an agent connect files or directories to likely reviewers and domain experts.
+
+## When to Use
+
+- The user asks who should review or own a change.
+- The workflow needs likely experts for a file, directory, or subsystem.
+- The agent needs to connect refactoring recommendations to responsible people.
+
+Do not use this skill to rank technical debt. Use `prioritizing-technical-debt` for that.
+
+## Quick Reference
+
+- `select_project`: Establish the correct project context if needed.
+- `code_ownership_for_path`: Retrieve likely owners and their key paths for a file or directory.
+
+## Implementation
+
+1. Establish the correct project context.
+2. Run `code_ownership_for_path` for the relevant file or directory.
+3. Present likely owners with their key areas.
+4. Use the ownership result to recommend reviewers, escalation paths, or stakeholders.
+
+## Common Mistakes
+
+- Using repository intuition instead of ownership data when the tool is available.
+- Treating ownership as an absolute truth instead of a strong signal.
+- Omitting the path context when the subsystem spans multiple files.

--- a/claude-code-plugin/skills/safeguarding-ai-generated-code/SKILL.md
+++ b/claude-code-plugin/skills/safeguarding-ai-generated-code/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: safeguarding-ai-generated-code
+description: Use when AI-generated or AI-modified changes need a Code Health gate before commit, handoff, or pull request.
+---
+
+# Safeguarding AI-Generated Code
+
+## Overview
+
+Use Code Health safeguards before declaring AI-touched code ready. The goal is to catch maintainability regressions early and prevent agents from normalizing technical debt.
+
+## When to Use
+
+- The agent changed code and is about to suggest a commit.
+- The user asks whether a branch or staged changes are safe to merge.
+- The workflow needs a quality gate for AI-generated code.
+
+Do not use this skill for broad refactoring discovery or project-level prioritization.
+
+## Quick Reference
+
+- `code_health_review`: Review each AI-modified file immediately after the change.
+- `pre_commit_code_health_safeguard`: Check staged or modified files before commit.
+- `analyze_change_set`: Check a branch or PR-style change set against a base ref.
+
+## Implementation
+
+1. After each AI modification to a file, run `code_health_review` on that file.
+2. If the review reports maintainability problems or regression risk, refactor the file in small steps and review it again.
+3. Run `pre_commit_code_health_safeguard` before commit-oriented recommendations as a broader gate across staged or modified files.
+4. Run `analyze_change_set` before PR-oriented recommendations as a final branch-level gate.
+5. If either later gate reports a regression, inspect the affected files with `code_health_review` and keep iterating until the issue is removed or the user explicitly accepts the risk.
+
+## Common Mistakes
+
+- Waiting until commit time to run the first Code Health check.
+- Treating safeguard output as optional guidance instead of a release gate.
+- Declaring work done after a failing safeguard.
+- Jumping straight to broad rewrites instead of inspecting the flagged files first.
+- Treating an accepted risk as invisible; call it out explicitly.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "codehealth-mcp",
-  "version": "1.1.2",
+  "version": "1.1.6",
   "description": "CodeScene's Code Health analysis as local AI-friendly tools.",
   "author": {
     "name": "CodeScene",


### PR DESCRIPTION
This PR updates the Claude Code plugin to version 1.1.6:
- Version strings in `manifest.json` and `plugin.json`
- Skills synced from `skills/`
- README skills table regenerated