### PR TITLE
CS-11228: Secure config file permissions and use atomic writes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -197,10 +197,27 @@ pub fn load() -> Result<ConfigData, ConfigError> {
 pub fn save(data: &ConfigData) -> Result<(), ConfigError> {
     let dir = config_dir();
     std::fs::create_dir_all(&dir)?;
+    restrict_path_permissions(&dir);
     let path = dir.join("config.json");
     let content = serde_json::to_string_pretty(data)?;
-    std::fs::write(path, content)?;
+    // Atomic write: temp file + rename to avoid truncation on crash
+    let temp = tempfile::NamedTempFile::new_in(&dir)?;
+    std::fs::write(temp.path(), &content)?;
+    restrict_path_permissions(temp.path());
+    temp.persist(&path).map_err(|e| {
+        ConfigError::Io(std::io::Error::new(std::io::ErrorKind::Other, e))
+    })?;
     Ok(())
+}
+
+/// Restrict path permissions to owner-only (0700 for dirs, 0600 for files) on Unix.
+fn restrict_path_permissions(path: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = if path.is_dir() { 0o700 } else { 0o600 };
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+    }
 }
 
 /// Record which config-related env vars are already set by the MCP client.

--- a/src/config.rs
+++ b/src/config.rs
@@ -619,6 +619,26 @@ mod tests {
     }
 
     #[test]
+    fn save_persist_failure_returns_io_error() {
+        with_temp_config_dir(|dir| {
+            // Create a directory where config.json should be, so persist (rename) fails
+            let blocker = dir.join("config.json");
+            std::fs::create_dir_all(&blocker).unwrap();
+            std::fs::write(blocker.join("block"), "x").unwrap(); // non-empty dir can't be replaced
+
+            let data = ConfigData {
+                instance_id: Some("persist-fail".to_string()),
+                values: HashMap::new(),
+            };
+            let err = save(&data).unwrap_err();
+            assert!(
+                matches!(err, ConfigError::Io(_)),
+                "expected ConfigError::Io, got: {err:?}"
+            );
+        });
+    }
+
+    #[test]
     fn load_creates_default_when_missing() {
         with_temp_config_dir(|dir| {
             let data = load().unwrap();


### PR DESCRIPTION
- Set 0700 on config directory and 0600 on config file (Unix) to prevent other users from reading tokens on shared hosts.
- Use tempfile + rename for atomic writes to avoid truncation on crash.