### PR TITLE
CS-11282: Remove MCP resources capability

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,7 +1,3 @@
 pub const HOW_IT_WORKS: &str = include_str!("docs/code-health/how-it-works.md");
 
 pub const BUSINESS_CASE: &str = include_str!("docs/code-health/business-case.md");
-
-pub const HOW_IT_WORKS_URI: &str = "file://codescene-docs/code-health/how-it-works.md";
-
-pub const BUSINESS_CASE_URI: &str = "file://codescene-docs/code-health/business-case.md";

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -1,13 +1,12 @@
 use rmcp::model::{
     GetPromptRequestParams, GetPromptResult, Implementation, ListPromptsResult,
-    ListResourcesResult, PaginatedRequestParams, Prompt, PromptArgument, PromptMessage,
-    PromptMessageRole, RawResource, ReadResourceRequestParams, ReadResourceResult,
-    ResourceContents, ServerCapabilities, ServerInfo,
+    PaginatedRequestParams, Prompt, PromptArgument, PromptMessage, PromptMessageRole,
+    ServerCapabilities, ServerInfo,
 };
 use rmcp::service::RequestContext;
 use rmcp::{tool_handler, ErrorData, RoleServer, ServerHandler};
 
-use crate::{config, prompts, resources, CodeSceneServer};
+use crate::{config, prompts, CodeSceneServer};
 
 #[tool_handler(router = "self.tool_router")]
 impl ServerHandler for CodeSceneServer {
@@ -16,7 +15,6 @@ impl ServerHandler for CodeSceneServer {
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_prompts()
-                .enable_resources()
                 .build(),
         )
         .with_protocol_version(protocol_version_2025_11_25())
@@ -28,45 +26,6 @@ impl ServerHandler for CodeSceneServer {
             self.is_standalone,
             config::enabled_tools(&self.config_data).is_some(),
         ))
-    }
-
-    async fn list_resources(
-        &self,
-        _request: Option<PaginatedRequestParams>,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ListResourcesResult, ErrorData> {
-        use rmcp::model::AnnotateAble;
-        let resources = vec![
-            RawResource::new(
-                resources::HOW_IT_WORKS_URI,
-                extract_md_title(resources::HOW_IT_WORKS),
-            )
-            .with_description(
-                "Explains CodeScene's Code Health metric for assessing code quality and maintainability for both human devs and AI.",
-            )
-            .with_mime_type("text/markdown")
-            .no_annotation(),
-            RawResource::new(
-                resources::BUSINESS_CASE_URI,
-                extract_md_title(resources::BUSINESS_CASE),
-            )
-            .with_description("Describes how to build a business case for Code Health improvements.")
-            .with_mime_type("text/markdown")
-            .no_annotation(),
-        ];
-        Ok(ListResourcesResult::with_all_items(resources))
-    }
-
-    async fn read_resource(
-        &self,
-        request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, ErrorData> {
-        let uri = request.uri.as_str();
-        let content = resolve_resource_content(uri)?;
-        Ok(ReadResourceResult::new(vec![ResourceContents::text(
-            content, uri,
-        )]))
     }
 
     async fn list_prompts(
@@ -118,20 +77,6 @@ fn protocol_version_2025_11_25() -> rmcp::model::ProtocolVersion {
     serde_json::from_str("\"2025-11-25\"").expect("valid MCP protocol version literal")
 }
 
-pub(crate) fn resolve_resource_content(uri: &str) -> Result<&'static str, ErrorData> {
-    if uri == resources::HOW_IT_WORKS_URI {
-        Ok(resources::HOW_IT_WORKS)
-    } else if uri == resources::BUSINESS_CASE_URI {
-        Ok(resources::BUSINESS_CASE)
-    } else {
-        Err(ErrorData::new(
-            rmcp::model::ErrorCode::INVALID_REQUEST,
-            format!("Unknown resource: {uri}"),
-            None,
-        ))
-    }
-}
-
 pub(crate) fn build_instructions(is_standalone: bool, tools_filtered: bool) -> String {
     let mut text = String::from(
         "CodeScene MCP Server - Code Health analysis tools for AI-assisted development.\n\n\
@@ -168,14 +113,6 @@ pub(crate) fn build_instructions(is_standalone: bool, tools_filtered: bool) -> S
     text
 }
 
-pub(crate) fn extract_md_title(content: &str) -> &str {
-    for line in content.lines() {
-        if let Some(title) = line.strip_prefix("# ") {
-            return title.trim();
-        }
-    }
-    "Untitled"
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -204,11 +204,11 @@ mod tests {
 
     use super::*;
     use crate::config::{self, ConfigData};
-    use crate::server_handler::{build_instructions, extract_md_title, resolve_resource_content};
+    use crate::server_handler::build_instructions;
     use crate::version_checker::VersionChecker;
     use crate::{
         display_version, fetch_cli_version, help_text, parse_cli_args,
-        resources, CliAction, API_ONLY_TOOLS,
+        CliAction, API_ONLY_TOOLS,
     };
 
     #[derive(Clone)]
@@ -463,24 +463,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_resource_content_returns_how_it_works() {
-        let content = resolve_resource_content(resources::HOW_IT_WORKS_URI).unwrap();
-        assert!(!content.is_empty());
-    }
-
-    #[test]
-    fn resolve_resource_content_returns_business_case() {
-        let content = resolve_resource_content(resources::BUSINESS_CASE_URI).unwrap();
-        assert!(!content.is_empty());
-    }
-
-    #[test]
-    fn resolve_resource_content_returns_error_for_unknown() {
-        let result = resolve_resource_content("unknown://resource");
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn build_instructions_standalone_omits_api_tools() {
         let text = build_instructions(true, false);
         assert!(text.contains("code_health_review"));
@@ -604,16 +586,6 @@ mod tests {
         let names = tool_names(&server);
         assert_tool_count_and_config(&names, 3);
         assert!(names.contains(&"analyze_change_set".to_string()));
-    }
-
-    #[test]
-    fn extract_md_title_returns_first_heading() {
-        assert_eq!(extract_md_title("# Hello World\nsome text"), "Hello World");
-    }
-
-    #[test]
-    fn extract_md_title_falls_back_to_resource() {
-        assert_eq!(extract_md_title("no heading here"), "Untitled");
     }
 
     #[test]


### PR DESCRIPTION
Remove list_resources/read_resource handlers and the resources server capability. The underlying content (HOW_IT_WORKS, BUSINESS_CASE) is retained as it is still served by the explain_code_health tools.