### PR TITLE
CS-11229: Add SHA-256 checksum verification for CLI downloads

### DIFF
--- a/.agents/skills/update-cli-version/SKILL.md
+++ b/.agents/skills/update-cli-version/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: update-cli-version
+description: Update the embedded CodeScene CLI to a new version, including downloading new binaries, computing SHA-256 checksums, and updating all pinned hashes in cli-checksums.sha256 and Dockerfile.
+metadata:
+  audience: contributors
+  language: rust
+---
+
+## Purpose
+
+Use this skill when upgrading the CodeScene CLI (`cs`) that is embedded in the MCP server binary and installed in the Docker image. The CLI is integrity-verified at build time, so upgrading requires updating multiple checksum files in lockstep.
+
+## Files involved
+
+| File | What to update | Why |
+|---|---|---|
+| `cli-checksums.sha256` | SHA-256 hashes for all 5 platform zip files | `build.rs` verifies the downloaded zip against these hashes at compile time |
+| `Dockerfile` | `CS_CLI_INSTALLER_SHA256` ARG value | The Docker build verifies the installer script hash before executing it |
+| `cli-checksums.sha256` line 1 | Version comment | Keeps the file self-documenting |
+
+The download URL in `build.rs` uses `-latest.zip` (not a versioned URL), so the URL itself does not change — only the checksums change.
+
+## Step-by-Step
+
+### 1. Download all platform zips and compute checksums
+
+Download each of the 5 platform variants and compute their SHA-256 hashes:
+
+```bash
+for variant in macos-aarch64 macos-amd64 linux-amd64 linux-aarch64 windows-amd64; do
+  url="https://downloads.codescene.io/enterprise/cli/cs-${variant}-latest.zip"
+  sha=$(curl --proto '=https' --tlsv1.2 -fsSL "$url" | shasum -a 256 | cut -d' ' -f1)
+  echo "${sha}  cs-${variant}-latest.zip"
+done
+```
+
+### 2. Get the new CLI version string
+
+Extract the version from one of the downloaded binaries:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  "https://downloads.codescene.io/enterprise/cli/cs-macos-aarch64-latest.zip" \
+  -o /tmp/cs-cli-version-check.zip
+unzip -o /tmp/cs-cli-version-check.zip -d /tmp/cs-cli-version-check
+chmod +x /tmp/cs-cli-version-check/cs
+/tmp/cs-cli-version-check/cs version
+```
+
+The first line of output looks like: `cs version 1.0.28 (commit-hash)`
+
+### 3. Update `cli-checksums.sha256`
+
+Replace the entire file contents with the new hashes and version comment. The format is:
+
+```
+# SHA-256 checksums for CodeScene CLI v<NEW_VERSION>
+# Verify with: shasum -a 256 -c cli-checksums.sha256
+# Update by downloading each variant and running: shasum -a 256 <file>
+<hash>  cs-macos-aarch64-latest.zip
+<hash>  cs-macos-amd64-latest.zip
+<hash>  cs-linux-amd64-latest.zip
+<hash>  cs-linux-aarch64-latest.zip
+<hash>  cs-windows-amd64-latest.zip
+```
+
+### 4. Update the Dockerfile installer checksum
+
+Compute the SHA-256 of the installer script:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://downloads.codescene.io/enterprise/cli/install-cs-tool.sh \
+  | shasum -a 256 | cut -d' ' -f1
+```
+
+Then update the `CS_CLI_INSTALLER_SHA256` ARG in `Dockerfile` (line 34):
+
+```dockerfile
+ARG CS_CLI_INSTALLER_SHA256="<new_hash>"
+```
+
+### 5. Clean build and verify
+
+The build cache may contain the old zip. Clean and rebuild:
+
+```bash
+cargo clean
+cargo build
+```
+
+The build will:
+1. Download the CLI zip via curl with `--proto =https --tlsv1.2`
+2. Compute its SHA-256
+3. Compare against `cli-checksums.sha256`
+4. Fail with a clear error if there's a mismatch
+
+### 6. Run tests
+
+```bash
+cargo test
+```
+
+All existing tests must still pass — the CLI version upgrade should be transparent to the test suite.
+
+## Troubleshooting
+
+**Build fails with "SHA-256 checksum verification failed":**
+The downloaded zip doesn't match `cli-checksums.sha256`. Either the checksums file has a typo, or the CDN is serving different content than what you hashed. Re-run step 1 and compare.
+
+**Build fails with "No checksum entry found for '...'":**
+A new platform variant was added to `build.rs` but not to `cli-checksums.sha256`. Add the missing line.
+
+**Dockerfile build fails with "sha256sum: WARNING: 1 computed checksum did NOT match":**
+The installer script changed. Re-run step 4 to get the new hash.
+
+## Checklist
+
+Before considering the upgrade complete:
+
+- [ ] All 5 platform hashes updated in `cli-checksums.sha256`
+- [ ] Version comment in `cli-checksums.sha256` updated to new CLI version
+- [ ] `CS_CLI_INSTALLER_SHA256` in `Dockerfile` updated
+- [ ] `cargo clean && cargo build` succeeds (verifies checksum logic end-to-end)
+- [ ] `cargo test` passes
+- [ ] New CLI version confirmed with `cargo run -- --cli-version`

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,15 @@ RUN apt-get update \
 # "dubious ownership" safe-directory check (git 2.35.2+).
 RUN git config --global safe.directory '*'
 
-# Install the CodeScene CLI (cs-tool)
-RUN curl https://downloads.codescene.io/enterprise/cli/install-cs-tool.sh | bash -s -- -y
+# Install the CodeScene CLI (cs-tool) with integrity verification.
+# Update the checksum when upgrading the CLI version.
+ARG CS_CLI_INSTALLER_SHA256="6a119bd0746de31740bb899fbcc16f44b31df2392740642d5a29616961501f06"
+RUN set -eu; \
+    curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/install-cs-tool.sh \
+         https://downloads.codescene.io/enterprise/cli/install-cs-tool.sh && \
+    echo "${CS_CLI_INSTALLER_SHA256}  /tmp/install-cs-tool.sh" | sha256sum -c - && \
+    bash /tmp/install-cs-tool.sh -y && \
+    rm /tmp/install-cs-tool.sh
 
 # Copy the binary from the builder stage
 COPY --from=builder /build/target/release/cs-mcp /usr/local/bin/cs-mcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG VERSION=dev
 WORKDIR /build
 
 # Copy only what the build needs (keeps layer cache friendly)
-COPY Cargo.toml Cargo.lock build.rs ./
+COPY Cargo.toml Cargo.lock build.rs cli-checksums.sha256 ./
 COPY src/ src/
 
 RUN CS_MCP_VERSION="${VERSION}" cargo build --release

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,17 @@
 ///
 /// The git tag (e.g., "v1.0.0") is available as `env!("CS_MCP_VERSION")`.
 /// The CS CLI zip is downloaded to `OUT_DIR/cs-cli.zip` and embedded at compile time.
+///
+/// Security: downloaded CLI zips are verified against SHA-256 checksums
+/// committed in `cli-checksums.sha256`. Update that file when upgrading
+/// the CLI version.
+
+use std::collections::HashMap;
 
 fn main() {
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs/tags");
+    println!("cargo:rerun-if-changed=cli-checksums.sha256");
     println!("cargo:rerun-if-env-changed=CS_MCP_VERSION");
     println!("cargo:rerun-if-env-changed=CS_CLI_EMBED_PATH");
 
@@ -51,20 +58,209 @@ fn download_cli() {
         return;
     }
 
-    // Skip re-download if already present (cargo caches OUT_DIR across rebuilds)
+    // Skip re-download if already present and verified
     if std::path::Path::new(&dest).exists() {
-        return;
+        if verify_checksum(&dest) {
+            return;
+        }
+        // Checksum mismatch on cached file — re-download
+        eprintln!("Cached CLI zip failed checksum verification, re-downloading");
+        std::fs::remove_file(&dest).ok();
     }
 
     let url = cli_download_url();
     eprintln!("Downloading CS CLI from {url}");
 
     let status = std::process::Command::new("curl")
-        .args(["-fsSL", "-o", &dest, &url])
+        .args([
+            "--proto", "=https",
+            "--tlsv1.2",
+            "-fsSL",
+            "-o", &dest,
+            &url,
+        ])
         .status()
         .expect("failed to run curl");
 
     assert!(status.success(), "Failed to download CS CLI from {url}");
+
+    assert!(
+        verify_checksum(&dest),
+        "SHA-256 checksum verification failed for downloaded CLI zip.\n\
+         This could indicate a corrupted download or a supply-chain attack.\n\
+         If you are intentionally upgrading the CLI, update cli-checksums.sha256."
+    );
+}
+
+/// Verify the downloaded file against the committed SHA-256 checksums.
+fn verify_checksum(file_path: &str) -> bool {
+    let checksums = load_checksums();
+    let zip_name = cli_zip_filename();
+
+    let expected = match checksums.get(&zip_name) {
+        Some(hash) => hash,
+        None => {
+            panic!(
+                "No checksum entry found for '{zip_name}' in cli-checksums.sha256.\n\
+                 Add a line: <sha256>  {zip_name}"
+            );
+        }
+    };
+
+    let actual = sha256_hex(file_path);
+    if actual != *expected {
+        eprintln!(
+            "Checksum mismatch for {zip_name}:\n  expected: {expected}\n  actual:   {actual}"
+        );
+        return false;
+    }
+
+    true
+}
+
+fn sha256_hex(path: &str) -> String {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).expect("failed to open file for checksum");
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = file.read(&mut buf).expect("failed to read file");
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    hasher.finalize_hex()
+}
+
+/// Minimal SHA-256 implementation for build script (no external crate dependencies).
+struct Sha256 {
+    state: [u32; 8],
+    buffer: Vec<u8>,
+    total_len: u64,
+}
+
+impl Sha256 {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+
+    fn new() -> Self {
+        Self {
+            state: [
+                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c,
+                0x1f83d9ab, 0x5be0cd19,
+            ],
+            buffer: Vec::new(),
+            total_len: 0,
+        }
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.total_len += data.len() as u64;
+        self.buffer.extend_from_slice(data);
+        while self.buffer.len() >= 64 {
+            let block: [u8; 64] = self.buffer[..64].try_into().unwrap();
+            self.compress(&block);
+            self.buffer.drain(..64);
+        }
+    }
+
+    fn compress(&mut self, block: &[u8; 64]) {
+        let mut w = [0u32; 64];
+        for i in 0..16 {
+            w[i] = u32::from_be_bytes(block[i * 4..i * 4 + 4].try_into().unwrap());
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = self.state;
+
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = h
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(Self::K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+
+        self.state[0] = self.state[0].wrapping_add(a);
+        self.state[1] = self.state[1].wrapping_add(b);
+        self.state[2] = self.state[2].wrapping_add(c);
+        self.state[3] = self.state[3].wrapping_add(d);
+        self.state[4] = self.state[4].wrapping_add(e);
+        self.state[5] = self.state[5].wrapping_add(f);
+        self.state[6] = self.state[6].wrapping_add(g);
+        self.state[7] = self.state[7].wrapping_add(h);
+    }
+
+    fn finalize_hex(mut self) -> String {
+        let bit_len = self.total_len * 8;
+        self.buffer.push(0x80);
+        while (self.buffer.len() % 64) != 56 {
+            self.buffer.push(0);
+        }
+        self.buffer.extend_from_slice(&bit_len.to_be_bytes());
+
+        let padded = std::mem::take(&mut self.buffer);
+        for chunk in padded.chunks(64) {
+            let block: [u8; 64] = chunk.try_into().unwrap();
+            self.compress(&block);
+        }
+
+        self.state
+            .iter()
+            .map(|v| format!("{v:08x}"))
+            .collect::<String>()
+    }
+}
+
+/// Parse cli-checksums.sha256 into a map of filename -> hash.
+fn load_checksums() -> HashMap<String, String> {
+    let content = std::fs::read_to_string("cli-checksums.sha256")
+        .expect("Failed to read cli-checksums.sha256 — is it committed in the repo root?");
+
+    content
+        .lines()
+        .filter(|line| !line.starts_with('#') && !line.trim().is_empty())
+        .map(|line| {
+            let mut parts = line.split_whitespace();
+            let hash = parts.next().expect("malformed checksum line: missing hash");
+            let filename = parts
+                .next()
+                .expect("malformed checksum line: missing filename");
+            (filename.to_string(), hash.to_string())
+        })
+        .collect()
 }
 
 fn maybe_embed_local_cli(dest_zip: &str) -> bool {
@@ -101,6 +297,16 @@ fn maybe_embed_local_cli(dest_zip: &str) -> bool {
 }
 
 fn cli_download_url() -> String {
+    let (os_part, arch_part) = cli_platform_parts();
+    format!("https://downloads.codescene.io/enterprise/cli/cs-{os_part}-{arch_part}-latest.zip")
+}
+
+fn cli_zip_filename() -> String {
+    let (os_part, arch_part) = cli_platform_parts();
+    format!("cs-{os_part}-{arch_part}-latest.zip")
+}
+
+fn cli_platform_parts() -> (&'static str, &'static str) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
 
@@ -117,5 +323,5 @@ fn cli_download_url() -> String {
         other => panic!("Unsupported target arch: {other}"),
     };
 
-    format!("https://downloads.codescene.io/enterprise/cli/cs-{os_part}-{arch_part}-latest.zip")
+    (os_part, arch_part)
 }

--- a/cli-checksums.sha256
+++ b/cli-checksums.sha256
@@ -1,0 +1,8 @@
+# SHA-256 checksums for CodeScene CLI v1.0.28
+# Verify with: shasum -a 256 -c cli-checksums.sha256
+# Update by downloading each variant and running: shasum -a 256 <file>
+2a69494926aac406fff60a3c605425899f2b0bd4998c058dda7e368f97c4a017  cs-macos-aarch64-latest.zip
+fc3b96203c52c92ed1aace9cb3104c658643c40783654c63001a61c1258e5647  cs-macos-amd64-latest.zip
+e4c81fb27537caa168bcd89d843a8534e8caeb8d70c92304496a551cb389d7b3  cs-linux-amd64-latest.zip
+fa43f064f366c18ffd627c75251361668b9407ad7926623f28faec28cae99046  cs-linux-aarch64-latest.zip
+0d76e300f58547e2a4ed4c6a031a96386d4c802f444ee220383ac243c4ffd3e3  cs-windows-amd64-latest.zip


### PR DESCRIPTION
Pin embedded CLI by SHA-256 in build.rs and verify after download. Harden `curl` with `--proto =https --tlsv1.2` in both build.rs and Dockerfile. Add `update-cli-version` skill documenting the upgrade workflow.