### PR TITLE
CS-11283: Expose embedded skills as MCP resources via `skill://` URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +380,7 @@ dependencies = [
  "base64",
  "dirs",
  "ed25519-dalek",
+ "gray_matter",
  "p12-keystore",
  "reqwest",
  "rmcp",
@@ -639,6 +646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +868,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gray_matter"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3563a3eb8bacf11a0a6d93de7885f2cca224dddff0114e4eb8053ca0f1918acd"
+dependencies = [
+ "serde",
+ "thiserror",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +892,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -3002,6 +3038,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "yaml-rust2"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # Temp files (CLI extraction)
 tempfile = "3"
+gray_matter = { version = "0.3.2", features = ["yaml"] }
 
 [profile.release]
 opt-level = "z"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /build
 # Copy only what the build needs (keeps layer cache friendly)
 COPY Cargo.toml Cargo.lock build.rs cli-checksums.sha256 ./
 COPY src/ src/
+COPY skills/ skills/
 
 RUN CS_MCP_VERSION="${VERSION}" cargo build --release
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod platform;
 mod prompts;
 mod resources;
 mod server_handler;
+mod skills;
 mod startup;
 #[cfg(test)]
 mod test_utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,9 @@ use crate::cli::CliRunner;
 use crate::config::ConfigData;
 use crate::http::HttpClient;
 use crate::tools::{
-    ChangeSetParam, FilePathParam, GetConfigParam, GitRepoParam, OptionalContext, OwnershipParam,
-    ProjectFileParam, ProjectParam, SetConfigParam,
+    ChangeSetParam, DownloadSkillParam, FilePathParam, GetConfigParam, GitRepoParam,
+    OptionalContext, OwnershipParam, ProjectFileParam, ProjectParam, SetConfigParam,
+    SkillNameParam, SyncSkillsParam,
 };
 use crate::version_checker::VersionChecker;
 
@@ -390,6 +391,46 @@ impl CodeSceneServer {
         Parameters(params): Parameters<SetConfigParam>,
     ) -> Result<CallToolResult, ErrorData> {
         tools::set_config::handle(self, params).await
+    }
+
+    #[tool(
+        description = "List all available skills embedded in this MCP server.\n\nWhen to use:\n    Use this tool to discover what skills are available for\n    download or inspection.\n\nLimitations:\n    - Returns only skills embedded at compile time.\n    - Does not scan external skill directories.\n\nReturns:\n    A formatted list of skill names with their descriptions.\n\nExample:\n    Call this tool to see all available skills, then use\n    download_skill or sync_skills to install them locally."
+    )]
+    async fn list_skills(&self) -> Result<CallToolResult, ErrorData> {
+        tools::list_skills::handle(self).await
+    }
+
+    #[tool(
+        description = "Get the file manifest for a specific skill.\n\nWhen to use:\n    Use this tool to inspect what files a skill contains,\n    their sizes, and SHA256 hashes before downloading.\n\nLimitations:\n    - Requires a valid skill name from list_skills.\n\nReturns:\n    A JSON manifest with the skill name and an array of files,\n    each with path, size in bytes, and sha256 hash.\n\nExample:\n    Call with skill_name=\"safeguarding-ai-generated-code\" to\n    see the manifest, then use download_skill to install it.",
+        input_schema = inlined_schema_for::<SkillNameParam>()
+    )]
+    async fn get_skill_manifest(
+        &self,
+        Parameters(params): Parameters<SkillNameParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        tools::get_skill_manifest::handle(self, params).await
+    }
+
+    #[tool(
+        description = "Download a single skill to a local directory.\n\nWhen to use:\n    Use this tool to install a specific skill into your local\n    skills directory (e.g., ~/.claude/skills/).\n\nLimitations:\n    - By default, refuses to overwrite existing skills.\n    - Set overwrite=true to replace an existing skill.\n    - Creates the destination directory if it does not exist.\n\nReturns:\n    A confirmation message with the path where the skill was written.\n\nExample:\n    Call with skill_name=\"safeguarding-ai-generated-code\" and\n    destination_dir=\"~/.claude/skills\" to install the skill.",
+        input_schema = inlined_schema_for::<DownloadSkillParam>()
+    )]
+    async fn download_skill(
+        &self,
+        Parameters(params): Parameters<DownloadSkillParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        tools::download_skill::handle(self, params).await
+    }
+
+    #[tool(
+        description = "Download all available skills to a local directory.\n\nWhen to use:\n    Use this tool to install every embedded skill into your\n    local skills directory at once.\n\nLimitations:\n    - By default, skips skills that already exist locally.\n    - Set overwrite=true to replace all existing skills.\n    - Creates the destination directory if it does not exist.\n\nReturns:\n    A summary showing how many skills were downloaded and how\n    many were skipped (if any already existed).\n\nExample:\n    Call with destination_dir=\"~/.claude/skills\" to install\n    all skills. Use overwrite=true to force-update them.",
+        input_schema = inlined_schema_for::<SyncSkillsParam>()
+    )]
+    async fn sync_skills(
+        &self,
+        Parameters(params): Parameters<SyncSkillsParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        tools::sync_skills::handle(self, params).await
     }
 }
 

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -1,12 +1,13 @@
 use rmcp::model::{
-    GetPromptRequestParams, GetPromptResult, Implementation, ListPromptsResult,
-    PaginatedRequestParams, Prompt, PromptArgument, PromptMessage, PromptMessageRole,
-    ServerCapabilities, ServerInfo,
+    AnnotateAble, GetPromptRequestParams, GetPromptResult, Implementation, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, PaginatedRequestParams, Prompt,
+    PromptArgument, PromptMessage, PromptMessageRole, RawResource, RawResourceTemplate,
+    ReadResourceRequestParams, ReadResourceResult, ResourceContents, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::RequestContext;
 use rmcp::{tool_handler, ErrorData, RoleServer, ServerHandler};
 
-use crate::{config, prompts, CodeSceneServer};
+use crate::{config, prompts, skills, CodeSceneServer};
 
 #[tool_handler(router = "self.tool_router")]
 impl ServerHandler for CodeSceneServer {
@@ -15,6 +16,7 @@ impl ServerHandler for CodeSceneServer {
             ServerCapabilities::builder()
                 .enable_tools()
                 .enable_prompts()
+                .enable_resources()
                 .build(),
         )
         .with_protocol_version(protocol_version_2025_11_25())
@@ -71,6 +73,104 @@ impl ServerHandler for CodeSceneServer {
             text,
         )]))
     }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        let skill_list = skills::load_skills();
+        let resources = skill_list
+            .iter()
+            .flat_map(|skill| {
+                let main_uri = skills::skill_uri(&skill.name, "SKILL.md");
+                let manifest_uri_str = skills::manifest_uri(&skill.name);
+                let manifest_name = format!("{} manifest", skill.name);
+                let manifest_desc =
+                    format!("File manifest for the {} skill", skill.name);
+                vec![
+                    RawResource::new(main_uri, &skill.name)
+                        .with_description(&skill.description)
+                        .with_mime_type("text/markdown")
+                        .with_size(skill.content.len() as u32)
+                        .no_annotation(),
+                    RawResource::new(manifest_uri_str, manifest_name)
+                        .with_description(manifest_desc)
+                        .with_mime_type("application/json")
+                        .no_annotation(),
+                ]
+            })
+            .collect();
+        Ok(ListResourcesResult {
+            resources,
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        let (skill_name, path) =
+            skills::parse_skill_uri(&request.uri).ok_or_else(|| {
+                ErrorData::resource_not_found(
+                    format!("Invalid skill URI: {}", request.uri),
+                    None,
+                )
+            })?;
+
+        let skill_list = skills::load_skills();
+        let skill = skill_list
+            .iter()
+            .find(|s| s.name == skill_name)
+            .ok_or_else(|| {
+                ErrorData::resource_not_found(
+                    format!("Skill not found: {skill_name}"),
+                    None,
+                )
+            })?;
+
+        match path {
+            "SKILL.md" => Ok(ReadResourceResult::new(vec![
+                ResourceContents::text(skill.content, &request.uri)
+                    .with_mime_type("text/markdown"),
+            ])),
+            "_manifest" => {
+                let manifest = skills::build_manifest(skill);
+                Ok(ReadResourceResult::new(vec![
+                    ResourceContents::text(manifest, &request.uri)
+                        .with_mime_type("application/json"),
+                ]))
+            }
+            _ => Err(ErrorData::resource_not_found(
+                format!("File not found in skill {skill_name}: {path}"),
+                None,
+            )),
+        }
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, ErrorData> {
+        let template = RawResourceTemplate::new(
+            "skill://{skill_name}/{path}",
+            "Skill file",
+        )
+        .with_description(
+            "Access a specific file within a CodeScene skill. \
+             Use skill_name from the resource list and path from the manifest.",
+        )
+        .with_mime_type("text/markdown");
+        Ok(ListResourceTemplatesResult {
+            resource_templates: vec![template.no_annotation()],
+            next_cursor: None,
+            meta: None,
+        })
+    }
 }
 
 fn protocol_version_2025_11_25() -> rmcp::model::ProtocolVersion {
@@ -88,7 +188,12 @@ pub(crate) fn build_instructions(is_standalone: bool, tools_filtered: bool) -> S
          - pre_commit_code_health_safeguard: Check staged changes before commit.\n\
          - analyze_change_set: Branch-level review before PR.\n\
          - code_health_refactoring_business_case: ROI for refactoring.\n\
-         - get_config / set_config: Manage server configuration.\n",
+         - get_config / set_config: Manage server configuration.\n\
+         \n\
+         RESOURCES:\n\
+         - skill://<name>/SKILL.md: Agent skill instructions for Code Health workflows.\n\
+         - skill://<name>/_manifest: File listing for a skill.\n\
+         Use resources/list to discover available skills.\n",
     );
 
     if !is_standalone {

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -35,25 +35,7 @@ impl ServerHandler for CodeSceneServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, ErrorData> {
-        let prompts_list = vec![
-            Prompt::new(
-                "review_code_health",
-                Some(
-                    "Review Code Health and assess code quality for the current open file. The file path needs to be sent to the code_health_review MCP tool when using this prompt.",
-                ),
-                Some(vec![PromptArgument::new("context")
-                    .with_description("Optional context string.")
-                    .with_required(false)]),
-            ),
-            Prompt::new(
-                "plan_code_health_refactoring",
-                Some("Plan a prioritized, low-risk refactoring to remediate detected Code Health issues."),
-                Some(vec![PromptArgument::new("context")
-                    .with_description("Optional context string.")
-                    .with_required(false)]),
-            ),
-        ];
-        Ok(ListPromptsResult::with_all_items(prompts_list))
+        Ok(build_prompts_list())
     }
 
     async fn get_prompt(
@@ -61,17 +43,7 @@ impl ServerHandler for CodeSceneServer {
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<GetPromptResult, ErrorData> {
-        let text = prompts::resolve_prompt_text(&request.name).ok_or_else(|| {
-            ErrorData::new(
-                rmcp::model::ErrorCode::INVALID_REQUEST,
-                format!("Unknown prompt: {}", request.name),
-                None,
-            )
-        })?;
-        Ok(GetPromptResult::new(vec![PromptMessage::new_text(
-            PromptMessageRole::User,
-            text,
-        )]))
+        resolve_prompt(&request.name)
     }
 
     async fn list_resources(
@@ -79,33 +51,7 @@ impl ServerHandler for CodeSceneServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
-        let skill_list = skills::load_skills();
-        let resources = skill_list
-            .iter()
-            .flat_map(|skill| {
-                let main_uri = skills::skill_uri(&skill.name, "SKILL.md");
-                let manifest_uri_str = skills::manifest_uri(&skill.name);
-                let manifest_name = format!("{} manifest", skill.name);
-                let manifest_desc =
-                    format!("File manifest for the {} skill", skill.name);
-                vec![
-                    RawResource::new(main_uri, &skill.name)
-                        .with_description(&skill.description)
-                        .with_mime_type("text/markdown")
-                        .with_size(skill.content.len() as u32)
-                        .no_annotation(),
-                    RawResource::new(manifest_uri_str, manifest_name)
-                        .with_description(manifest_desc)
-                        .with_mime_type("application/json")
-                        .no_annotation(),
-                ]
-            })
-            .collect();
-        Ok(ListResourcesResult {
-            resources,
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(build_resources_list())
     }
 
     async fn read_resource(
@@ -113,42 +59,7 @@ impl ServerHandler for CodeSceneServer {
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
-        let (skill_name, path) =
-            skills::parse_skill_uri(&request.uri).ok_or_else(|| {
-                ErrorData::resource_not_found(
-                    format!("Invalid skill URI: {}", request.uri),
-                    None,
-                )
-            })?;
-
-        let skill_list = skills::load_skills();
-        let skill = skill_list
-            .iter()
-            .find(|s| s.name == skill_name)
-            .ok_or_else(|| {
-                ErrorData::resource_not_found(
-                    format!("Skill not found: {skill_name}"),
-                    None,
-                )
-            })?;
-
-        match path {
-            "SKILL.md" => Ok(ReadResourceResult::new(vec![
-                ResourceContents::text(skill.content, &request.uri)
-                    .with_mime_type("text/markdown"),
-            ])),
-            "_manifest" => {
-                let manifest = skills::build_manifest(skill);
-                Ok(ReadResourceResult::new(vec![
-                    ResourceContents::text(manifest, &request.uri)
-                        .with_mime_type("application/json"),
-                ]))
-            }
-            _ => Err(ErrorData::resource_not_found(
-                format!("File not found in skill {skill_name}: {path}"),
-                None,
-            )),
-        }
+        resolve_resource(&request.uri)
     }
 
     async fn list_resource_templates(
@@ -156,25 +67,134 @@ impl ServerHandler for CodeSceneServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourceTemplatesResult, ErrorData> {
-        let template = RawResourceTemplate::new(
-            "skill://{skill_name}/{path}",
-            "Skill file",
-        )
-        .with_description(
-            "Access a specific file within a CodeScene skill. \
-             Use skill_name from the resource list and path from the manifest.",
-        )
-        .with_mime_type("text/markdown");
-        Ok(ListResourceTemplatesResult {
-            resource_templates: vec![template.no_annotation()],
-            next_cursor: None,
-            meta: None,
-        })
+        Ok(build_resource_templates())
     }
 }
 
 fn protocol_version_2025_11_25() -> rmcp::model::ProtocolVersion {
     serde_json::from_str("\"2025-11-25\"").expect("valid MCP protocol version literal")
+}
+
+fn build_prompts_list() -> ListPromptsResult {
+    let prompts_list = vec![
+        Prompt::new(
+            "review_code_health",
+            Some(
+                "Review Code Health and assess code quality for the current open file. The file path needs to be sent to the code_health_review MCP tool when using this prompt.",
+            ),
+            Some(vec![PromptArgument::new("context")
+                .with_description("Optional context string.")
+                .with_required(false)]),
+        ),
+        Prompt::new(
+            "plan_code_health_refactoring",
+            Some("Plan a prioritized, low-risk refactoring to remediate detected Code Health issues."),
+            Some(vec![PromptArgument::new("context")
+                .with_description("Optional context string.")
+                .with_required(false)]),
+        ),
+    ];
+    ListPromptsResult::with_all_items(prompts_list)
+}
+
+fn resolve_prompt(name: &str) -> Result<GetPromptResult, ErrorData> {
+    let text = prompts::resolve_prompt_text(name).ok_or_else(|| {
+        ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_REQUEST,
+            format!("Unknown prompt: {name}"),
+            None,
+        )
+    })?;
+    Ok(GetPromptResult::new(vec![PromptMessage::new_text(
+        PromptMessageRole::User,
+        text,
+    )]))
+}
+
+fn build_resources_list() -> ListResourcesResult {
+    let skill_list = skills::load_skills();
+    let resources = skill_list
+        .iter()
+        .flat_map(|skill| {
+            let main_uri = skills::skill_uri(&skill.name, "SKILL.md");
+            let manifest_uri_str = skills::manifest_uri(&skill.name);
+            let manifest_name = format!("{} manifest", skill.name);
+            let manifest_desc =
+                format!("File manifest for the {} skill", skill.name);
+            vec![
+                RawResource::new(main_uri, &skill.name)
+                    .with_description(&skill.description)
+                    .with_mime_type("text/markdown")
+                    .with_size(skill.content.len() as u32)
+                    .no_annotation(),
+                RawResource::new(manifest_uri_str, manifest_name)
+                    .with_description(manifest_desc)
+                    .with_mime_type("application/json")
+                    .no_annotation(),
+            ]
+        })
+        .collect();
+    ListResourcesResult {
+        resources,
+        next_cursor: None,
+        meta: None,
+    }
+}
+
+fn resolve_resource(uri: &str) -> Result<ReadResourceResult, ErrorData> {
+    let (skill_name, path) =
+        skills::parse_skill_uri(uri).ok_or_else(|| {
+            ErrorData::resource_not_found(
+                format!("Invalid skill URI: {uri}"),
+                None,
+            )
+        })?;
+
+    let skill_list = skills::load_skills();
+    let skill = skill_list
+        .iter()
+        .find(|s| s.name == skill_name)
+        .ok_or_else(|| {
+            ErrorData::resource_not_found(
+                format!("Skill not found: {skill_name}"),
+                None,
+            )
+        })?;
+
+    match path {
+        "SKILL.md" => Ok(ReadResourceResult::new(vec![
+            ResourceContents::text(skill.content, uri)
+                .with_mime_type("text/markdown"),
+        ])),
+        "_manifest" => {
+            let manifest = skills::build_manifest(skill);
+            Ok(ReadResourceResult::new(vec![
+                ResourceContents::text(manifest, uri)
+                    .with_mime_type("application/json"),
+            ]))
+        }
+        _ => Err(ErrorData::resource_not_found(
+            format!("File not found in skill {skill_name}: {path}"),
+            None,
+        )),
+    }
+}
+
+fn build_resource_templates() -> ListResourceTemplatesResult {
+    let template = RawResourceTemplate::new(
+        "skill://{skill_name}/{path}",
+        "Skill file",
+    )
+    .with_description(
+        "Access a specific file within a CodeScene skill. \
+         Use skill_name from the resource list and path from the manifest.",
+    )
+    .with_mime_type("text/markdown");
+    ListResourceTemplatesResult {
+        resource_templates: vec![template.no_annotation()],
+        next_cursor: None,
+        meta: None,
+    }
 }
 
 pub(crate) fn build_instructions(is_standalone: bool, tools_filtered: bool) -> String {
@@ -226,5 +246,104 @@ mod tests {
     #[test]
     fn protocol_version_is_2025_11_25() {
         assert_eq!(protocol_version_2025_11_25().as_str(), "2025-11-25");
+    }
+
+    #[test]
+    fn prompts_list_contains_two_prompts() {
+        let result = build_prompts_list();
+        assert_eq!(result.prompts.len(), 2);
+        let names: Vec<&str> = result.prompts.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"review_code_health"));
+        assert!(names.contains(&"plan_code_health_refactoring"));
+    }
+
+    #[test]
+    fn resolve_known_prompt_succeeds() {
+        let result = resolve_prompt("review_code_health");
+        assert!(result.is_ok());
+        let prompt = result.unwrap();
+        assert!(!prompt.messages.is_empty());
+    }
+
+    #[test]
+    fn resolve_unknown_prompt_returns_error() {
+        let result = resolve_prompt("nonexistent_prompt");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unknown prompt"));
+    }
+
+    #[test]
+    fn resources_list_contains_all_skills() {
+        let result = build_resources_list();
+        let skills = skills::load_skills();
+        assert_eq!(result.resources.len(), skills.len() * 2);
+    }
+
+    #[test]
+    fn resources_have_correct_mime_types() {
+        let result = build_resources_list();
+        let md_resources: Vec<_> = result
+            .resources
+            .iter()
+            .filter(|r| r.uri.ends_with("/SKILL.md"))
+            .collect();
+        assert!(!md_resources.is_empty());
+        for r in &md_resources {
+            assert_eq!(r.mime_type.as_deref(), Some("text/markdown"));
+        }
+        let manifest_resources: Vec<_> = result
+            .resources
+            .iter()
+            .filter(|r| r.uri.ends_with("/_manifest"))
+            .collect();
+        for r in &manifest_resources {
+            assert_eq!(r.mime_type.as_deref(), Some("application/json"));
+        }
+    }
+
+    #[test]
+    fn read_skill_md_resource() {
+        let uri = "skill://safeguarding-ai-generated-code/SKILL.md";
+        let result = resolve_resource(uri).unwrap();
+        assert_eq!(result.contents.len(), 1);
+    }
+
+    #[test]
+    fn read_manifest_resource() {
+        let uri = "skill://safeguarding-ai-generated-code/_manifest";
+        let result = resolve_resource(uri).unwrap();
+        assert_eq!(result.contents.len(), 1);
+    }
+
+    #[test]
+    fn read_unknown_skill_returns_error() {
+        let result = resolve_resource("skill://nonexistent/SKILL.md");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Skill not found"));
+    }
+
+    #[test]
+    fn read_invalid_uri_returns_error() {
+        let result = resolve_resource("file:///etc/passwd");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Invalid skill URI"));
+    }
+
+    #[test]
+    fn read_unknown_path_in_skill_returns_error() {
+        let result =
+            resolve_resource("skill://safeguarding-ai-generated-code/unknown.txt");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("File not found"));
+    }
+
+    #[test]
+    fn resource_templates_contains_skill_template() {
+        let result = build_resource_templates();
+        assert_eq!(result.resource_templates.len(), 1);
     }
 }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,0 +1,222 @@
+use gray_matter::engine::YAML;
+use gray_matter::Matter;
+use sha2::{Digest, Sha256};
+
+const SKILL_URI_SCHEME: &str = "skill://";
+
+struct EmbeddedSkill {
+    dir_name: &'static str,
+    content: &'static str,
+}
+
+const EMBEDDED_SKILLS: &[EmbeddedSkill] = &[
+    EmbeddedSkill {
+        dir_name: "configuring-codescene-mcp",
+        content: include_str!("../skills/configuring-codescene-mcp/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "explaining-code-health",
+        content: include_str!("../skills/explaining-code-health/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "guiding-refactoring-with-code-health",
+        content: include_str!("../skills/guiding-refactoring-with-code-health/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "installing-and-activating-codescene-mcp",
+        content: include_str!("../skills/installing-and-activating-codescene-mcp/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "making-the-business-case-for-code-health",
+        content: include_str!("../skills/making-the-business-case-for-code-health/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "prioritizing-technical-debt",
+        content: include_str!("../skills/prioritizing-technical-debt/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "risk-based-testing-with-code-health",
+        content: include_str!("../skills/risk-based-testing-with-code-health/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "routing-work-with-code-ownership",
+        content: include_str!("../skills/routing-work-with-code-ownership/SKILL.md"),
+    },
+    EmbeddedSkill {
+        dir_name: "safeguarding-ai-generated-code",
+        content: include_str!("../skills/safeguarding-ai-generated-code/SKILL.md"),
+    },
+];
+
+/// A parsed skill with metadata extracted from YAML frontmatter.
+pub(crate) struct Skill {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) content: &'static str,
+    pub(crate) content_hash: String,
+}
+
+/// Extract the `description` field from YAML frontmatter.
+///
+/// Falls back to `"No description"` if frontmatter is absent or the
+/// `description` key is missing.
+fn extract_description(content: &str) -> String {
+    let matter = Matter::<YAML>::new();
+    match matter.parse(content) {
+        Ok(parsed) => parsed
+            .data
+            .and_then(|d: gray_matter::Pod| d["description"].as_string().ok())
+            .unwrap_or_else(|| "No description".to_string()),
+        Err(_) => "No description".to_string(),
+    }
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    let hash = Sha256::digest(data);
+    hex::encode(hash)
+}
+
+/// Encode bytes as lowercase hexadecimal.
+mod hex {
+    pub(super) fn encode(bytes: impl AsRef<[u8]>) -> String {
+        bytes
+            .as_ref()
+            .iter()
+            .fold(String::new(), |mut acc, b| {
+                use std::fmt::Write;
+                let _ = write!(acc, "{b:02x}");
+                acc
+            })
+    }
+}
+
+/// Build the skill registry from embedded content.
+pub(crate) fn load_skills() -> Vec<Skill> {
+    EMBEDDED_SKILLS
+        .iter()
+        .map(|embedded| {
+            let description = extract_description(embedded.content);
+            let content_hash = sha256_hex(embedded.content.as_bytes());
+            Skill {
+                name: embedded.dir_name.to_string(),
+                description,
+                content: embedded.content,
+                content_hash,
+            }
+        })
+        .collect()
+}
+
+/// Build a `skill://` URI for a skill file.
+pub(crate) fn skill_uri(skill_name: &str, path: &str) -> String {
+    format!("{SKILL_URI_SCHEME}{skill_name}/{path}")
+}
+
+/// Build a manifest URI for a skill.
+pub(crate) fn manifest_uri(skill_name: &str) -> String {
+    skill_uri(skill_name, "_manifest")
+}
+
+/// Build the JSON manifest for a single skill.
+pub(crate) fn build_manifest(skill: &Skill) -> String {
+    let size = skill.content.len();
+    serde_json::json!({
+        "skill": skill.name,
+        "files": [
+            {
+                "path": "SKILL.md",
+                "size": size,
+                "hash": format!("sha256:{}", skill.content_hash),
+            }
+        ]
+    })
+    .to_string()
+}
+
+/// Parse a `skill://` URI into `(skill_name, file_path)`.
+///
+/// Returns `None` if the URI does not use the `skill://` scheme.
+pub(crate) fn parse_skill_uri(uri: &str) -> Option<(&str, &str)> {
+    let rest = uri.strip_prefix(SKILL_URI_SCHEME)?;
+    let (name, path) = rest.split_once('/')?;
+    if name.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some((name, path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_description_from_frontmatter() {
+        let content = "---\nname: test-skill\ndescription: A test skill.\n---\n\n# Body";
+        let desc = extract_description(content);
+        assert_eq!(desc, "A test skill.");
+    }
+
+    #[test]
+    fn extract_description_without_frontmatter() {
+        let content = "# Title\n\nSome text.";
+        let desc = extract_description(content);
+        assert_eq!(desc, "No description");
+    }
+
+    #[test]
+    fn parse_skill_uri_valid() {
+        let (name, path) = parse_skill_uri("skill://my-skill/SKILL.md").unwrap();
+        assert_eq!(name, "my-skill");
+        assert_eq!(path, "SKILL.md");
+    }
+
+    #[test]
+    fn parse_skill_uri_manifest() {
+        let (name, path) = parse_skill_uri("skill://my-skill/_manifest").unwrap();
+        assert_eq!(name, "my-skill");
+        assert_eq!(path, "_manifest");
+    }
+
+    #[test]
+    fn parse_skill_uri_rejects_invalid() {
+        assert!(parse_skill_uri("file:///foo").is_none());
+        assert!(parse_skill_uri("skill://").is_none());
+        assert!(parse_skill_uri("skill:///foo").is_none());
+    }
+
+    #[test]
+    fn load_skills_returns_all_embedded() {
+        let skills = load_skills();
+        assert_eq!(skills.len(), EMBEDDED_SKILLS.len());
+        for skill in &skills {
+            assert!(!skill.name.is_empty());
+            assert!(!skill.description.is_empty());
+            assert!(!skill.content.is_empty());
+            assert!(!skill.content_hash.is_empty());
+        }
+    }
+
+    #[test]
+    fn manifest_contains_file_info() {
+        let skills = load_skills();
+        let manifest = build_manifest(&skills[0]);
+        let parsed: serde_json::Value = serde_json::from_str(&manifest).unwrap();
+        assert_eq!(parsed["skill"], skills[0].name);
+        let files = parsed["files"].as_array().unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0]["path"], "SKILL.md");
+        assert!(files[0]["size"].as_u64().unwrap() > 0);
+        assert!(files[0]["hash"].as_str().unwrap().starts_with("sha256:"));
+    }
+
+    #[test]
+    fn skill_uri_builds_correctly() {
+        assert_eq!(skill_uri("foo", "SKILL.md"), "skill://foo/SKILL.md");
+        assert_eq!(manifest_uri("foo"), "skill://foo/_manifest");
+    }
+
+    #[test]
+    fn hex_encode_works() {
+        assert_eq!(hex::encode([0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+    }
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -62,13 +62,20 @@ pub(crate) struct Skill {
 /// `description` key is missing.
 fn extract_description(content: &str) -> String {
     let matter = Matter::<YAML>::new();
-    match matter.parse(content) {
-        Ok(parsed) => parsed
-            .data
-            .and_then(|d: gray_matter::Pod| d["description"].as_string().ok())
-            .unwrap_or_else(|| "No description".to_string()),
-        Err(_) => "No description".to_string(),
-    }
+    let parsed = match matter.parse(content) {
+        Ok(p) => p,
+        Err(_) => return "No description".to_string(),
+    };
+    parsed
+        .data
+        .and_then(|d: gray_matter::Pod| {
+            d.as_hashmap()
+                .ok()?
+                .get("description")?
+                .as_string()
+                .ok()
+        })
+        .unwrap_or_else(|| "No description".to_string())
 }
 
 fn sha256_hex(data: &[u8]) -> String {
@@ -218,5 +225,24 @@ mod tests {
     #[test]
     fn hex_encode_works() {
         assert_eq!(hex::encode([0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+    }
+
+    #[test]
+    fn extract_description_falls_back_on_missing_frontmatter() {
+        assert_eq!(extract_description("no frontmatter here"), "No description");
+    }
+
+    #[test]
+    fn extract_description_falls_back_on_missing_key() {
+        assert_eq!(
+            extract_description("---\ntitle: foo\n---\nbody"),
+            "No description"
+        );
+    }
+
+    #[test]
+    fn extract_description_returns_value() {
+        let content = "---\ndescription: My skill\n---\nbody";
+        assert_eq!(extract_description(content), "My skill");
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -536,7 +536,7 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server(false);
         let names = tool_names(&server);
-        assert_tool_count_and_config(&names, 15);
+        assert_tool_count_and_config(&names, 19);
         assert!(names.contains(&"code_health_review".to_string()));
     }
 

--- a/src/tools/download_skill.rs
+++ b/src/tools/download_skill.rs
@@ -1,0 +1,151 @@
+use std::fs;
+use std::path::Path;
+
+use rmcp::model::{CallToolResult, Content};
+use rmcp::ErrorData;
+
+use crate::skills;
+use crate::tools::common::tool_error;
+use crate::tools::DownloadSkillParam;
+use crate::CodeSceneServer;
+
+pub(crate) async fn handle(
+    server: &CodeSceneServer,
+    params: DownloadSkillParam,
+) -> Result<CallToolResult, ErrorData> {
+    server.version_checker.check_in_background();
+    let skill_list = skills::load_skills();
+    let skill = skill_list.iter().find(|s| s.name == params.skill_name);
+    let skill = match skill {
+        Some(s) => s,
+        None => {
+            return Ok(tool_error(&format!(
+                "Unknown skill: '{}'. Use list_skills to see available skills.",
+                params.skill_name
+            )));
+        }
+    };
+
+    let skill_dir = Path::new(&params.destination_dir).join(&skill.name);
+    let skill_file = skill_dir.join("SKILL.md");
+
+    if skill_file.exists() && !params.overwrite {
+        return Ok(tool_error(&format!(
+            "Skill '{}' already exists at {}. Set overwrite=true to replace it.",
+            skill.name,
+            skill_file.display()
+        )));
+    }
+
+    if let Err(e) = fs::create_dir_all(&skill_dir) {
+        return Ok(tool_error(&format!(
+            "Failed to create directory {}: {e}",
+            skill_dir.display()
+        )));
+    }
+
+    if let Err(e) = fs::write(&skill_file, skill.content) {
+        return Ok(tool_error(&format!(
+            "Failed to write {}: {e}",
+            skill_file.display()
+        )));
+    }
+
+    let msg = format!(
+        "Downloaded skill '{}' to {}",
+        skill.name,
+        skill_file.display()
+    );
+    let text = server.maybe_version_warning(&msg).await;
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::handler::server::wrapper::Parameters;
+
+    use crate::tests::{
+        assert_error_contains, assert_success_contains, make_server, set_token,
+    };
+    use crate::tools::DownloadSkillParam;
+
+    #[tokio::test]
+    async fn downloads_skill_to_directory() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+        let params = DownloadSkillParam {
+            skill_name: "safeguarding-ai-generated-code".to_string(),
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: false,
+        };
+        let result = make_server(false)
+            .download_skill(Parameters(params))
+            .await
+            .unwrap();
+        assert_success_contains(&result, "Downloaded skill");
+
+        let file = tmp
+            .path()
+            .join("safeguarding-ai-generated-code")
+            .join("SKILL.md");
+        assert!(file.exists());
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(content.contains("---"));
+    }
+
+    #[tokio::test]
+    async fn refuses_overwrite_by_default() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "old").unwrap();
+
+        let params = DownloadSkillParam {
+            skill_name: "safeguarding-ai-generated-code".to_string(),
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: false,
+        };
+        let result = make_server(false)
+            .download_skill(Parameters(params))
+            .await
+            .unwrap();
+        assert_error_contains(&result, "already exists");
+    }
+
+    #[tokio::test]
+    async fn overwrites_when_flag_set() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "old").unwrap();
+
+        let params = DownloadSkillParam {
+            skill_name: "safeguarding-ai-generated-code".to_string(),
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: true,
+        };
+        let result = make_server(false)
+            .download_skill(Parameters(params))
+            .await
+            .unwrap();
+        assert_success_contains(&result, "Downloaded skill");
+    }
+
+    #[tokio::test]
+    async fn returns_error_for_unknown_skill() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+        let params = DownloadSkillParam {
+            skill_name: "nonexistent".to_string(),
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: false,
+        };
+        let result = make_server(false)
+            .download_skill(Parameters(params))
+            .await
+            .unwrap();
+        assert_error_contains(&result, "Unknown skill");
+    }
+}

--- a/src/tools/download_skill.rs
+++ b/src/tools/download_skill.rs
@@ -148,4 +148,40 @@ mod tests {
             .unwrap();
         assert_error_contains(&result, "Unknown skill");
     }
+
+    #[tokio::test]
+    async fn returns_error_when_directory_creation_fails() {
+        let _g = set_token("tok");
+        // Use /dev/null as parent — cannot create subdirectories under a device file
+        let params = DownloadSkillParam {
+            skill_name: "safeguarding-ai-generated-code".to_string(),
+            destination_dir: "/dev/null/impossible".to_string(),
+            overwrite: false,
+        };
+        let result = make_server(false)
+            .download_skill(Parameters(params))
+            .await
+            .unwrap();
+        assert_error_contains(&result, "Failed to create directory");
+    }
+
+    #[tokio::test]
+    async fn returns_error_when_write_fails() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
+        // Create SKILL.md as a directory so fs::write fails
+        std::fs::create_dir_all(skill_dir.join("SKILL.md")).unwrap();
+
+        let params = DownloadSkillParam {
+            skill_name: "safeguarding-ai-generated-code".to_string(),
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: true,
+        };
+        let result = make_server(false)
+            .download_skill(Parameters(params))
+            .await
+            .unwrap();
+        assert_error_contains(&result, "Failed to write");
+    }
 }

--- a/src/tools/download_skill.rs
+++ b/src/tools/download_skill.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use rmcp::model::{CallToolResult, Content};
 use rmcp::ErrorData;
 
+use crate::docker;
 use crate::skills;
 use crate::tools::common::tool_error;
 use crate::tools::DownloadSkillParam;
@@ -26,7 +27,8 @@ pub(crate) async fn handle(
         }
     };
 
-    let skill_dir = Path::new(&params.destination_dir).join(&skill.name);
+    let dest_path = docker::adapt_path_for_docker(Path::new(&params.destination_dir));
+    let skill_dir = Path::new(&dest_path).join(&skill.name);
     let skill_file = skill_dir.join("SKILL.md");
 
     if skill_file.exists() && !params.overwrite {

--- a/src/tools/get_skill_manifest.rs
+++ b/src/tools/get_skill_manifest.rs
@@ -1,0 +1,65 @@
+use rmcp::model::{CallToolResult, Content};
+use rmcp::ErrorData;
+
+use crate::skills;
+use crate::tools::common::tool_error;
+use crate::tools::SkillNameParam;
+use crate::CodeSceneServer;
+
+pub(crate) async fn handle(
+    server: &CodeSceneServer,
+    params: SkillNameParam,
+) -> Result<CallToolResult, ErrorData> {
+    server.version_checker.check_in_background();
+    let skill_list = skills::load_skills();
+    let skill = skill_list.iter().find(|s| s.name == params.skill_name);
+    match skill {
+        Some(s) => {
+            let manifest = skills::build_manifest(s);
+            let text = server.maybe_version_warning(&manifest).await;
+            Ok(CallToolResult::success(vec![Content::text(text)]))
+        }
+        None => Ok(tool_error(&format!(
+            "Unknown skill: '{}'. Use list_skills to see available skills.",
+            params.skill_name
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::handler::server::wrapper::Parameters;
+
+    use crate::tests::{
+        assert_error_contains, assert_success_contains, make_server, set_token,
+    };
+    use crate::tools::SkillNameParam;
+
+    #[tokio::test]
+    async fn returns_manifest_for_valid_skill() {
+        let _g = set_token("tok");
+        let params = SkillNameParam {
+            skill_name: "safeguarding-ai-generated-code".to_string(),
+        };
+        let result = make_server(false)
+            .get_skill_manifest(Parameters(params))
+            .await
+            .unwrap();
+        assert_success_contains(&result, "safeguarding-ai-generated-code");
+        assert_success_contains(&result, "SKILL.md");
+        assert_success_contains(&result, "sha256:");
+    }
+
+    #[tokio::test]
+    async fn returns_error_for_unknown_skill() {
+        let _g = set_token("tok");
+        let params = SkillNameParam {
+            skill_name: "nonexistent".to_string(),
+        };
+        let result = make_server(false)
+            .get_skill_manifest(Parameters(params))
+            .await
+            .unwrap();
+        assert_error_contains(&result, "Unknown skill");
+    }
+}

--- a/src/tools/list_skills.rs
+++ b/src/tools/list_skills.rs
@@ -1,0 +1,36 @@
+use rmcp::model::{CallToolResult, Content};
+use rmcp::ErrorData;
+
+use crate::skills;
+use crate::CodeSceneServer;
+
+pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, ErrorData> {
+    server.version_checker.check_in_background();
+    let skill_list = skills::load_skills();
+    let entries: Vec<String> = skill_list
+        .iter()
+        .map(|s| format!("- **{}**: {}", s.name, s.description))
+        .collect();
+    let text = format!(
+        "Available skills ({}):\n\n{}",
+        entries.len(),
+        entries.join("\n")
+    );
+    let text = server.maybe_version_warning(&text).await;
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::{make_server, result_text, set_token};
+
+    #[tokio::test]
+    async fn returns_all_skills() {
+        let _g = set_token("tok");
+        let result = make_server(false).list_skills().await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("Available skills"));
+        assert!(text.contains("safeguarding-ai-generated-code"));
+        assert!(text.contains("explaining-code-health"));
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -8,9 +8,12 @@ pub mod code_health_score;
 pub mod code_ownership_for_path;
 pub mod codescene_links;
 pub mod common;
+pub mod download_skill;
 pub mod explain_code_health;
 pub mod explain_code_health_productivity;
 pub mod get_config;
+pub mod get_skill_manifest;
+pub mod list_skills;
 pub mod list_technical_debt_goals_for_project;
 pub mod list_technical_debt_goals_for_project_file;
 pub mod list_technical_debt_hotspots_for_project;
@@ -18,6 +21,7 @@ pub mod list_technical_debt_hotspots_for_project_file;
 pub mod pre_commit_code_health_safeguard;
 pub mod select_project;
 pub mod set_config;
+pub mod sync_skills;
 
 /// Optional context parameter used by explain tools.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -99,6 +103,40 @@ pub struct SetConfigParam {
 
     /// The value to store. Pass an empty string to remove the key.
     pub value: String,
+}
+
+/// Parameters for get_skill_manifest.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SkillNameParam {
+    /// Name of the skill (e.g., "safeguarding-ai-generated-code").
+    pub skill_name: String,
+}
+
+/// Parameters for download_skill.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DownloadSkillParam {
+    /// Name of the skill to download (e.g., "safeguarding-ai-generated-code").
+    pub skill_name: String,
+
+    /// Directory to write the skill into. A subdirectory named after
+    /// the skill will be created containing SKILL.md.
+    pub destination_dir: String,
+
+    /// Whether to overwrite an existing skill. Defaults to false.
+    #[serde(default)]
+    pub overwrite: bool,
+}
+
+/// Parameters for sync_skills.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SyncSkillsParam {
+    /// Directory to write all skills into. Each skill gets its own
+    /// subdirectory containing SKILL.md.
+    pub destination_dir: String,
+
+    /// Whether to overwrite existing skills. Defaults to false.
+    #[serde(default)]
+    pub overwrite: bool,
 }
 
 #[cfg(test)]
@@ -184,5 +222,36 @@ mod tests {
         let p: SetConfigParam = serde_json::from_str(json).unwrap();
         assert_eq!(p.key, "access_token");
         assert_eq!(p.value, "abc123");
+    }
+
+    #[test]
+    fn skill_name_param_deserializes() {
+        let json = r#"{"skill_name": "my-skill"}"#;
+        let p: SkillNameParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.skill_name, "my-skill");
+    }
+
+    #[test]
+    fn download_skill_param_deserializes() {
+        let json = r#"{"skill_name": "my-skill", "destination_dir": "/tmp/skills"}"#;
+        let p: DownloadSkillParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.skill_name, "my-skill");
+        assert_eq!(p.destination_dir, "/tmp/skills");
+        assert!(!p.overwrite);
+    }
+
+    #[test]
+    fn download_skill_param_with_overwrite() {
+        let json = r#"{"skill_name": "x", "destination_dir": "/tmp", "overwrite": true}"#;
+        let p: DownloadSkillParam = serde_json::from_str(json).unwrap();
+        assert!(p.overwrite);
+    }
+
+    #[test]
+    fn sync_skills_param_deserializes() {
+        let json = r#"{"destination_dir": "/tmp/skills"}"#;
+        let p: SyncSkillsParam = serde_json::from_str(json).unwrap();
+        assert_eq!(p.destination_dir, "/tmp/skills");
+        assert!(!p.overwrite);
     }
 }

--- a/src/tools/sync_skills.rs
+++ b/src/tools/sync_skills.rs
@@ -1,0 +1,151 @@
+use std::fs;
+use std::path::Path;
+
+use rmcp::model::{CallToolResult, Content};
+use rmcp::ErrorData;
+
+use crate::skills;
+use crate::tools::common::tool_error;
+use crate::tools::SyncSkillsParam;
+use crate::CodeSceneServer;
+
+pub(crate) async fn handle(
+    server: &CodeSceneServer,
+    params: SyncSkillsParam,
+) -> Result<CallToolResult, ErrorData> {
+    server.version_checker.check_in_background();
+    let skill_list = skills::load_skills();
+    let dest = Path::new(&params.destination_dir);
+
+    let mut downloaded = Vec::new();
+    let mut skipped = Vec::new();
+    let mut errors = Vec::new();
+
+    for skill in &skill_list {
+        let skill_dir = dest.join(&skill.name);
+        let skill_file = skill_dir.join("SKILL.md");
+
+        if skill_file.exists() && !params.overwrite {
+            skipped.push(skill.name.clone());
+            continue;
+        }
+
+        if let Err(e) = fs::create_dir_all(&skill_dir) {
+            errors.push(format!("{}: {e}", skill.name));
+            continue;
+        }
+
+        match fs::write(&skill_file, skill.content) {
+            Ok(()) => downloaded.push(skill.name.clone()),
+            Err(e) => errors.push(format!("{}: {e}", skill.name)),
+        }
+    }
+
+    if !errors.is_empty() {
+        return Ok(tool_error(&format!(
+            "Failed to write some skills:\n{}",
+            errors.join("\n")
+        )));
+    }
+
+    let msg = format_summary(&downloaded, &skipped, dest);
+    let text = server.maybe_version_warning(&msg).await;
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+fn format_summary(downloaded: &[String], skipped: &[String], dest: &Path) -> String {
+    let mut parts = Vec::new();
+    if !downloaded.is_empty() {
+        parts.push(format!(
+            "Downloaded {} skill(s) to {}:\n{}",
+            downloaded.len(),
+            dest.display(),
+            downloaded.iter().map(|s| format!("  - {s}")).collect::<Vec<_>>().join("\n")
+        ));
+    }
+    if !skipped.is_empty() {
+        parts.push(format!(
+            "Skipped {} existing skill(s) (use overwrite=true to replace):\n{}",
+            skipped.len(),
+            skipped.iter().map(|s| format!("  - {s}")).collect::<Vec<_>>().join("\n")
+        ));
+    }
+    if parts.is_empty() {
+        return "No skills to sync.".to_string();
+    }
+    parts.join("\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use rmcp::handler::server::wrapper::Parameters;
+
+    use crate::tests::{assert_success_contains, make_server, result_text, set_token};
+    use crate::tools::SyncSkillsParam;
+
+    #[tokio::test]
+    async fn syncs_all_skills() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+        let params = SyncSkillsParam {
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: false,
+        };
+        let result = make_server(false)
+            .sync_skills(Parameters(params))
+            .await
+            .unwrap();
+        assert_success_contains(&result, "Downloaded");
+
+        let entries: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(entries.len() >= 9);
+    }
+
+    #[tokio::test]
+    async fn skips_existing_without_overwrite() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Pre-create one skill
+        let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "old").unwrap();
+
+        let params = SyncSkillsParam {
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: false,
+        };
+        let result = make_server(false)
+            .sync_skills(Parameters(params))
+            .await
+            .unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("Skipped 1"));
+        assert!(text.contains("Downloaded"));
+    }
+
+    #[tokio::test]
+    async fn overwrites_when_flag_set() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "old").unwrap();
+
+        let params = SyncSkillsParam {
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite: true,
+        };
+        let result = make_server(false)
+            .sync_skills(Parameters(params))
+            .await
+            .unwrap();
+        let text = result_text(&result);
+        assert!(!text.contains("Skipped"));
+        assert!(text.contains("Downloaded"));
+    }
+}

--- a/src/tools/sync_skills.rs
+++ b/src/tools/sync_skills.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use rmcp::model::{CallToolResult, Content};
 use rmcp::ErrorData;
 
+use crate::docker;
 use crate::skills;
 use crate::tools::common::tool_error;
 use crate::tools::SyncSkillsParam;
@@ -15,7 +16,8 @@ pub(crate) async fn handle(
 ) -> Result<CallToolResult, ErrorData> {
     server.version_checker.check_in_background();
     let skill_list = skills::load_skills();
-    let dest = Path::new(&params.destination_dir);
+    let dest_path = docker::adapt_path_for_docker(Path::new(&params.destination_dir));
+    let dest = Path::new(&dest_path);
 
     let mut downloaded = Vec::new();
     let mut skipped = Vec::new();

--- a/src/tools/sync_skills.rs
+++ b/src/tools/sync_skills.rs
@@ -80,8 +80,29 @@ fn format_summary(downloaded: &[String], skipped: &[String], dest: &Path) -> Str
 mod tests {
     use rmcp::handler::server::wrapper::Parameters;
 
-    use crate::tests::{assert_success_contains, make_server, result_text, set_token};
+    use crate::tests::{
+        assert_error_contains, assert_success_contains, make_server, result_text, set_token,
+    };
     use crate::tools::SyncSkillsParam;
+
+    use super::format_summary;
+
+    async fn sync_with_precreated_skill(overwrite: bool) -> String {
+        let tmp = tempfile::tempdir().unwrap();
+        let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "old").unwrap();
+
+        let params = SyncSkillsParam {
+            destination_dir: tmp.path().to_str().unwrap().to_string(),
+            overwrite,
+        };
+        let result = make_server(false)
+            .sync_skills(Parameters(params))
+            .await
+            .unwrap();
+        result_text(&result).to_string()
+    }
 
     #[tokio::test]
     async fn syncs_all_skills() {
@@ -107,22 +128,7 @@ mod tests {
     #[tokio::test]
     async fn skips_existing_without_overwrite() {
         let _g = set_token("tok");
-        let tmp = tempfile::tempdir().unwrap();
-
-        // Pre-create one skill
-        let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
-        std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(skill_dir.join("SKILL.md"), "old").unwrap();
-
-        let params = SyncSkillsParam {
-            destination_dir: tmp.path().to_str().unwrap().to_string(),
-            overwrite: false,
-        };
-        let result = make_server(false)
-            .sync_skills(Parameters(params))
-            .await
-            .unwrap();
-        let text = result_text(&result);
+        let text = sync_with_precreated_skill(false).await;
         assert!(text.contains("Skipped 1"));
         assert!(text.contains("Downloaded"));
     }
@@ -130,11 +136,32 @@ mod tests {
     #[tokio::test]
     async fn overwrites_when_flag_set() {
         let _g = set_token("tok");
-        let tmp = tempfile::tempdir().unwrap();
+        let text = sync_with_precreated_skill(true).await;
+        assert!(!text.contains("Skipped"));
+        assert!(text.contains("Downloaded"));
+    }
 
+    #[tokio::test]
+    async fn returns_error_when_directory_creation_fails() {
+        let _g = set_token("tok");
+        let params = SyncSkillsParam {
+            destination_dir: "/dev/null/impossible".to_string(),
+            overwrite: false,
+        };
+        let result = make_server(false)
+            .sync_skills(Parameters(params))
+            .await
+            .unwrap();
+        assert_error_contains(&result, "Failed to write some skills");
+    }
+
+    #[tokio::test]
+    async fn returns_error_when_write_fails() {
+        let _g = set_token("tok");
+        let tmp = tempfile::tempdir().unwrap();
+        // Make one skill's SKILL.md a directory so write fails
         let skill_dir = tmp.path().join("safeguarding-ai-generated-code");
-        std::fs::create_dir_all(&skill_dir).unwrap();
-        std::fs::write(skill_dir.join("SKILL.md"), "old").unwrap();
+        std::fs::create_dir_all(skill_dir.join("SKILL.md")).unwrap();
 
         let params = SyncSkillsParam {
             destination_dir: tmp.path().to_str().unwrap().to_string(),
@@ -144,8 +171,23 @@ mod tests {
             .sync_skills(Parameters(params))
             .await
             .unwrap();
-        let text = result_text(&result);
-        assert!(!text.contains("Skipped"));
-        assert!(text.contains("Downloaded"));
+        assert_error_contains(&result, "Failed to write some skills");
+    }
+
+    #[test]
+    fn format_summary_with_no_skills() {
+        let result = format_summary(&[], &[], std::path::Path::new("/tmp"));
+        assert_eq!(result, "No skills to sync.");
+    }
+
+    #[test]
+    fn format_summary_with_only_skipped() {
+        let result = format_summary(
+            &[],
+            &["skill-a".to_string()],
+            std::path::Path::new("/tmp"),
+        );
+        assert!(result.contains("Skipped 1"));
+        assert!(!result.contains("Downloaded"));
     }
 }

--- a/tests/integration/run_all_tests.py
+++ b/tests/integration/run_all_tests.py
@@ -456,6 +456,7 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
     from test_shutdown_during_handshake import (
         run_shutdown_during_handshake_tests_with_backend,
     )
+    from test_skill_resources import run_skill_resources_tests_with_backend
     from test_standalone_license import run_standalone_license_tests_with_backend
     from test_ssl_api_ca_bundle import run_ssl_api_ca_bundle_tests_with_backend
     from test_ssl_cli_truststore import run_ssl_cli_truststore_tests_with_backend
@@ -486,6 +487,7 @@ def _run_additional_test_modules(backend: ServerBackend) -> list[tuple[str, bool
         ("SSL Truststore CLI Tests", run_ssl_cli_truststore_tests_with_backend),
         ("SSL API CA Bundle Tests", run_ssl_api_ca_bundle_tests_with_backend),
         ("Error Logging Tests", run_error_logging_tests_with_backend),
+        ("Skill Resources Tests", run_skill_resources_tests_with_backend),
     ]
     return [_run_test_module(name, func, backend) for name, func in modules]
 

--- a/tests/integration/test_skill_resources.py
+++ b/tests/integration/test_skill_resources.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Skill resources integration tests.
+
+Tests that the MCP server exposes embedded skills as MCP resources
+using the skill:// URI scheme.
+
+This test suite validates:
+1. resources/list returns skill resources with correct URIs and metadata
+2. resources/read returns SKILL.md content for each skill
+3. resources/read returns valid JSON manifests for each skill
+4. resources/templates/list returns the skill file template
+5. resources/read rejects unknown skill names and invalid URIs
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from fixtures import get_sample_files
+
+from test_utils import (
+    MCPClient,
+    CargoBackend,
+    ServerBackend,
+    create_git_repo,
+    print_header,
+    print_summary,
+    print_test,
+    safe_temp_directory,
+)
+
+EXPECTED_SKILL_NAMES = [
+    "configuring-codescene-mcp",
+    "explaining-code-health",
+    "guiding-refactoring-with-code-health",
+    "installing-and-activating-codescene-mcp",
+    "making-the-business-case-for-code-health",
+    "prioritizing-technical-debt",
+    "risk-based-testing-with-code-health",
+    "routing-work-with-code-ownership",
+    "safeguarding-ai-generated-code",
+]
+
+
+def run_skill_resources_tests(executable: Path) -> int:
+    backend = CargoBackend(executable=executable)
+    return run_skill_resources_tests_with_backend(backend)
+
+
+def run_skill_resources_tests_with_backend(backend: ServerBackend) -> int:
+    with safe_temp_directory(prefix="cs_mcp_skill_resources_test_") as test_dir:
+        print(f"\nTest directory: {test_dir}")
+
+        print("\nCreating test repository...")
+        repo_dir = create_git_repo(test_dir, get_sample_files())
+        print(f"Repository: {repo_dir}")
+
+        command = backend.get_command(repo_dir)
+        env = backend.get_env(os.environ.copy(), repo_dir)
+
+        results = [
+            ("Initialize reports resources capability", test_init_capabilities(command, env, repo_dir)),
+            ("List resources returns all skills", test_list_resources(command, env, repo_dir)),
+            ("Read SKILL.md resource", test_read_skill_md(command, env, repo_dir)),
+            ("Read manifest resource", test_read_manifest(command, env, repo_dir)),
+            ("List resource templates", test_list_resource_templates(command, env, repo_dir)),
+            ("Read error cases", test_read_error_cases(command, env, repo_dir)),
+        ]
+
+        return print_summary(results)
+
+
+def test_init_capabilities(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test that initialize response advertises resources capability."""
+    print_header("Test: Initialize Reports Resources Capability")
+
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            return False
+        print_test("Server started", True)
+
+        response = client.initialize()
+        capabilities = response.get("result", {}).get("capabilities", {})
+        has_resources = "resources" in capabilities
+        print_test("Resources capability advertised", has_resources, f"capabilities keys: {list(capabilities.keys())}")
+        return has_resources
+
+    except Exception as e:
+        print_test("Initialize capabilities", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def _verify_skill_md_metadata(resources: list[dict]) -> bool:
+    """Check mime type and description on a sample SKILL.md resource."""
+    sample = next((r for r in resources if r["uri"].endswith("/SKILL.md")), None)
+    if not sample:
+        print_test("Sample SKILL.md resource found", False)
+        return False
+    has_mime = sample.get("mimeType") == "text/markdown"
+    print_test("SKILL.md has text/markdown mime type", has_mime, f"mimeType: {sample.get('mimeType')}")
+    has_desc = bool(sample.get("description"))
+    print_test("SKILL.md has description", has_desc)
+    return has_mime and has_desc
+
+
+def _verify_expected_uris(resources: list[dict]) -> tuple[bool, bool, bool]:
+    """Verify resource count and expected URIs. Returns (count_ok, skills_ok, manifests_ok)."""
+    expected_count = len(EXPECTED_SKILL_NAMES) * 2
+    has_correct_count = len(resources) == expected_count
+    print_test(f"Resource count matches ({expected_count})", has_correct_count, f"Actual: {len(resources)}")
+
+    skill_md_uris = {r["uri"] for r in resources if r["uri"].endswith("/SKILL.md")}
+    all_skills_present = all(f"skill://{name}/SKILL.md" in skill_md_uris for name in EXPECTED_SKILL_NAMES)
+    print_test("All skill SKILL.md URIs present", all_skills_present)
+
+    manifest_uris = {r["uri"] for r in resources if r["uri"].endswith("/_manifest")}
+    all_manifests_present = all(f"skill://{name}/_manifest" in manifest_uris for name in EXPECTED_SKILL_NAMES)
+    print_test("All skill _manifest URIs present", all_manifests_present)
+
+    return has_correct_count, all_skills_present, all_manifests_present
+
+
+def test_list_resources(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test that resources/list returns all embedded skills."""
+    print_header("Test: List Resources Returns All Skills")
+
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            return False
+        print_test("Server started", True)
+        client.initialize()
+
+        response = client.send_request("resources/list")
+        resources = response.get("result", {}).get("resources", [])
+
+        count_ok, skills_ok, manifests_ok = _verify_expected_uris(resources)
+        metadata_ok = _verify_skill_md_metadata(resources)
+
+        return count_ok and skills_ok and manifests_ok and metadata_ok
+
+    except Exception as e:
+        print_test("List resources", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_read_skill_md(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test reading a SKILL.md resource returns valid content."""
+    print_header("Test: Read SKILL.md Resource")
+
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            return False
+        print_test("Server started", True)
+        client.initialize()
+
+        skill_name = "safeguarding-ai-generated-code"
+        uri = f"skill://{skill_name}/SKILL.md"
+        response = client.send_request("resources/read", {"uri": uri})
+        contents = response.get("result", {}).get("contents", [])
+
+        has_content = len(contents) > 0
+        print_test("Response has contents", has_content)
+        if not has_content:
+            return False
+
+        text = contents[0].get("text", "")
+        has_text = len(text) > 50
+        print_test("Content has substantial text", has_text, f"Length: {len(text)} chars")
+
+        has_frontmatter = "---" in text
+        print_test("Content includes frontmatter", has_frontmatter)
+
+        has_skill_content = "code health" in text.lower() or "safeguard" in text.lower()
+        print_test("Content is skill-related", has_skill_content)
+
+        return has_text
+
+    except Exception as e:
+        print_test("Read SKILL.md", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def _verify_manifest_files(files: list[dict]) -> bool:
+    """Verify the files array in a manifest response."""
+    has_files = len(files) == 1
+    print_test("Manifest lists one file", has_files, f"Count: {len(files)}")
+    if not files:
+        return False
+
+    f = files[0]
+    has_path = f.get("path") == "SKILL.md"
+    print_test("File path is SKILL.md", has_path)
+
+    size = f.get("size", 0)
+    print_test("File has positive size", size > 0, f"Size: {size}")
+
+    hash_val = f.get("hash", "")
+    print_test("File has sha256 hash", hash_val.startswith("sha256:"), f"Hash: {hash_val[:20]}...")
+
+    return has_files and has_path
+
+
+def test_read_manifest(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test that reading a _manifest resource returns valid JSON metadata."""
+    print_header("Test: Read Manifest Resource")
+
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            return False
+        print_test("Server started", True)
+        client.initialize()
+
+        skill_name = "safeguarding-ai-generated-code"
+        uri = f"skill://{skill_name}/_manifest"
+        response = client.send_request("resources/read", {"uri": uri})
+        contents = response.get("result", {}).get("contents", [])
+
+        has_content = len(contents) > 0
+        print_test("Response has contents", has_content)
+        if not has_content:
+            return False
+
+        text = contents[0].get("text", "")
+        try:
+            manifest = json.loads(text)
+        except json.JSONDecodeError:
+            print_test("Manifest is valid JSON", False, f"Text: {text[:200]}")
+            return False
+        print_test("Manifest is valid JSON", True)
+
+        has_skill_field = manifest.get("skill") == skill_name
+        print_test("Manifest has correct skill name", has_skill_field)
+
+        files_ok = _verify_manifest_files(manifest.get("files", []))
+
+        return has_content and has_skill_field and files_ok
+
+    except Exception as e:
+        print_test("Read manifest", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_list_resource_templates(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test that resources/templates/list returns the skill template."""
+    print_header("Test: List Resource Templates")
+
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            return False
+        print_test("Server started", True)
+        client.initialize()
+
+        response = client.send_request("resources/templates/list")
+        templates = response.get("result", {}).get("resourceTemplates", [])
+
+        has_templates = len(templates) > 0
+        print_test("Templates returned", has_templates, f"Count: {len(templates)}")
+        if not has_templates:
+            return False
+
+        uri_template = templates[0].get("uriTemplate", "")
+        has_skill_template = "skill://" in uri_template and "{skill_name}" in uri_template
+        print_test("Template has skill:// URI pattern", has_skill_template, f"URI: {uri_template}")
+        return has_skill_template
+
+    except Exception as e:
+        print_test("List resource templates", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def test_read_error_cases(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test that reading invalid or unknown URIs returns errors."""
+    print_header("Test: Read Error Cases")
+
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            return False
+        print_test("Server started", True)
+        client.initialize()
+
+        error_cases = [
+            ("skill://nonexistent-skill/SKILL.md", "unknown skill"),
+            ("file:///etc/passwd", "non-skill URI"),
+        ]
+
+        all_passed = True
+        for uri, label in error_cases:
+            response = client.send_request("resources/read", {"uri": uri})
+            has_error = "error" in response
+            print_test(f"Error returned for {label}", has_error)
+            all_passed = all_passed and has_error
+
+        return all_passed
+
+    except Exception as e:
+        print_test("Read error cases", False, str(e))
+        return False
+    finally:
+        client.stop()
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: python test_skill_resources.py /path/to/cs-mcp")
+        return 1
+
+    executable = Path(sys.argv[1])
+    if not executable.exists():
+        print(f"Error: Executable not found: {executable}")
+        return 1
+
+    print_header("Skill Resources Integration Tests")
+    print("\nThese tests verify that embedded skills are exposed")
+    print("as MCP resources using the skill:// URI scheme.")
+
+    return run_skill_resources_tests(executable)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_skill_resources.py
+++ b/tests/integration/test_skill_resources.py
@@ -16,6 +16,7 @@ This test suite validates:
 import json
 import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -46,6 +47,22 @@ EXPECTED_SKILL_NAMES = [
 ]
 
 
+@contextmanager
+def _mcp_session(command, env, repo_dir):
+    """Start an MCP client, initialize it, and yield it. Stops on exit."""
+    client = MCPClient(command, env=env, cwd=str(repo_dir))
+    try:
+        if not client.start():
+            print_test("Server started", False)
+            yield None
+            return
+        print_test("Server started", True)
+        client.initialize()
+        yield client
+    finally:
+        client.stop()
+
+
 def run_skill_resources_tests(executable: Path) -> int:
     backend = CargoBackend(executable=executable)
     return run_skill_resources_tests_with_backend(backend)
@@ -69,6 +86,10 @@ def run_skill_resources_tests_with_backend(backend: ServerBackend) -> int:
             ("Read manifest resource", test_read_manifest(command, env, repo_dir)),
             ("List resource templates", test_list_resource_templates(command, env, repo_dir)),
             ("Read error cases", test_read_error_cases(command, env, repo_dir)),
+            ("list_skills tool", test_list_skills_tool(command, env, repo_dir)),
+            ("get_skill_manifest tool", test_get_skill_manifest_tool(command, env, repo_dir)),
+            ("download_skill tool", test_download_skill_tool(command, env, repo_dir, test_dir)),
+            ("sync_skills tool", test_sync_skills_tool(command, env, repo_dir, test_dir)),
         ]
 
         return print_summary(results)
@@ -78,6 +99,7 @@ def test_init_capabilities(command: list[str], env: dict, repo_dir: Path) -> boo
     """Test that initialize response advertises resources capability."""
     print_header("Test: Initialize Reports Resources Capability")
 
+    # This test needs raw client access (pre-initialize) so doesn't use _mcp_session
     client = MCPClient(command, env=env, cwd=str(repo_dir))
     try:
         if not client.start():
@@ -132,43 +154,24 @@ def test_list_resources(command: list[str], env: dict, repo_dir: Path) -> bool:
     """Test that resources/list returns all embedded skills."""
     print_header("Test: List Resources Returns All Skills")
 
-    client = MCPClient(command, env=env, cwd=str(repo_dir))
-    try:
-        if not client.start():
-            print_test("Server started", False)
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
             return False
-        print_test("Server started", True)
-        client.initialize()
-
         response = client.send_request("resources/list")
         resources = response.get("result", {}).get("resources", [])
-
         count_ok, skills_ok, manifests_ok = _verify_expected_uris(resources)
         metadata_ok = _verify_skill_md_metadata(resources)
-
         return count_ok and skills_ok and manifests_ok and metadata_ok
-
-    except Exception as e:
-        print_test("List resources", False, str(e))
-        return False
-    finally:
-        client.stop()
 
 
 def test_read_skill_md(command: list[str], env: dict, repo_dir: Path) -> bool:
     """Test reading a SKILL.md resource returns valid content."""
     print_header("Test: Read SKILL.md Resource")
 
-    client = MCPClient(command, env=env, cwd=str(repo_dir))
-    try:
-        if not client.start():
-            print_test("Server started", False)
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
             return False
-        print_test("Server started", True)
-        client.initialize()
-
-        skill_name = "safeguarding-ai-generated-code"
-        uri = f"skill://{skill_name}/SKILL.md"
+        uri = "skill://safeguarding-ai-generated-code/SKILL.md"
         response = client.send_request("resources/read", {"uri": uri})
         contents = response.get("result", {}).get("contents", [])
 
@@ -180,20 +183,9 @@ def test_read_skill_md(command: list[str], env: dict, repo_dir: Path) -> bool:
         text = contents[0].get("text", "")
         has_text = len(text) > 50
         print_test("Content has substantial text", has_text, f"Length: {len(text)} chars")
-
-        has_frontmatter = "---" in text
-        print_test("Content includes frontmatter", has_frontmatter)
-
-        has_skill_content = "code health" in text.lower() or "safeguard" in text.lower()
-        print_test("Content is skill-related", has_skill_content)
-
+        print_test("Content includes frontmatter", "---" in text)
+        print_test("Content is skill-related", "code health" in text.lower() or "safeguard" in text.lower())
         return has_text
-
-    except Exception as e:
-        print_test("Read SKILL.md", False, str(e))
-        return False
-    finally:
-        client.stop()
 
 
 def _verify_manifest_files(files: list[dict]) -> bool:
@@ -220,14 +212,9 @@ def test_read_manifest(command: list[str], env: dict, repo_dir: Path) -> bool:
     """Test that reading a _manifest resource returns valid JSON metadata."""
     print_header("Test: Read Manifest Resource")
 
-    client = MCPClient(command, env=env, cwd=str(repo_dir))
-    try:
-        if not client.start():
-            print_test("Server started", False)
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
             return False
-        print_test("Server started", True)
-        client.initialize()
-
         skill_name = "safeguarding-ai-generated-code"
         uri = f"skill://{skill_name}/_manifest"
         response = client.send_request("resources/read", {"uri": uri})
@@ -248,30 +235,17 @@ def test_read_manifest(command: list[str], env: dict, repo_dir: Path) -> bool:
 
         has_skill_field = manifest.get("skill") == skill_name
         print_test("Manifest has correct skill name", has_skill_field)
-
         files_ok = _verify_manifest_files(manifest.get("files", []))
-
         return has_content and has_skill_field and files_ok
-
-    except Exception as e:
-        print_test("Read manifest", False, str(e))
-        return False
-    finally:
-        client.stop()
 
 
 def test_list_resource_templates(command: list[str], env: dict, repo_dir: Path) -> bool:
     """Test that resources/templates/list returns the skill template."""
     print_header("Test: List Resource Templates")
 
-    client = MCPClient(command, env=env, cwd=str(repo_dir))
-    try:
-        if not client.start():
-            print_test("Server started", False)
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
             return False
-        print_test("Server started", True)
-        client.initialize()
-
         response = client.send_request("resources/templates/list")
         templates = response.get("result", {}).get("resourceTemplates", [])
 
@@ -285,25 +259,14 @@ def test_list_resource_templates(command: list[str], env: dict, repo_dir: Path) 
         print_test("Template has skill:// URI pattern", has_skill_template, f"URI: {uri_template}")
         return has_skill_template
 
-    except Exception as e:
-        print_test("List resource templates", False, str(e))
-        return False
-    finally:
-        client.stop()
-
 
 def test_read_error_cases(command: list[str], env: dict, repo_dir: Path) -> bool:
     """Test that reading invalid or unknown URIs returns errors."""
     print_header("Test: Read Error Cases")
 
-    client = MCPClient(command, env=env, cwd=str(repo_dir))
-    try:
-        if not client.start():
-            print_test("Server started", False)
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
             return False
-        print_test("Server started", True)
-        client.initialize()
-
         error_cases = [
             ("skill://nonexistent-skill/SKILL.md", "unknown skill"),
             ("file:///etc/passwd", "non-skill URI"),
@@ -318,11 +281,96 @@ def test_read_error_cases(command: list[str], env: dict, repo_dir: Path) -> bool
 
         return all_passed
 
-    except Exception as e:
-        print_test("Read error cases", False, str(e))
-        return False
-    finally:
-        client.stop()
+
+def test_list_skills_tool(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test the list_skills tool returns all embedded skills."""
+    print_header("Test: list_skills Tool")
+
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
+            return False
+        content = _extract_tool_text(client.call_tool("list_skills", {}))
+        if content is None:
+            print_test("Tool returned content", False)
+            return False
+        print_test("Tool returned content", True)
+
+        has_count = f"Available skills ({len(EXPECTED_SKILL_NAMES)})" in content
+        print_test("Lists correct skill count", has_count)
+
+        has_skill = "safeguarding-ai-generated-code" in content
+        print_test("Contains expected skill name", has_skill)
+        return has_count and has_skill
+
+
+def test_get_skill_manifest_tool(command: list[str], env: dict, repo_dir: Path) -> bool:
+    """Test the get_skill_manifest tool returns valid JSON."""
+    print_header("Test: get_skill_manifest Tool")
+
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
+            return False
+        skill_name = "safeguarding-ai-generated-code"
+        content = _extract_tool_text(client.call_tool("get_skill_manifest", {"skill_name": skill_name}))
+        if content is None:
+            print_test("Tool returned content", False)
+            return False
+        print_test("Tool returned content", True)
+
+        manifest = json.loads(content)
+        has_name = manifest.get("skill") == skill_name
+        print_test("Manifest has correct skill name", has_name)
+
+        has_files = len(manifest.get("files", [])) == 1
+        print_test("Manifest lists one file", has_files)
+        return has_name and has_files
+
+
+def test_download_skill_tool(command: list[str], env: dict, repo_dir: Path, test_dir: Path) -> bool:
+    """Test the download_skill tool writes SKILL.md to disk."""
+    print_header("Test: download_skill Tool")
+
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
+            return False
+        dest = test_dir / "download_test"
+        skill_name = "safeguarding-ai-generated-code"
+        content = _extract_tool_text(client.call_tool("download_skill", {
+            "skill_name": skill_name,
+            "destination_dir": str(dest),
+        }))
+        has_content = content is not None and "Downloaded" in content
+        print_test("Tool reports success", has_content)
+
+        file_exists = (dest / skill_name / "SKILL.md").exists()
+        print_test("SKILL.md written to disk", file_exists)
+        return has_content and file_exists
+
+
+def test_sync_skills_tool(command: list[str], env: dict, repo_dir: Path, test_dir: Path) -> bool:
+    """Test the sync_skills tool downloads all skills."""
+    print_header("Test: sync_skills Tool")
+
+    with _mcp_session(command, env, repo_dir) as client:
+        if client is None:
+            return False
+        dest = test_dir / "sync_test"
+        content = _extract_tool_text(client.call_tool("sync_skills", {"destination_dir": str(dest)}))
+        has_content = content is not None and "Downloaded" in content
+        print_test("Tool reports success", has_content)
+
+        dirs = [d for d in dest.iterdir() if d.is_dir()] if dest.exists() else []
+        all_synced = len(dirs) == len(EXPECTED_SKILL_NAMES)
+        print_test(f"All {len(EXPECTED_SKILL_NAMES)} skills synced", all_synced, f"Actual: {len(dirs)}")
+        return has_content and all_synced
+
+
+def _extract_tool_text(response: dict) -> str | None:
+    """Extract text content from a tools/call response."""
+    content = response.get("result", {}).get("content", [])
+    if not content:
+        return None
+    return content[0].get("text")
 
 
 def main() -> int:

--- a/tests/integration/test_skill_resources.py
+++ b/tests/integration/test_skill_resources.py
@@ -88,8 +88,8 @@ def run_skill_resources_tests_with_backend(backend: ServerBackend) -> int:
             ("Read error cases", test_read_error_cases(command, env, repo_dir)),
             ("list_skills tool", test_list_skills_tool(command, env, repo_dir)),
             ("get_skill_manifest tool", test_get_skill_manifest_tool(command, env, repo_dir)),
-            ("download_skill tool", test_download_skill_tool(command, env, repo_dir, test_dir)),
-            ("sync_skills tool", test_sync_skills_tool(command, env, repo_dir, test_dir)),
+            ("download_skill tool", test_download_skill_tool(command, env, repo_dir)),
+            ("sync_skills tool", test_sync_skills_tool(command, env, repo_dir)),
         ]
 
         return print_summary(results)
@@ -326,14 +326,14 @@ def test_get_skill_manifest_tool(command: list[str], env: dict, repo_dir: Path) 
         return has_name and has_files
 
 
-def test_download_skill_tool(command: list[str], env: dict, repo_dir: Path, test_dir: Path) -> bool:
+def test_download_skill_tool(command: list[str], env: dict, repo_dir: Path) -> bool:
     """Test the download_skill tool writes SKILL.md to disk."""
     print_header("Test: download_skill Tool")
 
     with _mcp_session(command, env, repo_dir) as client:
         if client is None:
             return False
-        dest = test_dir / "download_test"
+        dest = repo_dir / "download_test"
         skill_name = "safeguarding-ai-generated-code"
         content = _extract_tool_text(client.call_tool("download_skill", {
             "skill_name": skill_name,
@@ -347,14 +347,14 @@ def test_download_skill_tool(command: list[str], env: dict, repo_dir: Path, test
         return has_content and file_exists
 
 
-def test_sync_skills_tool(command: list[str], env: dict, repo_dir: Path, test_dir: Path) -> bool:
+def test_sync_skills_tool(command: list[str], env: dict, repo_dir: Path) -> bool:
     """Test the sync_skills tool downloads all skills."""
     print_header("Test: sync_skills Tool")
 
     with _mcp_session(command, env, repo_dir) as client:
         if client is None:
             return False
-        dest = test_dir / "sync_test"
+        dest = repo_dir / "sync_test"
         content = _extract_tool_text(client.call_tool("sync_skills", {"destination_dir": str(dest)}))
         has_content = content is not None and "Downloaded" in content
         print_test("Tool reports success", has_content)


### PR DESCRIPTION
This pull request introduces a new system for managing "skills"—modular, embedded instructional resources—within the MCP server. It adds a set of tools and resource APIs to discover, inspect, and download these skills, both individually and in bulk. The implementation includes embedding skill content, exposing them as resources, and providing robust test coverage for the new features.

The most important changes are:

**Skill Embedding and Registry:**
* Added a new `skills` module (`src/skills.rs`) that embeds a set of skill markdown files, parses their YAML frontmatter for metadata, computes content hashes, and exposes functions for skill lookup, manifest generation, and URI parsing.
* Updated the build system and Dockerfile to include the `skills/` directory and added the `gray_matter` dependency for YAML parsing. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R13) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R59)

**New Skill-Related Tools:**
* Added four new tools to the `CodeSceneServer` API: `list_skills`, `get_skill_manifest`, `download_skill`, and `sync_skills`. These allow clients to enumerate available skills, inspect their manifests, and download them to a local directory, with overwrite protection and clear error handling. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL44-R47) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR395-R434) [[3]](diffhunk://#diff-d95cc32dc1d5463cb523f2e2aeb802007ef38688eb7e39c1ed59ac26a4afe49fR1-R151)

**Resource API Integration:**
* Exposed skills as resources via the RMCP resource API: implemented `list_resources`, `read_resource`, and `list_resource_templates` to allow agents to access skill files and manifests using URIs like `skill://<name>/SKILL.md`. [[1]](diffhunk://#diff-78dbbd4c5197711c07d46377b3b5e51438777d9b6003ca8a446e6e663783ae1fL2-R10) [[2]](diffhunk://#diff-78dbbd4c5197711c07d46377b3b5e51438777d9b6003ca8a446e6e663783ae1fR19) [[3]](diffhunk://#diff-78dbbd4c5197711c07d46377b3b5e51438777d9b6003ca8a446e6e663783ae1fR76-R173)
* Updated the server's capabilities and help text to advertise resource support and document the new skill resource URIs.

**Test Coverage and Tool Count:**
* Added comprehensive tests for skill parsing, manifest generation, URI handling, and all new tool endpoints, including edge cases (e.g., overwrite protection, unknown skills). [[1]](diffhunk://#diff-69cc0dd520474746cdc037124ddd1dd4ca54b6ad851a7c2e730cd413d4f150ddR1-R222) [[2]](diffhunk://#diff-d95cc32dc1d5463cb523f2e2aeb802007ef38688eb7e39c1ed59ac26a4afe49fR1-R151)
* Updated the expected tool count in the test suite to account for the new skill tools.

These changes lay the foundation for modular, discoverable, and easily distributable skill content within the MCP server, improving extensibility and user guidance.