### PR TITLE
Pin CLI to v1.0.29 (379b4680) using commit hash URLs

### DIFF
--- a/.agents/skills/update-cli-version/SKILL.md
+++ b/.agents/skills/update-cli-version/SKILL.md
@@ -8,35 +8,25 @@ metadata:
 
 ## Purpose
 
-Use this skill when upgrading the CodeScene CLI (`cs`) that is embedded in the MCP server binary and installed in the Docker image. The CLI is integrity-verified at build time, so upgrading requires updating multiple checksum files in lockstep.
+Use this skill when upgrading the CodeScene CLI (`cs`) that is embedded in the MCP server binary and installed in the Docker image. The CLI is integrity-verified at build time, so upgrading requires updating the pinned version, checksums, and Dockerfile in lockstep.
 
 ## Files involved
 
 | File | What to update | Why |
 |---|---|---|
+| `build.rs` | `CLI_VERSION` constant (commit hash) | Pins the exact CLI version downloaded at build time |
 | `cli-checksums.sha256` | SHA-256 hashes for all 5 platform zip files | `build.rs` verifies the downloaded zip against these hashes at compile time |
 | `Dockerfile` | `CS_CLI_INSTALLER_SHA256` ARG value | The Docker build verifies the installer script hash before executing it |
 | `cli-checksums.sha256` line 1 | Version comment | Keeps the file self-documenting |
 
-The download URL in `build.rs` uses `-latest.zip` (not a versioned URL), so the URL itself does not change — only the checksums change.
+The download URL in `build.rs` uses the commit hash from `CLI_VERSION` to pin an exact CLI release:
+`https://downloads.codescene.io/enterprise/cli/cs-{os}-{arch}-{CLI_VERSION}.zip`
 
 ## Step-by-Step
 
-### 1. Download all platform zips and compute checksums
+### 1. Get the new CLI version and commit hash
 
-Download each of the 5 platform variants and compute their SHA-256 hashes:
-
-```bash
-for variant in macos-aarch64 macos-amd64 linux-amd64 linux-aarch64 windows-amd64; do
-  url="https://downloads.codescene.io/enterprise/cli/cs-${variant}-latest.zip"
-  sha=$(curl --proto '=https' --tlsv1.2 -fsSL "$url" | shasum -a 256 | cut -d' ' -f1)
-  echo "${sha}  cs-${variant}-latest.zip"
-done
-```
-
-### 2. Get the new CLI version string
-
-Extract the version from one of the downloaded binaries:
+Download the latest CLI and extract both the version string and commit hash:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -fsSL \
@@ -47,24 +37,47 @@ chmod +x /tmp/cs-cli-version-check/cs
 /tmp/cs-cli-version-check/cs version
 ```
 
-The first line of output looks like: `cs version 1.0.28 (commit-hash)`
+The output looks like: `cs version 1.0.29 (379b46808f26ed3c4eaefc2e11bee6c55dc44000)`
 
-### 3. Update `cli-checksums.sha256`
+The commit hash in parentheses (e.g., `379b46808f26ed3c4eaefc2e11bee6c55dc44000`) is used as the `CLI_VERSION` in `build.rs` and in download URLs/checksum filenames.
+
+### 2. Download all platform zips using the commit hash and compute checksums
+
+Download each of the 5 platform variants using the **commit hash** (not `-latest`) and compute their SHA-256 hashes:
+
+```bash
+COMMIT_HASH="<commit_hash_from_step_1>"
+for variant in macos-aarch64 macos-amd64 linux-amd64 linux-aarch64 windows-amd64; do
+  url="https://downloads.codescene.io/enterprise/cli/cs-${variant}-${COMMIT_HASH}.zip"
+  sha=$(curl --proto '=https' --tlsv1.2 -fsSL "$url" | shasum -a 256 | cut -d' ' -f1)
+  echo "${sha}  cs-${variant}-${COMMIT_HASH}.zip"
+done
+```
+
+### 3. Update `CLI_VERSION` in `build.rs`
+
+Update the `CLI_VERSION` constant at the top of the `cli_download_url` / `cli_zip_filename` section:
+
+```rust
+const CLI_VERSION: &str = "<commit_hash_from_step_1>";
+```
+
+### 4. Update `cli-checksums.sha256`
 
 Replace the entire file contents with the new hashes and version comment. The format is:
 
 ```
-# SHA-256 checksums for CodeScene CLI v<NEW_VERSION>
+# SHA-256 checksums for CodeScene CLI v<NEW_VERSION> (<COMMIT_HASH>)
 # Verify with: shasum -a 256 -c cli-checksums.sha256
 # Update by downloading each variant and running: shasum -a 256 <file>
-<hash>  cs-macos-aarch64-latest.zip
-<hash>  cs-macos-amd64-latest.zip
-<hash>  cs-linux-amd64-latest.zip
-<hash>  cs-linux-aarch64-latest.zip
-<hash>  cs-windows-amd64-latest.zip
+<hash>  cs-macos-aarch64-<COMMIT_HASH>.zip
+<hash>  cs-macos-amd64-<COMMIT_HASH>.zip
+<hash>  cs-linux-amd64-<COMMIT_HASH>.zip
+<hash>  cs-linux-aarch64-<COMMIT_HASH>.zip
+<hash>  cs-windows-amd64-<COMMIT_HASH>.zip
 ```
 
-### 4. Update the Dockerfile installer checksum
+### 5. Update the Dockerfile installer checksum
 
 Compute the SHA-256 of the installer script:
 
@@ -74,13 +87,13 @@ curl --proto '=https' --tlsv1.2 -fsSL \
   | shasum -a 256 | cut -d' ' -f1
 ```
 
-Then update the `CS_CLI_INSTALLER_SHA256` ARG in `Dockerfile` (line 34):
+Then update the `CS_CLI_INSTALLER_SHA256` ARG in `Dockerfile`:
 
 ```dockerfile
 ARG CS_CLI_INSTALLER_SHA256="<new_hash>"
 ```
 
-### 5. Clean build and verify
+### 6. Clean build and verify
 
 The build cache may contain the old zip. Clean and rebuild:
 
@@ -90,12 +103,12 @@ cargo build
 ```
 
 The build will:
-1. Download the CLI zip via curl with `--proto =https --tlsv1.2`
+1. Download the CLI zip via curl with `--proto =https --tlsv1.2` using the pinned commit hash URL
 2. Compute its SHA-256
 3. Compare against `cli-checksums.sha256`
 4. Fail with a clear error if there's a mismatch
 
-### 6. Run tests
+### 7. Run tests
 
 ```bash
 cargo test
@@ -106,21 +119,22 @@ All existing tests must still pass — the CLI version upgrade should be transpa
 ## Troubleshooting
 
 **Build fails with "SHA-256 checksum verification failed":**
-The downloaded zip doesn't match `cli-checksums.sha256`. Either the checksums file has a typo, or the CDN is serving different content than what you hashed. Re-run step 1 and compare.
+The downloaded zip doesn't match `cli-checksums.sha256`. Either the checksums file has a typo, or the CDN is serving different content than what you hashed. Re-run step 2 and compare.
 
 **Build fails with "No checksum entry found for '...'":**
-A new platform variant was added to `build.rs` but not to `cli-checksums.sha256`. Add the missing line.
+The `CLI_VERSION` in `build.rs` doesn't match the commit hash used in `cli-checksums.sha256` filenames. Ensure they are identical.
 
 **Dockerfile build fails with "sha256sum: WARNING: 1 computed checksum did NOT match":**
-The installer script changed. Re-run step 4 to get the new hash.
+The installer script changed. Re-run step 5 to get the new hash.
 
 ## Checklist
 
 Before considering the upgrade complete:
 
-- [ ] All 5 platform hashes updated in `cli-checksums.sha256`
-- [ ] Version comment in `cli-checksums.sha256` updated to new CLI version
-- [ ] `CS_CLI_INSTALLER_SHA256` in `Dockerfile` updated
+- [ ] `CLI_VERSION` in `build.rs` updated to new commit hash
+- [ ] All 5 platform hashes updated in `cli-checksums.sha256` with commit hash filenames
+- [ ] Version comment in `cli-checksums.sha256` updated to new CLI version and commit hash
+- [ ] `CS_CLI_INSTALLER_SHA256` in `Dockerfile` updated (if changed)
 - [ ] `cargo clean && cargo build` succeeds (verifies checksum logic end-to-end)
 - [ ] `cargo test` passes
 - [ ] New CLI version confirmed with `cargo run -- --cli-version`

--- a/build.rs
+++ b/build.rs
@@ -296,14 +296,18 @@ fn maybe_embed_local_cli(dest_zip: &str) -> bool {
     true
 }
 
+/// Pinned CLI version (commit hash from `cs version` output).
+/// Update this when upgrading the CLI, along with cli-checksums.sha256.
+const CLI_VERSION: &str = "379b46808f26ed3c4eaefc2e11bee6c55dc44000";
+
 fn cli_download_url() -> String {
     let (os_part, arch_part) = cli_platform_parts();
-    format!("https://downloads.codescene.io/enterprise/cli/cs-{os_part}-{arch_part}-latest.zip")
+    format!("https://downloads.codescene.io/enterprise/cli/cs-{os_part}-{arch_part}-{CLI_VERSION}.zip")
 }
 
 fn cli_zip_filename() -> String {
     let (os_part, arch_part) = cli_platform_parts();
-    format!("cs-{os_part}-{arch_part}-latest.zip")
+    format!("cs-{os_part}-{arch_part}-{CLI_VERSION}.zip")
 }
 
 fn cli_platform_parts() -> (&'static str, &'static str) {

--- a/cli-checksums.sha256
+++ b/cli-checksums.sha256
@@ -1,8 +1,8 @@
-# SHA-256 checksums for CodeScene CLI v1.0.28
+# SHA-256 checksums for CodeScene CLI v1.0.29 (379b46808f26ed3c4eaefc2e11bee6c55dc44000)
 # Verify with: shasum -a 256 -c cli-checksums.sha256
 # Update by downloading each variant and running: shasum -a 256 <file>
-2a69494926aac406fff60a3c605425899f2b0bd4998c058dda7e368f97c4a017  cs-macos-aarch64-latest.zip
-fc3b96203c52c92ed1aace9cb3104c658643c40783654c63001a61c1258e5647  cs-macos-amd64-latest.zip
-e4c81fb27537caa168bcd89d843a8534e8caeb8d70c92304496a551cb389d7b3  cs-linux-amd64-latest.zip
-fa43f064f366c18ffd627c75251361668b9407ad7926623f28faec28cae99046  cs-linux-aarch64-latest.zip
-0d76e300f58547e2a4ed4c6a031a96386d4c802f444ee220383ac243c4ffd3e3  cs-windows-amd64-latest.zip
+7d20c3bfc7f83f94e3bf786c81d51fdfef6043a92dc4721969ac420545d51377  cs-macos-aarch64-379b46808f26ed3c4eaefc2e11bee6c55dc44000.zip
+9c01b9d4feb9e151d1e2604d25b19210a4db195310f6ba69c740d386de805979  cs-macos-amd64-379b46808f26ed3c4eaefc2e11bee6c55dc44000.zip
+bfdfc0d603dfe3c7ef8c8674558bdeb4dce693098574dd105c5bd988c3a7e4b3  cs-linux-amd64-379b46808f26ed3c4eaefc2e11bee6c55dc44000.zip
+ae4082064b3fe845e626e209901ec4537f5cc5dd123382888244e6b5e1537c4b  cs-linux-aarch64-379b46808f26ed3c4eaefc2e11bee6c55dc44000.zip
+e18bfa35bdcc8407626c521162f1779f9a9ced0b1c851a4ebbe6df79dddf4de7  cs-windows-amd64-379b46808f26ed3c4eaefc2e11bee6c55dc44000.zip


### PR DESCRIPTION
- Replace -latest.zip URLs with commit-hash-pinned URLs in build.rs
- Add CLI_VERSION constant for centralized version management
- Update cli-checksums.sha256 with pinned filenames and new hashes
- Update update-cli-version skill to reflect pinned version workflow