### PR TITLE
CS-11237: Run Docker image as non-root user and harden git commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,26 +24,40 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Allow git to operate on bind-mounted repos owned by a different user.
-# The container runs as root but the mounted directory is typically owned
-# by the host user (e.g., UID 1001 on Linux CI), which triggers git's
-# "dubious ownership" safe-directory check (git 2.35.2+).
-RUN git config --global safe.directory '*'
+# Written to the *system* gitconfig so it applies regardless of which
+# UID the container runs as (the default mcp user, or a --user override).
+RUN git config --system safe.directory '*'
 
-# Install the CodeScene CLI (cs-tool) with integrity verification.
-# Update the checksum when upgrading the CLI version.
+# Create a non-root user to run the server.  Using a fixed UID/GID
+# avoids running as root, which limits blast radius if a vulnerability
+# is exploited inside the container.
+RUN groupadd -g 1000 mcp && useradd -u 1000 -g mcp -m mcp
+
+# Install the CodeScene CLI (cs-tool) with integrity verification
+# as root (needs write access to /usr/local or default install dir),
+# then make it accessible to the non-root user.
 ARG CS_CLI_INSTALLER_SHA256="6a119bd0746de31740bb899fbcc16f44b31df2392740642d5a29616961501f06"
 RUN set -eu; \
     curl --proto '=https' --tlsv1.2 -fsSL -o /tmp/install-cs-tool.sh \
          https://downloads.codescene.io/enterprise/cli/install-cs-tool.sh && \
     echo "${CS_CLI_INSTALLER_SHA256}  /tmp/install-cs-tool.sh" | sha256sum -c - && \
-    bash /tmp/install-cs-tool.sh -y && \
-    rm /tmp/install-cs-tool.sh
+    HOME=/home/mcp bash /tmp/install-cs-tool.sh -y && \
+    rm /tmp/install-cs-tool.sh && \
+    chown -R mcp:mcp /home/mcp/.local
+
+# Pre-create the config directory with correct ownership so that
+# Docker named volumes inherit mcp:mcp permissions when first mounted.
+RUN mkdir -p /home/mcp/.config/codehealth-mcp && \
+    chown -R mcp:mcp /home/mcp/.config
 
 # Copy the binary from the builder stage
 COPY --from=builder /build/target/release/cs-mcp /usr/local/bin/cs-mcp
 
+# Switch to the non-root user for all subsequent operations.
+USER mcp:mcp
+
 # Ensure the CodeScene CLI is on PATH
-ENV PATH="/root/.local/bin:${PATH}"
+ENV PATH="/home/mcp/.local/bin:${PATH}"
 
 LABEL io.modelcontextprotocol.server.name="com.codescene/codescene-mcp-server"
 

--- a/docs/docker-installation.md
+++ b/docs/docker-installation.md
@@ -220,6 +220,29 @@ Replace `/path/to/your/code` with the actual absolute path to your code director
 
 For additional configuration — including CodeScene on-prem, custom SSL/TLS certificates, and more — see [Configuration Options](configuration-options.md).
 
+### Persistent Configuration and Logs
+
+By default, configuration changes made through `set_config` (e.g., setting a default project) and diagnostic log files are stored inside the container and lost when it stops. If you want these to persist across restarts, add a named volume for the config directory:
+
+```
+--mount type=volume,src=codescene-mcp-config,dst=/home/mcp/.config/codehealth-mcp
+```
+
+For example, in a JSON configuration:
+
+```json
+"args": [
+    "run", "-i", "--rm",
+    "-e", "CS_ACCESS_TOKEN",
+    "-e", "CS_MOUNT_PATH=/path/to/your/code",
+    "--mount", "type=bind,src=/path/to/your/code,dst=/mount/,ro",
+    "--mount", "type=volume,src=codescene-mcp-config,dst=/home/mcp/.config/codehealth-mcp",
+    "codescene/codescene-mcp"
+]
+```
+
+This is entirely optional — configuration passed via environment variables (such as `CS_ACCESS_TOKEN`) is unaffected and does not require persistence. The volume is only needed to preserve settings changed at runtime through `set_config` and to retain diagnostic log files across container restarts.
+
 ## Building Docker Image Locally
 
 See [Building the Docker image locally](building-docker-locally.md) for instructions on building the image from source.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,14 +27,14 @@ const CLI_ZIP: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/cs-cli.zip"));
 
 const CLI_BINARY_NAME: &str = if cfg!(windows) { "cs.exe" } else { "cs" };
 
-const DOCKER_CLI_PATH: &str = "/root/.local/bin/cs";
+const DOCKER_CLI_PATH: &str = "/home/mcp/.local/bin/cs";
 const SSL_TRUSTSTORE_PASSWORD: &str = "changeit";
 
 /// Resolve the path to the `cs` CLI binary.
 ///
 /// Resolution order:
 /// 1. `CS_CLI_PATH` environment variable override
-/// 2. Docker container path (`/root/.local/bin/cs`)
+/// 2. Docker container path (`/home/mcp/.local/bin/cs`)
 /// 3. Extracted from embedded zip to cache directory
 pub fn resolve_cli_path() -> Result<PathBuf, CliError> {
     resolve_from_env_override()

--- a/src/main.rs
+++ b/src/main.rs
@@ -392,6 +392,48 @@ impl CodeSceneServer {
     }
 }
 
+/// Initialise tracing with stderr output and optional file logging.
+///
+/// Returns the non-blocking file-appender guard when file logging is
+/// active.  The guard must be held for the lifetime of the program so
+/// that buffered log entries are flushed on shutdown.
+fn init_tracing(
+    config_data: &config::ConfigData,
+) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+    let env_filter =
+        EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into());
+    let stderr_layer = tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_ansi(false);
+
+    let retention_days = config::log_retention_days(config_data);
+    if retention_days > 0 {
+        let log_dir = config::log_dir();
+        if let Ok(()) = std::fs::create_dir_all(&log_dir) {
+            cleanup_old_logs(&log_dir, retention_days);
+            let file_appender = tracing_appender::rolling::daily(&log_dir, "mcp.log");
+            let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+            let file_layer = tracing_subscriber::fmt::layer()
+                .with_writer(non_blocking)
+                .with_ansi(false);
+            tracing_subscriber::registry()
+                .with(env_filter)
+                .with(stderr_layer)
+                .with(file_layer)
+                .init();
+            return Some(guard);
+        }
+    }
+
+    // Stderr-only: file logging disabled or log directory not writable
+    // (e.g. non-root container with a read-only config path).
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(stderr_layer)
+        .init();
+    None
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> anyhow::Result<()> {
     let raw_version = env!("CS_MCP_VERSION");
@@ -422,37 +464,7 @@ async fn main() -> anyhow::Result<()> {
     let config_data = config::load().unwrap_or_default();
     config::apply_to_env(&config_data);
 
-    let env_filter =
-        EnvFilter::from_default_env().add_directive(tracing::Level::INFO.into());
-
-    let stderr_layer = tracing_subscriber::fmt::layer()
-        .with_writer(std::io::stderr)
-        .with_ansi(false);
-
-    let retention_days = config::log_retention_days(&config_data);
-    let _file_guard = if retention_days > 0 {
-        let log_dir = config::log_dir();
-        std::fs::create_dir_all(&log_dir).ok();
-        cleanup_old_logs(&log_dir, retention_days);
-        let file_appender =
-            tracing_appender::rolling::daily(&log_dir, "mcp.log");
-        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
-        let file_layer = tracing_subscriber::fmt::layer()
-            .with_writer(non_blocking)
-            .with_ansi(false);
-        tracing_subscriber::registry()
-            .with(env_filter)
-            .with(stderr_layer)
-            .with(file_layer)
-            .init();
-        Some(guard)
-    } else {
-        tracing_subscriber::registry()
-            .with(env_filter)
-            .with(stderr_layer)
-            .init();
-        None
-    };
+    let _file_guard = init_tracing(&config_data);
 
     startup::print_startup_logo();
     tracing::info!("CodeScene MCP server started");

--- a/src/tools/common.rs
+++ b/src/tools/common.rs
@@ -37,13 +37,22 @@ pub(crate) async fn run_review(
 /// container's git cannot parse.  Scrubs sensitive env vars from the
 /// child process since git never needs tokens.  Non-zero exit is
 /// expected and harmless.
+///
+/// The `-c` overrides neutralize repo-level `core.*` settings that git
+/// would otherwise honor and that could lead to arbitrary command
+/// execution (e.g. `core.fsmonitor`, `core.sshCommand`, `core.hooksPath`).
 async fn refresh_git_index(repo_path: &Path) {
     let mut git_cmd = tokio::process::Command::new("git");
     for var in crate::config::sensitive_env_vars() {
         git_cmd.env_remove(var);
     }
     let _ = git_cmd
-        .args(["update-index", "--refresh"])
+        .args([
+            "-c", "core.fsmonitor=",
+            "-c", "core.sshCommand=echo",
+            "-c", "core.hooksPath=/dev/null",
+            "update-index", "--refresh",
+        ])
         .current_dir(repo_path)
         .output()
         .await;

--- a/tests/integration/server_backends.py
+++ b/tests/integration/server_backends.py
@@ -8,7 +8,6 @@ This module provides:
 - DockerBackend for running in containers
 - NpmBackend for testing the npm package flow
 """
-
 import json
 import os
 import platform
@@ -171,12 +170,16 @@ class DockerBackend(ServerBackend):
         - CS_MOUNT_PATH is set to the HOST path (working_dir)
         - Mount binds host path to /mount/ in container
         - Server translates paths internally
+        - --user matches the host UID/GID so the container can
+          write config and log files inside the bind mount
         """
         return [
             "docker",
             "run",
             "-i",
             "--rm",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
             "-e",
             "CS_ACCESS_TOKEN",
             "-e",

--- a/tests/integration/test_configure.py
+++ b/tests/integration/test_configure.py
@@ -51,10 +51,22 @@ _VALID_STANDALONE_JWT = (
 # --- Helpers ---
 
 
-def _make_env_with_config_dir(base_env: dict, config_dir: Path) -> dict:
-    """Return env dict with CS_CONFIG_DIR pointed at *config_dir*."""
+def _make_env_with_config_dir(
+    base_env: dict, config_dir: Path, repo_dir: Path | None = None,
+    *, is_docker: bool = False,
+) -> dict:
+    """Return env dict with CS_CONFIG_DIR pointed at *config_dir*.
+
+    When running in Docker the config dir must be accessible inside the
+    container.  If *repo_dir* is provided and *config_dir* is inside it,
+    the path is translated to the container mount point.
+    """
     env = base_env.copy()
-    env["CS_CONFIG_DIR"] = str(config_dir)
+    if is_docker and repo_dir is not None:
+        relative = config_dir.relative_to(repo_dir)
+        env["CS_CONFIG_DIR"] = f"/mount/{relative}"
+    else:
+        env["CS_CONFIG_DIR"] = str(config_dir)
     return env
 
 
@@ -431,17 +443,24 @@ def run_configure_tests_with_backend(backend: ServerBackend) -> int:
     with safe_temp_directory(prefix="cs_mcp_configure_test_") as test_dir:
         print(f"\nTest directory: {test_dir}")
 
-        config_dir = test_dir / "config"
-        config_dir.mkdir()
-
         # Minimal git repo needed for server startup
         sample_files = {"hello.py": "def hello():\n    return 'world'\n"}
         repo_dir = create_git_repo(test_dir, sample_files)
         print(f"Repository: {repo_dir}")
 
+        # Place config dir inside repo_dir so it is accessible via Docker
+        # bind mount.
+        config_dir = repo_dir / ".cs_config"
+        config_dir.mkdir(exist_ok=True)
+
         command = backend.get_command(repo_dir)
         base_env = backend.get_env(os.environ.copy(), repo_dir)
-        env = _make_env_with_config_dir(base_env, config_dir)
+        from server_backends import DockerBackend
+
+        is_docker = isinstance(backend, DockerBackend)
+        env = _make_env_with_config_dir(
+            base_env, config_dir, repo_dir, is_docker=is_docker,
+        )
         cwd = str(repo_dir)
 
         results: list[tuple[str, bool]] = [

--- a/tests/integration/test_enabled_tools.py
+++ b/tests/integration/test_enabled_tools.py
@@ -301,16 +301,23 @@ def run_enabled_tools_tests_with_backend(backend: ServerBackend) -> int:
     with safe_temp_directory(prefix="cs_mcp_enabled_tools_test_") as test_dir:
         print(f"\nTest directory: {test_dir}")
 
-        config_dir = _make_config_dir(test_dir)
-
         sample_files = {"hello.py": "def hello():\n    return 'world'\n"}
         repo_dir = create_git_repo(test_dir, sample_files)
         print(f"Repository: {repo_dir}")
 
+        config_dir = repo_dir / ".cs_config"
+        config_dir.mkdir(exist_ok=True)
+
         command = backend.get_command(repo_dir)
         base_env = backend.get_env(os.environ.copy(), repo_dir)
         env = base_env.copy()
-        env["CS_CONFIG_DIR"] = str(config_dir)
+        # Translate config dir to container path for Docker backends
+        from server_backends import DockerBackend
+        if isinstance(backend, DockerBackend):
+            relative = config_dir.relative_to(repo_dir)
+            env["CS_CONFIG_DIR"] = f"/mount/{relative}"
+        else:
+            env["CS_CONFIG_DIR"] = str(config_dir)
         cwd = str(repo_dir)
         ctx = ServerContext(command, env, cwd)
 

--- a/tests/integration/test_require_access_token.py
+++ b/tests/integration/test_require_access_token.py
@@ -179,12 +179,18 @@ def run_require_access_token_tests_with_backend(backend: ServerBackend) -> int:
         repo_dir = create_git_repo(test_dir, sample_files)
         print(f"Repository: {repo_dir}")
 
-        config_dir = test_dir / "config"
-        config_dir.mkdir()
+        config_dir = repo_dir / ".cs_config"
+        config_dir.mkdir(exist_ok=True)
 
         command = backend.get_command(repo_dir)
         base_env = backend.get_env(os.environ.copy(), repo_dir)
-        base_env["CS_CONFIG_DIR"] = str(config_dir)
+        # Translate config dir to container path for Docker backends
+        from server_backends import DockerBackend
+        if isinstance(backend, DockerBackend):
+            relative = config_dir.relative_to(repo_dir)
+            base_env["CS_CONFIG_DIR"] = f"/mount/{relative}"
+        else:
+            base_env["CS_CONFIG_DIR"] = str(config_dir)
         cwd = str(repo_dir)
 
         cases = _build_test_cases(repo_dir)


### PR DESCRIPTION
- Add non-root 'mcp' user (UID 1000) to Dockerfile, install cs-tool under /home/mcp/.local/bin, switch to USER mcp after setup
- Harden refresh_git_index() with -c overrides to disable fsmonitor, sshCommand, and hooksPath
- Graceful fallback to stderr-only logging when log dir is unwritable
- Fix integration tests: place config dir inside repo_dir (.cs_config) so it is accessible via Docker bind mount, detect Docker backend via isinstance() instead of checking CS_MOUNT_PATH in env dict