### PR TITLE
Fix tool filtering broken by rmcp-macros 1.6.0 default router change

### DIFF
--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -9,7 +9,7 @@ use rmcp::{tool_handler, ErrorData, RoleServer, ServerHandler};
 
 use crate::{config, prompts, resources, CodeSceneServer};
 
-#[tool_handler]
+#[tool_handler(router = "self.tool_router")]
 impl ServerHandler for CodeSceneServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(


### PR DESCRIPTION
The rmcp-macros upgrade from 1.3.0 to 1.6.0 changed the default router expression in #[tool_handler] from 'self.tool_router' (instance field) to 'Self::tool_router()' (static method). This caused list_tools, call_tool, and get_tool to use a fresh unmodified router, ignoring enabled_tools filtering and standalone tool removal.

Explicitly set router = "self.tool_router" to use the instance field.