### PR TITLE
CS-11294: Fix parallel test race on `CS_ACCESS_TOKEN`

### DIFF
--- a/src/tools/common.rs
+++ b/src/tools/common.rs
@@ -248,10 +248,8 @@ mod tests {
             .current_dir(dir.path())
             .output()
             .unwrap();
-        // Set a sensitive env var in our process
-        std::env::set_var("CS_ACCESS_TOKEN", "test-secret");
+        // Set a sensitive env var in our process (guard holds mutex + cleans up on drop)
+        let _guard = crate::test_utils::set_token("test-secret");
         refresh_git_index(dir.path()).await;
-        // Clean up
-        std::env::remove_var("CS_ACCESS_TOKEN");
     }
 }


### PR DESCRIPTION
Use `set_token()` helper (which holds `TEST_ENV_LOCK` mutex) instead of raw set_var/remove_var in `refresh_git_index_scrubs_sensitive_env_vars` test. This was the only test manipulating `CS_ACCESS_TOKEN` without the lock, causing intermittent failures in `rejects_standalone_mode` tests.