### PR TITLE
Fix intermittent license check failures in e2e tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,16 @@ async fn run_cli_at_path(
         return parse_cli_output(retry_output);
     }
 
+    if is_license_check_failure(&stderr) {
+        tracing::warn!("License check failed, retrying after brief delay...");
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let retry_output = run_cli_process(cli_path, args, working_dir, false).await?;
+        if retry_output.status.success() {
+            return Ok(String::from_utf8_lossy(&retry_output.stdout).to_string());
+        }
+        return parse_cli_output(retry_output);
+    }
+
     parse_cli_output(output)
 }
 
@@ -777,6 +787,31 @@ mod tests {
     fn should_not_retry_for_other_no_such_file_error() {
         let stderr = "java.nio.file.NoSuchFileException: /tmp/other-file.log";
         assert!(!should_retry_after_telemetry_flush_error(stderr));
+    }
+
+    #[tokio::test]
+    async fn run_cli_at_path_retries_once_on_license_check_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("license-retry.marker");
+        let marker_path = marker.to_string_lossy().to_string();
+        let script = format!(
+            "if [ ! -f '{marker_path}' ]; then touch '{marker_path}'; >&2 echo 'License check failed: [401] The user must reauthorize.'; exit 1; fi; echo ok"
+        );
+
+        let output = run_cli_at_path(Path::new("/bin/sh"), &["-c", &script], None).await;
+        assert_eq!(output.unwrap().trim(), "ok");
+    }
+
+    #[tokio::test]
+    async fn run_cli_at_path_license_check_failure_persists_after_retry() {
+        let script =
+            ">&2 echo 'License check failed: [401] The user must reauthorize.'; exit 1";
+
+        let result = run_cli_at_path(Path::new("/bin/sh"), &["-c", script], None).await;
+        match result.unwrap_err() {
+            CliError::LicenseCheckFailed => {}
+            other => panic!("Expected LicenseCheckFailed, got: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/tests/e2e/mcp_client.rs
+++ b/tests/e2e/mcp_client.rs
@@ -118,13 +118,14 @@ impl MCPClient {
         params: Value,
         timeout: Duration,
     ) -> Result<Value, String> {
+        let id = next_msg_id();
         self.write_message(&json!({
             "jsonrpc": "2.0",
-            "id": next_msg_id(),
+            "id": id,
             "method": method,
             "params": params,
         }))?;
-        self.await_response(timeout)
+        self.await_response(id, timeout)
     }
 
     fn write_message(&mut self, message: &Value) -> Result<(), String> {
@@ -136,19 +137,45 @@ impl MCPClient {
         stdin.flush().map_err(|e| format!("Flush failed: {e}"))
     }
 
-    fn await_response(&self, timeout: Duration) -> Result<Value, String> {
+    fn await_response(&self, expected_id: u64, timeout: Duration) -> Result<Value, String> {
         let start = Instant::now();
+        let mut stashed: Vec<String> = Vec::new();
         loop {
-            if let Some(line) = self.responses.lock().unwrap().pop_front() {
-                return serde_json::from_str::<Value>(&line)
-                    .map_err(|e| format!("Invalid JSON: {e}"));
+            let line = self.responses.lock().unwrap().pop_front();
+            if let Some(line) = line {
+                match self.try_match_response(&line, expected_id) {
+                    Some(val) => {
+                        self.restore_stashed(stashed);
+                        return Ok(val);
+                    }
+                    None => stashed.push(line),
+                }
             }
             if start.elapsed() > timeout {
+                self.restore_stashed(stashed);
                 let tail: String = self.get_stderr().lines().rev().take(10)
                     .collect::<Vec<_>>().join("\n");
-                return Err(format!("Timeout waiting for response. Recent stderr:\n{tail}"));
+                return Err(format!("Timeout waiting for response (id={expected_id}). Recent stderr:\n{tail}"));
             }
             thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn try_match_response(&self, line: &str, expected_id: u64) -> Option<Value> {
+        let val = serde_json::from_str::<Value>(line).ok()?;
+        if val.get("id").and_then(|v| v.as_u64()) == Some(expected_id) {
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    fn restore_stashed(&self, stashed: Vec<String>) {
+        if !stashed.is_empty() {
+            let mut buf = self.responses.lock().unwrap();
+            for s in stashed.into_iter().rev() {
+                buf.push_front(s);
+            }
         }
     }
 


### PR DESCRIPTION
- Add retry with 500ms backoff for CLI license check failures, mitigating transient errors from parallel test runs hitting the license validation endpoint concurrently.

- Fix e2e MCPClient.await_response() to match JSON-RPC message IDs instead of returning the first available stdout line, preventing response mismatches from server notifications.