### PR TITLE
CS-11235: Stop sending raw stderr to telemetry, add file logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +386,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "zip",
@@ -2138,6 +2148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2370,6 +2386,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ schemars = "1"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter", "ansi", "std"] }
+tracing-appender = "0.2.5"
 
 # Error handling
 anyhow = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,6 +122,16 @@ pub const OPTIONS: &[ConfigOption] = &[
         aliases: &["tools"],
         docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
     },
+    ConfigOption {
+        key: "log_retention_days",
+        env_var: "CS_LOG_RETENTION_DAYS",
+        description: "Number of days to keep log files (default: 7, set to 0 to disable file logging)",
+        sensitive: false,
+        hidden: false,
+        api_only: false,
+        aliases: &["log_days"],
+        docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
+    },
 ];
 
 /// Tool names that can be enabled/disabled via the `enabled_tools` config.
@@ -334,6 +344,24 @@ pub fn enabled_tools(data: &ConfigData) -> Option<HashSet<String>> {
             .filter(|s| !s.is_empty())
             .collect(),
     )
+}
+
+/// Returns the number of days to retain log files. Defaults to 7.
+/// Returns 0 if file logging is disabled.
+pub fn log_retention_days(data: &ConfigData) -> u32 {
+    let option = match find_option("log_retention_days") {
+        Some(o) => o,
+        None => return 7,
+    };
+    match get_effective(option, data) {
+        Some(v) => v.trim().parse().unwrap_or(7),
+        None => 7,
+    }
+}
+
+/// Returns the directory for log files.
+pub fn log_dir() -> PathBuf {
+    config_dir().join("logs")
 }
 
 /// Mask sensitive values for display.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,30 @@ pub enum CliError {
     LicenseCheckFailed,
 }
 
+impl CliError {
+    /// Returns a safe, fixed label for telemetry (no sensitive data).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::NonZeroExit { .. } => "non_zero_exit",
+            Self::NotFound(_) => "not_found",
+            Self::Io(_) => "io",
+            Self::InvalidInput(_) => "invalid_input",
+            Self::LicenseCheckFailed => "license_check_failed",
+        }
+    }
+}
+
+impl ApiError {
+    /// Returns a safe, fixed label for telemetry (no sensitive data).
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Http(_) => "http",
+            Self::Transport(_) => "transport",
+            Self::Status { .. } => "status",
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
     #[error("Config I/O error: {0}")]
@@ -144,5 +168,56 @@ mod tests {
             body: "not found".into(),
         };
         assert_eq!(err.to_string(), "API error 404: not found");
+    }
+
+    #[test]
+    fn cli_error_kind_returns_safe_labels() {
+        assert_eq!(
+            CliError::NonZeroExit {
+                code: 1,
+                stderr: "secret token=abc123 /home/user/.ssh/id_rsa".into()
+            }
+            .kind(),
+            "non_zero_exit"
+        );
+        assert_eq!(CliError::NotFound("/usr/bin/cs".into()).kind(), "not_found");
+        assert_eq!(
+            CliError::Io(std::io::Error::new(std::io::ErrorKind::NotFound, "x")).kind(),
+            "io"
+        );
+        assert_eq!(
+            CliError::InvalidInput("bad".into()).kind(),
+            "invalid_input"
+        );
+        assert_eq!(CliError::LicenseCheckFailed.kind(), "license_check_failed");
+    }
+
+    #[test]
+    fn cli_error_kind_never_contains_sensitive_data() {
+        let err = CliError::NonZeroExit {
+            code: 1,
+            stderr: "Bearer eyJhbGciOi password=secret /Users/me/.config/token".into(),
+        };
+        let kind = err.kind();
+        assert!(!kind.contains("Bearer"));
+        assert!(!kind.contains("password"));
+        assert!(!kind.contains("/Users"));
+        assert!(!kind.contains("secret"));
+    }
+
+    #[test]
+    fn api_error_kind_returns_safe_labels() {
+        assert_eq!(
+            ApiError::Transport("connection refused".into()).kind(),
+            "transport"
+        );
+        assert_eq!(
+            ApiError::Status {
+                status: 401,
+                body: "Bearer token invalid".into()
+            }
+            .kind(),
+            "status"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ use rmcp::model::{CallToolResult, Content};
 use rmcp::schemars::{self, JsonSchema};
 use rmcp::service::ServerInitializeError;
 use rmcp::{tool, tool_router, ErrorData, ServiceExt};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
 use crate::cli::CliRunner;
@@ -169,8 +171,19 @@ impl CodeSceneServer {
         tracking::track_event(event, props, &self.instance_id);
     }
 
-    pub(crate) fn track_err(&self, tool: &str, err: &str) {
-        tracking::track_error(err, tool, &self.instance_id);
+    pub(crate) fn track_err(&self, tool: &str, err: &errors::CliError) {
+        tracing::warn!(tool, error = %err, "tool error");
+        tracking::track_error(err.kind(), tool, &self.instance_id);
+    }
+
+    pub(crate) fn track_api_err(&self, tool: &str, err: &errors::ApiError) {
+        tracing::warn!(tool, error = %err, "API error");
+        tracking::track_error(err.kind(), tool, &self.instance_id);
+    }
+
+    pub(crate) fn track_err_msg(&self, tool: &str, error_kind: &str, err: &str) {
+        tracing::warn!(tool, error = err, "tool error");
+        tracking::track_error(error_kind, tool, &self.instance_id);
     }
 }
 
@@ -405,19 +418,46 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into()))
+    config::snapshot_client_env_vars();
+    let config_data = config::load().unwrap_or_default();
+    config::apply_to_env(&config_data);
+
+    let env_filter =
+        EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into());
+
+    let stderr_layer = tracing_subscriber::fmt::layer()
         .with_writer(std::io::stderr)
-        .with_ansi(false)
-        .init();
+        .with_ansi(false);
+
+    let retention_days = config::log_retention_days(&config_data);
+    let _file_guard = if retention_days > 0 {
+        let log_dir = config::log_dir();
+        std::fs::create_dir_all(&log_dir).ok();
+        cleanup_old_logs(&log_dir, retention_days);
+        let file_appender =
+            tracing_appender::rolling::daily(&log_dir, "mcp.log");
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_writer(non_blocking)
+            .with_ansi(false);
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(stderr_layer)
+            .with(file_layer)
+            .init();
+        Some(guard)
+    } else {
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(stderr_layer)
+            .init();
+        None
+    };
 
     startup::print_startup_logo();
     tracing::info!("CodeScene MCP server started");
     tracing::info!("Waiting for MCP client initialization...");
 
-    config::snapshot_client_env_vars();
-    let config_data = config::load().unwrap_or_default();
-    config::apply_to_env(&config_data);
     let instance_id = config::instance_id(&config_data);
 
     let token = std::env::var("CS_ACCESS_TOKEN").unwrap_or_default();
@@ -486,4 +526,25 @@ pub(crate) fn handle_serve_error(err: ServerInitializeError) -> anyhow::Result<(
 
     tracing::error!("serving error: {err:?}");
     Err(err.into())
+}
+
+/// Remove log files older than `retention_days` from the given directory.
+fn cleanup_old_logs(log_dir: &std::path::Path, retention_days: u32) {
+    let cutoff = std::time::SystemTime::now()
+        - std::time::Duration::from_secs(u64::from(retention_days) * 24 * 60 * 60);
+    let entries = match std::fs::read_dir(log_dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        if modified < cutoff {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }

--- a/src/tools/analyze_change_set.rs
+++ b/src/tools/analyze_change_set.rs
@@ -39,7 +39,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("analyze-change-set", &e.to_string());
+            server.track_err("analyze-change-set", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/code_health_refactoring_business_case.rs
+++ b/src/tools/code_health_refactoring_business_case.rs
@@ -39,7 +39,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("code-health-refactoring-business-case", &e.to_string());
+            server.track_err("code-health-refactoring-business-case", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/code_health_review.rs
+++ b/src/tools/code_health_review.rs
@@ -27,7 +27,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("code-health-review", &e.to_string());
+            server.track_err("code-health-review", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/code_health_score.rs
+++ b/src/tools/code_health_score.rs
@@ -31,7 +31,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("code-health-score", &e.to_string());
+            server.track_err("code-health-score", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/code_ownership_for_path.rs
+++ b/src/tools/code_ownership_for_path.rs
@@ -47,7 +47,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("code-ownership", &e.to_string());
+            server.track_api_err("code-ownership", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/list_technical_debt_goals_for_project.rs
+++ b/src/tools/list_technical_debt_goals_for_project.rs
@@ -29,7 +29,7 @@ pub(crate) async fn handle(
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
-            server.track_err("list-technical-debt-goals", &e);
+            server.track_err_msg("list-technical-debt-goals", "api_error", &e);
             return Ok(tool_error(&e));
         }
     };
@@ -58,7 +58,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("list-technical-debt-goals", &e.to_string());
+            server.track_api_err("list-technical-debt-goals", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/list_technical_debt_goals_for_project_file.rs
+++ b/src/tools/list_technical_debt_goals_for_project_file.rs
@@ -32,7 +32,7 @@ pub(crate) async fn handle(
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
-            server.track_err("list-technical-debt-goals-file", &e);
+            server.track_err_msg("list-technical-debt-goals-file", "api_error", &e);
             return Ok(tool_error(&e));
         }
     };
@@ -63,7 +63,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("list-technical-debt-goals-file", &e.to_string());
+            server.track_api_err("list-technical-debt-goals-file", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/list_technical_debt_hotspots_for_project.rs
+++ b/src/tools/list_technical_debt_hotspots_for_project.rs
@@ -29,7 +29,7 @@ pub(crate) async fn handle(
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
-            server.track_err("list-technical-debt-hotspots", &e);
+            server.track_err_msg("list-technical-debt-hotspots", "api_error", &e);
             return Ok(tool_error(&e));
         }
     };
@@ -60,7 +60,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("list-technical-debt-hotspots", &e.to_string());
+            server.track_api_err("list-technical-debt-hotspots", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/list_technical_debt_hotspots_for_project_file.rs
+++ b/src/tools/list_technical_debt_hotspots_for_project_file.rs
@@ -32,7 +32,7 @@ pub(crate) async fn handle(
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
-            server.track_err("list-technical-debt-hotspots-file", &e);
+            server.track_err_msg("list-technical-debt-hotspots-file", "api_error", &e);
             return Ok(tool_error(&e));
         }
     };
@@ -65,7 +65,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("list-technical-debt-hotspots-file", &e.to_string());
+            server.track_api_err("list-technical-debt-hotspots-file", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/pre_commit_code_health_safeguard.rs
+++ b/src/tools/pre_commit_code_health_safeguard.rs
@@ -33,7 +33,7 @@ pub(crate) async fn handle(
             Ok(CallToolResult::success(vec![Content::text(text)]))
         }
         Err(e) => {
-            server.track_err("pre-commit-code-health-safeguard", &e.to_string());
+            server.track_err("pre-commit-code-health-safeguard", &e);
             Ok(tool_error(&format!("Error: {e}")))
         }
     }

--- a/src/tools/select_project.rs
+++ b/src/tools/select_project.rs
@@ -29,7 +29,7 @@ pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, E
             )]))
         }
         Err(e) => {
-            server.track_err("select-project", e);
+            server.track_err_msg("select-project", "api_error", e);
             Ok(tool_error(e))
         }
     }

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -35,9 +35,9 @@ pub fn track_event(event: &str, properties: Value, instance_id: &str) {
     });
 }
 
-pub fn track_error(error_msg: &str, tool_name: &str, instance_id: &str) {
+pub fn track_error(error_kind: &str, tool_name: &str, instance_id: &str) {
     let properties = json!({
-        "error": error_msg,
+        "error": error_kind,
         "tool": tool_name,
     });
     track_event("error", properties, instance_id);

--- a/tests/integration/run_all_tests.py
+++ b/tests/integration/run_all_tests.py
@@ -452,6 +452,7 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
     from test_git_worktree import run_worktree_tests_with_backend
     from test_relative_paths import run_relative_path_tests_with_backend
     from test_require_access_token import run_require_access_token_tests_with_backend
+    from test_error_logging import run_error_logging_tests_with_backend
     from test_shutdown_during_handshake import (
         run_shutdown_during_handshake_tests_with_backend,
     )
@@ -484,6 +485,7 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
         ("CloudFront Headers Tests", run_cloudfront_headers_tests_with_backend),
         ("SSL Truststore CLI Tests", run_ssl_cli_truststore_tests_with_backend),
         ("SSL API CA Bundle Tests", run_ssl_api_ca_bundle_tests_with_backend),
+        ("Error Logging Tests", run_error_logging_tests_with_backend),
     ]
     return [_run_test_module(name, func, backend) for name, func in modules]
 

--- a/tests/integration/server_backends.py
+++ b/tests/integration/server_backends.py
@@ -197,6 +197,8 @@ class DockerBackend(ServerBackend):
             "CS_CONFIG_DIR",
             "-e",
             "CS_ENABLED_TOOLS",
+            "-e",
+            "CS_LOG_RETENTION_DAYS",
             "--add-host=host.docker.internal:host-gateway",
             "--mount",
             f"type=bind,src={working_dir},dst={self.CONTAINER_MOUNT_DEST}",

--- a/tests/integration/test_error_logging.py
+++ b/tests/integration/test_error_logging.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+Error logging and telemetry redaction integration tests.
+
+Tests that the MCP server:
+1. Sends only safe error kind labels (not raw stderr) to telemetry
+2. Logs full error details to a file when file logging is enabled
+3. Respects the log_retention_days=0 setting to disable file logging
+
+This prevents sensitive information (tokens, file paths, credentials)
+from leaking through the analytics/telemetry channel while ensuring
+errors are still captured locally for debugging.
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fixtures import get_sample_files
+
+from test_utils import (
+    DockerBackend,
+    MCPClient,
+    CargoBackend,
+    ServerBackend,
+    create_git_repo,
+    extract_result_text,
+    print_header,
+    print_summary,
+    print_test,
+    safe_temp_directory,
+)
+
+# Known safe error kind values that should appear in telemetry
+SAFE_ERROR_KINDS = {
+    "non_zero_exit",
+    "not_found",
+    "io",
+    "invalid_input",
+    "license_check_failed",
+    "http",
+    "transport",
+    "status",
+    "api_error",
+}
+
+
+class _FakeAnalyticsHandler(BaseHTTPRequestHandler):
+    """Captures analytics payloads for inspection."""
+
+    request_count = 0
+    request_count_lock = threading.Lock()
+    captured_payloads: list[dict] = []
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length)
+        with self.request_count_lock:
+            _FakeAnalyticsHandler.request_count += 1
+            try:
+                payload = json.loads(body)
+                _FakeAnalyticsHandler.captured_payloads.append(payload)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def log_message(self, format, *args):
+        pass
+
+    @classmethod
+    def reset(cls):
+        with cls.request_count_lock:
+            cls.request_count = 0
+            cls.captured_payloads = []
+
+    @classmethod
+    def get_captured_payloads(cls) -> list[dict]:
+        with cls.request_count_lock:
+            return list(cls.captured_payloads)
+
+
+def run_error_logging_tests(executable: Path) -> int:
+    """Run all error logging tests using a Cargo executable."""
+    backend = CargoBackend(executable=executable)
+    return run_error_logging_tests_with_backend(backend)
+
+
+def run_error_logging_tests_with_backend(backend: ServerBackend) -> int:
+    """
+    Run all error logging tests using a backend.
+
+    Args:
+        backend: Server backend to use
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    with safe_temp_directory(prefix="cs_mcp_error_logging_test_") as test_dir:
+        print(f"\nTest directory: {test_dir}")
+
+        print("\nCreating test repository...")
+        repo_dir = create_git_repo(test_dir, get_sample_files())
+        print(f"Repository: {repo_dir}")
+
+        results = [
+            (
+                "Error Telemetry - Only error kind sent, not raw stderr",
+                test_error_telemetry_sends_only_kind(backend, repo_dir, test_dir),
+            ),
+            (
+                "Error Telemetry - Invalid token reports license_check_failed",
+                test_error_telemetry_invalid_token(backend, repo_dir, test_dir),
+            ),
+            (
+                "Error Logging - Full error logged to file",
+                test_error_logged_to_file(backend, repo_dir, test_dir),
+            ),
+            (
+                "Error Logging - File logging disabled when retention is 0",
+                test_file_logging_disabled_when_zero(backend, repo_dir, test_dir),
+            ),
+        ]
+
+        return print_summary(results)
+
+
+def _trigger_error_with_fake_server(
+    backend: ServerBackend,
+    repo_dir: Path,
+    config_dir: Path,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[str, list[dict]]:
+    """Trigger a tool error with a fake analytics server.
+
+    Calls code_health_score on a non-existent file to reliably produce a
+    CliError::NonZeroExit or CliError::InvalidInput error.
+
+    For Docker backends, *config_dir* must be inside *repo_dir* so it is
+    accessible via the bind mount.  The env var is translated to the
+    container path automatically.
+
+    Returns (result_text, captured_payloads).
+    """
+    is_docker = isinstance(backend, DockerBackend)
+    bind_host = "0.0.0.0" if is_docker else "127.0.0.1"
+
+    _FakeAnalyticsHandler.reset()
+
+    server = HTTPServer((bind_host, 0), _FakeAnalyticsHandler)
+    port = server.server_address[1]
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    url_host = "host.docker.internal" if is_docker else "127.0.0.1"
+    local_url = f"http://{url_host}:{port}"
+    print(f"  Local analytics server at {local_url}")
+
+    env = backend.get_env(os.environ.copy(), repo_dir)
+    env["CS_TRACKING_URL"] = local_url
+
+    if is_docker:
+        # config_dir must be relative to repo_dir; translate to container path
+        relative = config_dir.relative_to(repo_dir)
+        env["CS_CONFIG_DIR"] = f"/mount/{relative}"
+    else:
+        env["CS_CONFIG_DIR"] = str(config_dir)
+
+    if extra_env:
+        env.update(extra_env)
+
+    command = backend.get_command(repo_dir)
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            return "", []
+
+        print_test("Server started", True)
+        client.initialize()
+
+        # Call with a non-existent file to trigger an error
+        nonexistent = str(repo_dir / "does_not_exist_xyz.py")
+        print(f"  Calling code_health_score on non-existent file: {nonexistent}")
+        response = client.call_tool(
+            "code_health_score", {"file_path": nonexistent}, timeout=60
+        )
+        result_text = extract_result_text(response)
+
+        # Wait for background tracking to deliver
+        time.sleep(2)
+
+        return result_text, _FakeAnalyticsHandler.get_captured_payloads()
+    finally:
+        client.stop()
+        server.shutdown()
+
+
+def _extract_error_payloads(payloads: list[dict]) -> list[dict]:
+    """Return only the error tracking payloads."""
+    return [p for p in payloads if "error" in p.get("event-type", "")]
+
+
+def _get_error_kind(payload: dict) -> str:
+    """Extract the error kind string from a tracking payload."""
+    return payload.get("event-properties", {}).get("error", "")
+
+
+def _assert_error_event_received(
+    result_text: str, payloads: list[dict],
+) -> tuple[bool, list[dict]]:
+    """Verify a response was received and contains error events.
+
+    Returns (ok, error_payloads).
+    """
+    has_response = len(result_text) > 0
+    print_test("Tool returned error response", has_response)
+
+    error_payloads = _extract_error_payloads(payloads)
+    has_error_event = len(error_payloads) > 0
+    print_test(
+        "Error tracking event sent",
+        has_error_event,
+        f"Found {len(error_payloads)} error event(s)",
+    )
+    return has_response and has_error_event, error_payloads
+
+
+def _assert_payload_is_safe(payload: dict) -> bool:
+    """Verify a single error payload contains only a safe kind label."""
+    error_value = _get_error_kind(payload)
+    is_safe = error_value in SAFE_ERROR_KINDS
+    print_test("Error value is safe kind label", is_safe, f"Got: '{error_value}'")
+
+    no_stderr_leak = "exited with code" not in error_value
+    no_path_leak = "/" not in error_value and "\\" not in error_value
+    print_test("No raw stderr in telemetry", no_stderr_leak)
+    print_test("No file paths in telemetry", no_path_leak)
+
+    return is_safe and no_stderr_leak and no_path_leak
+
+
+def _read_log_content(log_dir: Path) -> str:
+    """Read and concatenate all log files in a directory."""
+    return "".join(f.read_text(errors="replace") for f in log_dir.iterdir())
+
+
+def test_error_telemetry_sends_only_kind(
+    backend: ServerBackend, repo_dir: Path, test_dir: Path
+) -> bool:
+    """
+    Test that error telemetry contains only the error kind label.
+
+    Triggers a tool error and inspects the analytics payload to verify
+    that no raw stderr, file paths, or sensitive data is transmitted.
+    """
+    print_header("Test: Error Telemetry Sends Only Kind")
+
+    config_dir = repo_dir / ".config_telemetry"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result_text, payloads = _trigger_error_with_fake_server(
+            backend, repo_dir, config_dir
+        )
+
+        ok, error_payloads = _assert_error_event_received(result_text, payloads)
+        if not ok:
+            return False
+
+        return all(_assert_payload_is_safe(p) for p in error_payloads)
+
+    except Exception as e:
+        print_test("Error telemetry sends only kind", False, str(e))
+        return False
+
+
+def test_error_telemetry_invalid_token(
+    backend: ServerBackend, repo_dir: Path, test_dir: Path
+) -> bool:
+    """
+    Test that an invalid access token produces a license_check_failed error kind.
+    """
+    print_header("Test: Invalid Token Reports license_check_failed")
+
+    config_dir = repo_dir / ".config_invalid_token"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result_text, payloads = _trigger_error_with_fake_server(
+            backend,
+            repo_dir,
+            config_dir,
+            extra_env={"CS_ACCESS_TOKEN": "invalid-garbage-token-xyz"},
+        )
+
+        ok, error_payloads = _assert_error_event_received(result_text, payloads)
+        if not ok:
+            return False
+
+        error_value = _get_error_kind(error_payloads[0])
+        is_license_error = error_value == "license_check_failed"
+        print_test("Error kind is license_check_failed", is_license_error, f"Got: '{error_value}'")
+
+        no_token_leak = "invalid-garbage-token-xyz" not in error_value
+        print_test("Token value not in telemetry", no_token_leak)
+
+        return is_license_error and no_token_leak
+
+    except Exception as e:
+        print_test("Invalid token error telemetry", False, str(e))
+        return False
+
+
+def test_error_logged_to_file(
+    backend: ServerBackend, repo_dir: Path, test_dir: Path
+) -> bool:
+    """
+    Test that full error details are logged to a file.
+    """
+    print_header("Test: Full Error Logged to File")
+
+    config_dir = repo_dir / ".config_logging"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result_text, _payloads = _trigger_error_with_fake_server(
+            backend, repo_dir, config_dir, extra_env={"CS_LOG_RETENTION_DAYS": "7"}
+        )
+
+        has_response = len(result_text) > 0
+        print_test("Tool returned error response", has_response)
+
+        log_dir = config_dir / "logs"
+        log_dir_exists = log_dir.exists() and log_dir.is_dir()
+        print_test("Log directory created", log_dir_exists, f"Path: {log_dir}")
+        if not log_dir_exists:
+            return False
+
+        log_files = list(log_dir.iterdir())
+        has_log_files = len(log_files) > 0
+        print_test("Log files created", has_log_files, f"Found {len(log_files)} file(s)")
+        if not has_log_files:
+            return False
+
+        log_content = _read_log_content(log_dir)
+        has_error_logged = "error" in log_content.lower()
+        print_test("Error details in log file", has_error_logged, f"Log size: {len(log_content)} chars")
+
+        detail_markers = ["does_not_exist_xyz", "no such file", "not a supported", "non_zero_exit", "invalid_input"]
+        has_detail = any(m in log_content.lower() for m in detail_markers)
+        print_test("Log contains error detail", has_detail)
+
+        return has_response and has_log_files and has_error_logged
+
+    except Exception as e:
+        print_test("Full error logged to file", False, str(e))
+        return False
+
+
+def test_file_logging_disabled_when_zero(
+    backend: ServerBackend, repo_dir: Path, test_dir: Path
+) -> bool:
+    """
+    Test that file logging is disabled when log_retention_days=0.
+
+    Sets CS_LOG_RETENTION_DAYS=0 and verifies that no log directory
+    or log files are created.
+    """
+    print_header("Test: File Logging Disabled When Retention Is 0")
+
+    config_dir = repo_dir / ".config_no_logging"
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result_text, _payloads = _trigger_error_with_fake_server(
+            backend, repo_dir, config_dir, extra_env={"CS_LOG_RETENTION_DAYS": "0"}
+        )
+
+        has_response = len(result_text) > 0
+        print_test("Tool returned error response", has_response)
+
+        # Log directory should NOT be created
+        log_dir = config_dir / "logs"
+        no_log_dir = not log_dir.exists()
+        print_test(
+            "No log directory created",
+            no_log_dir,
+            f"Path: {log_dir} (exists={log_dir.exists()})",
+        )
+
+        return has_response and no_log_dir
+
+    except Exception as e:
+        print_test("File logging disabled when zero", False, str(e))
+        return False
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python test_error_logging.py /path/to/cs-mcp")
+        return 1
+
+    executable = Path(sys.argv[1])
+    if not executable.exists():
+        print(f"Error: Executable not found: {executable}")
+        return 1
+
+    print_header("Error Logging Integration Tests")
+    print("\nThese tests verify error telemetry redaction and file logging.")
+
+    return run_error_logging_tests(executable)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- Send only safe error kind labels to telemetry (e.g. 'non_zero_exit') instead of raw stderr which may contain tokens, paths, or credentials
- Add `CliError::kind()` and `ApiError::kind()` for safe telemetry labels
- Add file-based logging with daily rotation to `<config_dir>/logs/`
- Add `log_retention_days` config option (default: `7`, set `0` to disable)
- Add tracing-appender 0.2.5 for file log output
- Full error details are logged locally via tracing (stderr + file)
- Add e2e tests for telemetry redaction and file logging