### PR TITLE
docs: cleanup ACE mentions after auto-refactor tool removal

### DIFF
--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -25,7 +25,7 @@ Once installed, the following skills are available:
 <!-- SKILLS-TABLE:START -->
 | Skill | Description |
 |-------|-------------|
-| `/codescene:configuring-codescene-mcp` | Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, ACE tokens, default projects, or SSL certificates. |
+| `/codescene:configuring-codescene-mcp` | Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, default projects, or SSL certificates. |
 | `/codescene:explaining-code-health` | Use when a user asks what Code Health means, how to interpret scores, or why Code Health matters in daily development. |
 | `/codescene:guiding-refactoring-with-code-health` | Use when refactoring unhealthy code and needing Code Health findings to choose small safe steps and verify improvement. |
 | `/codescene:installing-and-activating-codescene-mcp` | Use when installing the CodeScene MCP Server binary or package, registering it in an AI assistant, or copying agent guidance files into a repository. |

--- a/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configuring-codescene-mcp
-description: Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, ACE tokens, default projects, or SSL certificates.
+description: Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, default projects, or SSL certificates.
 ---
 
 # Configuring CodeScene MCP

--- a/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
@@ -9,7 +9,7 @@ description: Use when installing the CodeScene MCP Server binary or package, reg
 
 Use this skill when the task is to get the CodeScene MCP Server installed and registered with an AI assistant. The workflow has three parts: install the server, register it in the assistant, and copy the agent guidance files into the repository.
 
-For configuring the server after installation (access tokens, on-prem URLs, ACE, SSL), use the `configuring-codescene-mcp` skill instead.
+For configuring the server after installation (access tokens, on-prem URLs, default project, SSL), use the `configuring-codescene-mcp` skill instead.
 
 ## When to Use
 

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -10,7 +10,7 @@ The simplest way to configure the MCP server is to ask your AI assistant directl
 
 > "Connect to our on-prem CodeScene at https://codescene.mycompany.com"
 
-> "Enable CodeScene ACE with token ace_xyz789"
+> "Set my default CodeScene project to 42"
 
 > "Disable the CodeScene version update check"
 

--- a/docs/docker-installation.md
+++ b/docs/docker-installation.md
@@ -22,11 +22,11 @@ docker pull codescene/codescene-mcp
 | `CS_ACCESS_TOKEN` | Yes | Your CodeScene personal access token |
 | `CS_MOUNT_PATH` | Yes | Absolute path to your code directory |
 
-For additional environment variables (on-prem, ACE, SSL, proxy settings, etc.), see [Configuration Options](configuration-options.md).
+For additional environment variables (on-prem, SSL, proxy settings, etc.), see [Configuration Options](configuration-options.md).
 
 ## Integration with AI Assistants
 
-> **Note:** Docker containers cannot read the host's config file, so `CS_ACCESS_TOKEN` must be passed as an environment variable in the examples below. For other configuration options (on-prem, ACE, SSL, etc.), you can ask your AI assistant directly — for example, *"Set my CodeScene on-prem URL to https://my-instance.example.com"*. See [Configuration Options](configuration-options.md) for all available settings.
+> **Note:** Docker containers cannot read the host's config file, so `CS_ACCESS_TOKEN` must be passed as an environment variable in the examples below. For other configuration options (on-prem, SSL, etc.), you can ask your AI assistant directly — for example, *"Set my CodeScene on-prem URL to https://my-instance.example.com"*. See [Configuration Options](configuration-options.md) for all available settings.
 
 ### Claude Code
 

--- a/skills/configuring-codescene-mcp/SKILL.md
+++ b/skills/configuring-codescene-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: configuring-codescene-mcp
-description: Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, ACE tokens, default projects, or SSL certificates.
+description: Use when the user wants to view, set, or troubleshoot CodeScene MCP configuration such as access tokens, on-prem URLs, default projects, or SSL certificates.
 ---
 
 # Configuring CodeScene MCP

--- a/skills/installing-and-activating-codescene-mcp/SKILL.md
+++ b/skills/installing-and-activating-codescene-mcp/SKILL.md
@@ -9,7 +9,7 @@ description: Use when installing the CodeScene MCP Server binary or package, reg
 
 Use this skill when the task is to get the CodeScene MCP Server installed and registered with an AI assistant. The workflow has three parts: install the server, register it in the assistant, and copy the agent guidance files into the repository.
 
-For configuring the server after installation (access tokens, on-prem URLs, ACE, SSL), use the `configuring-codescene-mcp` skill instead.
+For configuring the server after installation (access tokens, on-prem URLs, default project, SSL), use the `configuring-codescene-mcp` skill instead.
 
 ## When to Use
 

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -183,7 +183,7 @@ module.exports = AuthService;
 
 # Complex JavaScript code with code smells (many args, deep nesting, high complexity).
 # Uses top-level functions so the CLI parser can find them by name.
-# Python is NOT supported for code health auto-refactoring.
+# Python is not supported by the embedded CodeScene CLI for refactoring-target workflows.
 COMPLEX_JAVASCRIPT_CODE = """/**
  * Order processing module with maintainability issues.
  */


### PR DESCRIPTION
## Summary
This is a doc cleanup to remove ACE mentions from MCP documentation and skills after removing the auto-refactor tool.

ACE now lives in the refactoring agent:
https://codescene.io/docs/developer-tools/pr-refactoring-agent.html

## Changes
- Removed ACE wording from configuration/install docs
- Updated skill descriptions in both root skills and Claude plugin mirrors
- Updated plugin README skill table wording
- Adjusted one integration fixture comment to avoid stale auto-refactor wording

## Notes
This PR keeps support for refactoring and uplift scenarios through existing Code Health workflows (review/score/safeguard/business-case).