### PR TITLE
CS-11233: Scrub sensitive tokens from child process environments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -95,6 +95,14 @@ async fn run_cli_process(
     let mut cmd = tokio::process::Command::new(cli_path);
     let effective_args = with_ssl_cli_args_if_needed(cli_path, args);
 
+    // Scrub sensitive env vars (tokens) from the inherited environment so
+    // child processes that don't need them can't read them from /proc or
+    // inherit them to further subprocesses.  We then selectively add back
+    // only CS_ACCESS_TOKEN, which the CLI needs for on-prem authentication.
+    for var in crate::config::sensitive_env_vars() {
+        cmd.env_remove(var);
+    }
+
     cmd.args(&effective_args)
         .env("CS_CONTEXT", "mcp-server")
         .env("CS_DISABLE_VERSION_CHECK", "1");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -274,7 +274,7 @@ fn atomic_write_with_restricted_permissions(target: &Path, data: &[u8]) -> bool 
     };
 
     // Write to a temp file in the same directory (same filesystem for rename)
-    let tmp_path = parent.join(format!(".tmp-{}", std::process::id()));
+    let tmp_path = parent.join(format!(".tmp-{}-{:?}", std::process::id(), std::thread::current().id()));
     if std::fs::write(&tmp_path, data).is_err() {
         return false;
     }
@@ -475,6 +475,10 @@ mod tests {
     use std::os::unix::process::ExitStatusExt;
     use std::process::ExitStatus;
 
+    /// Serialize tests that touch the shared truststore cache directory
+    /// to prevent parallel filesystem races on the same hash-derived path.
+    static TRUSTSTORE_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// Create a temp directory containing a `.git` dir and an optional subdirectory.
     /// Returns `(tempdir_handle, repo_root_path)`.
     fn make_git_repo(subdir: Option<&str>) -> (tempfile::TempDir, PathBuf) {
@@ -631,6 +635,7 @@ mod tests {
 
     #[test]
     fn create_or_get_truststore_from_pem_creates_pkcs12_truststore() {
+        let _lock = TRUSTSTORE_TEST_MUTEX.lock().unwrap();
         let pem = tempfile::NamedTempFile::new().unwrap();
         let cert_pem = TEST_CA_CERT_PEM.as_bytes();
         std::fs::write(pem.path(), cert_pem).unwrap();
@@ -688,6 +693,7 @@ mod tests {
     #[test]
     fn create_or_get_truststore_rejects_world_writable_existing_file() {
         use std::os::unix::fs::PermissionsExt;
+        let _lock = TRUSTSTORE_TEST_MUTEX.lock().unwrap();
         let pem = tempfile::NamedTempFile::new().unwrap();
         let cert_pem = TEST_CA_CERT_PEM.as_bytes();
         std::fs::write(pem.path(), cert_pem).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -351,6 +351,16 @@ pub fn enabled_tools(data: &ConfigData) -> Option<HashSet<String>> {
 /// Shows a short prefix to identify the token kind, without revealing entropy.
 const SENSITIVE_PREFIX_LENGTH: usize = 4;
 
+/// Returns the env var names of all sensitive config options (tokens, keys, etc.).
+/// Used to scrub secrets from child process environments.
+pub fn sensitive_env_vars() -> Vec<&'static str> {
+    OPTIONS
+        .iter()
+        .filter(|o| o.sensitive)
+        .map(|o| o.env_var)
+        .collect()
+}
+
 pub fn mask_if_sensitive(option: &ConfigOption, value: &str) -> String {
     if option.sensitive && !value.is_empty() {
         if value.len() <= SENSITIVE_PREFIX_LENGTH {
@@ -885,5 +895,27 @@ mod tests {
         let opt = find_option("environment");
         assert!(opt.is_some());
         assert_eq!(opt.unwrap().key, "tracking_environment");
+    }
+
+    #[test]
+    fn sensitive_env_vars_includes_tokens() {
+        let vars = sensitive_env_vars();
+        assert!(
+            vars.contains(&"CS_ACCESS_TOKEN"),
+            "should include CS_ACCESS_TOKEN"
+        );
+        assert!(
+            vars.contains(&"CS_ACE_ACCESS_TOKEN"),
+            "should include CS_ACE_ACCESS_TOKEN"
+        );
+    }
+
+    #[test]
+    fn sensitive_env_vars_excludes_non_sensitive() {
+        let vars = sensitive_env_vars();
+        assert!(
+            !vars.contains(&"CS_ONPREM_URL"),
+            "should not include non-sensitive CS_ONPREM_URL"
+        );
     }
 }

--- a/src/tools/common.rs
+++ b/src/tools/common.rs
@@ -36,6 +36,22 @@ pub(crate) async fn run_review(
     cli_runner.run(&args, git_root.as_deref()).await
 }
 
+/// Run `git update-index --refresh` to fix index extensions that the
+/// container's git cannot parse.  Scrubs sensitive env vars from the
+/// child process since git never needs tokens.  Non-zero exit is
+/// expected and harmless.
+async fn refresh_git_index(repo_path: &Path) {
+    let mut git_cmd = tokio::process::Command::new("git");
+    for var in crate::config::sensitive_env_vars() {
+        git_cmd.env_remove(var);
+    }
+    let _ = git_cmd
+        .args(["update-index", "--refresh"])
+        .current_dir(repo_path)
+        .output()
+        .await;
+}
+
 pub(crate) async fn run_delta(
     repo_path: &Path,
     base_ref: Option<&str>,
@@ -49,16 +65,7 @@ pub(crate) async fn run_delta(
     // The command may return non-zero when file stats differ across the
     // bind-mount boundary — that is expected and harmless.
     if environment::is_docker() {
-        let mut git_cmd = tokio::process::Command::new("git");
-        // Scrub sensitive env vars — git never needs tokens.
-        for var in crate::config::sensitive_env_vars() {
-            git_cmd.env_remove(var);
-        }
-        let _ = git_cmd
-            .args(["update-index", "--refresh"])
-            .current_dir(repo_path)
-            .output()
-            .await;
+        refresh_git_index(repo_path).await;
     }
 
     let mut args = vec!["delta", "--output-format=json"];
@@ -440,5 +447,40 @@ mod tests {
         let _ = run_delta(Path::new("/tmp"), Some("main"), &cli).await;
         let args = captured.lock().unwrap();
         assert_eq!(args.as_slice(), &["delta", "--output-format=json", "main"]);
+    }
+
+    #[tokio::test]
+    async fn refresh_git_index_runs_without_error() {
+        // refresh_git_index should tolerate any repo path and never panic.
+        // Using a temp dir (not a real git repo) — the command will fail
+        // with a non-zero exit code, which is expected and ignored.
+        let dir = tempfile::tempdir().unwrap();
+        refresh_git_index(dir.path()).await;
+        // No panic or error means success — the function deliberately
+        // ignores the exit status.
+    }
+
+    #[tokio::test]
+    async fn refresh_git_index_scrubs_sensitive_env_vars() {
+        // Verify the function removes sensitive env vars by setting one
+        // and confirming the child process doesn't see it.  We do this by
+        // running in a real git repo and checking that the function
+        // completes without propagating the token.
+        //
+        // We can't easily inspect the child env directly, but we verify
+        // the code path executes without error.  The actual env_remove
+        // coverage is ensured by calling refresh_git_index which iterates
+        // over sensitive_env_vars() and calls env_remove for each.
+        let dir = tempfile::tempdir().unwrap();
+        std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        // Set a sensitive env var in our process
+        std::env::set_var("CS_ACCESS_TOKEN", "test-secret");
+        refresh_git_index(dir.path()).await;
+        // Clean up
+        std::env::remove_var("CS_ACCESS_TOKEN");
     }
 }

--- a/src/tools/common.rs
+++ b/src/tools/common.rs
@@ -49,7 +49,12 @@ pub(crate) async fn run_delta(
     // The command may return non-zero when file stats differ across the
     // bind-mount boundary — that is expected and harmless.
     if environment::is_docker() {
-        let _ = tokio::process::Command::new("git")
+        let mut git_cmd = tokio::process::Command::new("git");
+        // Scrub sensitive env vars — git never needs tokens.
+        for var in crate::config::sensitive_env_vars() {
+            git_cmd.env_remove(var);
+        }
+        let _ = git_cmd
             .args(["update-index", "--refresh"])
             .current_dir(repo_path)
             .output()


### PR DESCRIPTION
This pull request introduces several security and reliability improvements related to handling sensitive environment variables and file operations, as well as enhancements to test reliability. The main focus is on ensuring that sensitive data (such as tokens and keys) are not leaked to child processes unnecessarily, and on preventing test flakiness due to shared resources.

**Security and Environment Handling:**

* Added a new function `sensitive_env_vars` in `config.rs` to enumerate all sensitive environment variable names, making it easier to scrub secrets from child process environments.
* Updated `run_cli_process` and `run_delta` to remove sensitive environment variables from child process environments, ensuring that only necessary secrets (like `CS_ACCESS_TOKEN` for on-prem authentication) are passed to subprocesses. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR98-R105) [[2]](diffhunk://#diff-0455cf2cf9cd55b610fd52a8219a6fa215cc7cb0837b1a2c4ed4056f5447b649L52-R57)

**Reliability and Testing:**

* Introduced a static mutex `TRUSTSTORE_TEST_MUTEX` to serialize tests that interact with the shared truststore cache directory, preventing parallel filesystem races and improving test reliability. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR478-R481) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR638) [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR696)
* Added unit tests to verify that `sensitive_env_vars` includes all relevant sensitive variables and excludes non-sensitive ones.

**File Handling:**

* Improved atomic file writing by including the thread ID in the temporary file name, reducing the risk of filename collisions during concurrent operations.