### PR TITLE
CS-11252: Add `X-CS-Source` header to identify MCP as request origin

### DIFF
--- a/src/ace_client.rs
+++ b/src/ace_client.rs
@@ -80,6 +80,7 @@ fn build_ace_headers(token: &str) -> HashMap<String, String> {
             "User-Agent".to_string(),
             format!("codescene-mcp/{}", env!("CS_MCP_VERSION")),
         ),
+        ("X-CS-Source".to_string(), "mcp".to_string()),
     ]);
     if !token.is_empty() {
         headers.insert("Authorization".to_string(), format!("Bearer {token}"));

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -48,6 +48,7 @@ fn build_api_headers(token: &str) -> HashMap<String, String> {
             "User-Agent".to_string(),
             format!("codescene-mcp/{}", env!("CS_MCP_VERSION")),
         ),
+        ("X-CS-Source".to_string(), "mcp".to_string()),
     ]);
     if !token.is_empty() {
         headers.insert("Authorization".to_string(), format!("Bearer {token}"));

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -65,6 +65,7 @@ async fn send_event(mut te: TrackingEvent, client: &dyn HttpClient) -> Result<()
             "User-Agent".to_string(),
             format!("codescene-mcp/{}", env!("CS_MCP_VERSION")),
         ),
+        ("X-CS-Source".to_string(), "mcp".to_string()),
     ]);
     if !token.is_empty() {
         headers.insert("Authorization".to_string(), format!("Bearer {token}"));


### PR DESCRIPTION
This pull request adds a new custom header, `X-CS-Source: mcp`, to outgoing HTTP requests in several client modules. This helps identify the source of the requests for downstream services.

Header addition for source identification:

* Added the `X-CS-Source: mcp` header to all requests made by the `build_ace_headers` function in `src/ace_client.rs`.
* Added the `X-CS-Source: mcp` header to all requests made by the `build_api_headers` function in `src/api_client.rs`.
* Added the `X-CS-Source: mcp` header to all tracking event requests in `src/tracking.rs`.