### PR TITLE
CS-11414: fix Docker path resolution on Windows

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -28,8 +28,10 @@ jobs:
   # =============================================================================
   # E2E Docker Tests - Linux
   # =============================================================================
-  # Note: Docker tests only run on Linux and Windows because:
+  # Note: Docker tests only run on Linux because:
   # - macOS GitHub runners don't have native Docker; Colima/VZ is unreliable
+  # - Windows GitHub runners only support Windows containers (no Linux images)
+  # Windows path translation is covered by unit tests in src/docker.rs
   e2e-docker-linux:
     needs: check-secrets
     if: needs.check-secrets.outputs.has-token == 'true'
@@ -49,37 +51,3 @@ jobs:
 
       - name: Run e2e tests (docker backend)
         run: CS_MCP_BACKEND=docker cargo test --test e2e --release -- --test-threads=4
-
-  # =============================================================================
-  # E2E Docker Tests - Windows
-  # =============================================================================
-  # Windows Docker tests verify path translation between Windows host paths
-  # (e.g. C:\Users\...) and Linux container paths (/mount/...).
-  # Docker Desktop on Windows runs Linux containers via WSL2.
-  e2e-docker-windows:
-    needs: check-secrets
-    if: needs.check-secrets.outputs.has-token == 'true'
-    runs-on: x64-windows-8core
-    name: E2E Docker (Windows)
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Verify Docker is available
-        shell: pwsh
-        run: docker info
-
-      - name: Build Docker image
-        shell: pwsh
-        run: docker build --build-arg VERSION=MCP-0.0.0-test -t codescene-mcp-test .
-
-      - name: Run e2e tests (docker backend)
-        shell: pwsh
-        run: |
-          $env:CS_MCP_BACKEND = "docker"
-          cargo test --test e2e --release -- --test-threads=4

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -70,11 +70,9 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Switch Docker to Linux containers
+      - name: Verify Docker is available
         shell: pwsh
-        run: |
-          & "C:\Program Files\Docker\Docker\DockerCli.exe" -SwitchLinuxEngine 2>$null
-          docker info
+        run: docker info
 
       - name: Build Docker image
         shell: pwsh

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -28,9 +28,8 @@ jobs:
   # =============================================================================
   # E2E Docker Tests - Linux
   # =============================================================================
-  # Note: Docker tests only run on Linux because:
+  # Note: Docker tests only run on Linux and Windows because:
   # - macOS GitHub runners don't have native Docker; Colima/VZ is unreliable
-  # - Linux Docker tests provide sufficient coverage for the Docker backend
   e2e-docker-linux:
     needs: check-secrets
     if: needs.check-secrets.outputs.has-token == 'true'
@@ -50,3 +49,39 @@ jobs:
 
       - name: Run e2e tests (docker backend)
         run: CS_MCP_BACKEND=docker cargo test --test e2e --release -- --test-threads=4
+
+  # =============================================================================
+  # E2E Docker Tests - Windows
+  # =============================================================================
+  # Windows Docker tests verify path translation between Windows host paths
+  # (e.g. C:\Users\...) and Linux container paths (/mount/...).
+  # Docker Desktop on Windows runs Linux containers via WSL2.
+  e2e-docker-windows:
+    needs: check-secrets
+    if: needs.check-secrets.outputs.has-token == 'true'
+    runs-on: x64-windows-8core
+    name: E2E Docker (Windows)
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Switch Docker to Linux containers
+        shell: pwsh
+        run: |
+          & "C:\Program Files\Docker\Docker\DockerCli.exe" -SwitchLinuxEngine 2>$null
+          docker info
+
+      - name: Build Docker image
+        shell: pwsh
+        run: docker build --build-arg VERSION=MCP-0.0.0-test -t codescene-mcp-test .
+
+      - name: Run e2e tests (docker backend)
+        shell: pwsh
+        run: |
+          $env:CS_MCP_BACKEND = "docker"
+          cargo test --test e2e --release -- --test-threads=4

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -16,12 +16,25 @@ impl NormalizedPath {
     fn from_str(raw: &str) -> Self {
         let forward = raw.replace('\\', "/");
         let bytes = forward.as_bytes();
+
+        // Standard Windows drive letter: "C:/Users/..." → "/Users/..."
         let has_drive = forward.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
         if has_drive {
-            Self(forward[2..].to_string())
-        } else {
-            Self(forward)
+            return Self(forward[2..].to_string());
         }
+
+        // MSYS / Git-Bash style: "/c/Users/..." → "/Users/..."
+        // Docker Desktop on Windows with Git Bash auto-converts paths
+        // to this format before passing them to the process.
+        let is_msys_drive = forward.len() >= 3
+            && bytes[0] == b'/'
+            && bytes[1].is_ascii_alphabetic()
+            && bytes[2] == b'/';
+        if is_msys_drive {
+            return Self(forward[2..].to_string());
+        }
+
+        Self(forward)
     }
 
     /// Strip `prefix` (case-insensitively) and return the relative tail.
@@ -137,6 +150,12 @@ mod tests {
     }
 
     #[test]
+    fn strip_msys_drive_prefix() {
+        assert_eq!(NormalizedPath::from_str("/c/Users/foo").0, "/Users/foo");
+        assert_eq!(NormalizedPath::from_str("/d/code/project").0, "/code/project");
+    }
+
+    #[test]
     fn no_drive_letter_unix_path() {
         assert_eq!(
             NormalizedPath::from_path(Path::new("/home/user/project")).0,
@@ -190,6 +209,41 @@ mod tests {
         let path = NormalizedPath::from_str("/other/path");
         let prefix = NormalizedPath::from_str("/Users/foo");
         assert_eq!(path.strip_prefix(&prefix), None);
+    }
+
+    #[test]
+    fn strip_prefix_msys_vs_windows_drive() {
+        // CS_MOUNT_PATH from cmd.exe, git_repository_path from Git Bash
+        let path = NormalizedPath::from_str("/c/Users/john/project/src/main.rs");
+        let prefix = NormalizedPath::from_str(r"C:\Users\john\project");
+        assert_eq!(path.strip_prefix(&prefix), Some("src/main.rs".to_string()));
+    }
+
+    #[test]
+    fn strip_prefix_windows_drive_vs_msys() {
+        // CS_MOUNT_PATH from Git Bash, git_repository_path from cmd.exe
+        let path = NormalizedPath::from_str(r"C:\Users\john\project\src\main.rs");
+        let prefix = NormalizedPath::from_str("/c/Users/john/project");
+        assert_eq!(path.strip_prefix(&prefix), Some("src/main.rs".to_string()));
+    }
+
+    #[test]
+    fn translate_to_container_with_msys_paths() {
+        let result = translate_to_container(
+            Path::new("/c/Users/john/project/src/main.rs"),
+            Some(Path::new("/c/Users/john/project")),
+        );
+        assert_eq!(result, "/mount/src/main.rs");
+    }
+
+    #[test]
+    fn translate_to_container_msys_mount_windows_path() {
+        // Mount set via Git Bash, path from Windows-native MCP client
+        let result = translate_to_container(
+            Path::new(r"C:\Users\john\project\src\main.rs"),
+            Some(Path::new("/c/Users/john/project")),
+        );
+        assert_eq!(result, "/mount/src/main.rs");
     }
 
     #[test]

--- a/src/tools/codescene_links.rs
+++ b/src/tools/codescene_links.rs
@@ -123,6 +123,7 @@ mod tests {
         let _g = config::lock_test_env();
         std::env::set_var("CS_ONPREM_URL", "http://my-instance.com");
         assert!(onprem_url().is_none(), "HTTP URLs should be blocked");
+        std::env::remove_var("CS_ONPREM_URL");
     }
 
     // ── analysis_base ───────────────────────────────────────

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -638,6 +638,27 @@ fn test_sigterm_after_full_handshake() {
     tests::shutdown_during_handshake::test_sigterm_after_full_handshake();
 }
 
+// --- Docker Path Translation ---
+#[test]
+fn test_docker_verify_finds_git_repo() {
+    tests::docker_path_translation::test_docker_verify_finds_git_repo();
+}
+
+#[test]
+fn test_docker_code_health_score() {
+    tests::docker_path_translation::test_docker_code_health_score();
+}
+
+#[test]
+fn test_docker_pre_commit_safeguard() {
+    tests::docker_path_translation::test_docker_pre_commit_safeguard();
+}
+
+#[test]
+fn test_docker_code_health_review() {
+    tests::docker_path_translation::test_docker_code_health_review();
+}
+
 // --- Platform Specific ---
 #[test]
 fn test_platform_absolute_paths() {

--- a/tests/e2e/tests/docker_path_translation.rs
+++ b/tests/e2e/tests/docker_path_translation.rs
@@ -1,0 +1,150 @@
+//! Docker path translation integration tests.
+//!
+//! Validates that the MCP server correctly translates host paths to container
+//! paths when running inside Docker. This is the exact scenario reported in
+//! CS-11414: Windows users running Docker get "not inside a git repository"
+//! errors because path translation fails for Windows-style paths.
+//!
+//! These tests only run under the Docker backend (`CS_MCP_BACKEND=docker`).
+//! On a Windows host, the host paths are `C:\Users\...` which must be
+//! correctly translated to `/mount/...` inside the Linux container.
+
+use super::*;
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+fn skip_unless_docker(reason: &str) {
+    if !is_docker() {
+        eprintln!("  SKIP: {reason} (only runs under Docker backend)");
+    }
+}
+
+/// Verify that the Docker path translation finds the git repository.
+/// This is the exact failure from CS-11414: `verify_installation` reports
+/// "[FAIL] Git Repository" when host paths aren't translated correctly.
+pub fn test_docker_verify_finds_git_repo() {
+    if !is_docker() {
+        return skip_unless_docker("Docker git repo detection");
+    }
+    let (command, env, repo_dir, _tmp) = setup();
+    let mut client = make_client(&command, &env, &repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let response = client
+        .call_tool(
+            "verify_installation",
+            json!({"git_repository_path": repo_dir.to_string_lossy()}),
+            TIMEOUT,
+        )
+        .expect("Tool call should succeed");
+
+    let result_text = extract_result_text(&response);
+    let lower = result_text.to_lowercase();
+
+    assert!(
+        lower.contains("[pass] git repository"),
+        "Git repository check should pass under Docker. \
+         If this fails, host path translation is broken. \
+         Full output: {result_text}"
+    );
+    assert!(
+        lower.contains("git root"),
+        "Should report the git root path: {result_text}"
+    );
+}
+
+/// Verify that `code_health_score` works with host paths translated through Docker.
+pub fn test_docker_code_health_score() {
+    if !is_docker() {
+        return skip_unless_docker("Docker code health score");
+    }
+    let (command, env, repo_dir, _tmp) = setup();
+    let mut client = make_client(&command, &env, &repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let test_file = repo_dir.join("src/utils/calculator.py");
+    let response = client
+        .call_tool(
+            "code_health_score",
+            json!({"file_path": test_file.to_string_lossy()}),
+            TIMEOUT,
+        )
+        .expect("Tool call should succeed");
+
+    let result_text = extract_result_text(&response);
+    let score = extract_code_health_score(&result_text);
+
+    assert!(
+        score.is_some(),
+        "Should return a valid Code Health score under Docker. \
+         If this fails, file path translation is broken. \
+         Full output: {result_text}"
+    );
+}
+
+/// Verify that `pre_commit_code_health_safeguard` works with Docker paths.
+/// This tool takes `git_repository_path` which must be translated.
+pub fn test_docker_pre_commit_safeguard() {
+    if !is_docker() {
+        return skip_unless_docker("Docker pre-commit safeguard");
+    }
+    let (command, env, repo_dir, _tmp) = setup();
+    let mut client = make_client(&command, &env, &repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let response = client
+        .call_tool(
+            "pre_commit_code_health_safeguard",
+            json!({"git_repository_path": repo_dir.to_string_lossy()}),
+            TIMEOUT,
+        )
+        .expect("Tool call should succeed");
+
+    let result_text = extract_result_text(&response);
+    let lower = result_text.to_lowercase();
+
+    assert!(
+        lower.contains("quality") || lower.contains("gate") || lower.contains("code health"),
+        "Should return quality gate info under Docker. \
+         If this fails, git_repository_path translation is broken. \
+         Full output: {result_text}"
+    );
+}
+
+/// Verify that `code_health_review` works with Docker paths.
+pub fn test_docker_code_health_review() {
+    if !is_docker() {
+        return skip_unless_docker("Docker code health review");
+    }
+    let (command, env, repo_dir, _tmp) = setup();
+    let mut client = make_client(&command, &env, &repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let test_file = repo_dir.join("src/services/order_processor.py");
+    let response = client
+        .call_tool(
+            "code_health_review",
+            json!({"file_path": test_file.to_string_lossy()}),
+            TIMEOUT,
+        )
+        .expect("Tool call should succeed");
+
+    let result_text = extract_result_text(&response);
+
+    assert!(
+        result_text.len() > 50,
+        "Review should return substantial content under Docker. \
+         Full output: {result_text}"
+    );
+
+    let lower = result_text.to_lowercase();
+    assert!(
+        lower.contains("code health") || lower.contains("complexity") || lower.contains("function"),
+        "Review should contain Code Health terms under Docker. \
+         Full output: {result_text}"
+    );
+}

--- a/tests/e2e/tests/mod.rs
+++ b/tests/e2e/tests/mod.rs
@@ -24,6 +24,7 @@ pub mod bundled_docs;
 pub mod business_case;
 pub mod cloudfront_headers;
 pub mod configure;
+pub mod docker_path_translation;
 pub mod enabled_tools;
 pub mod error_logging;
 pub mod git_subtree;


### PR DESCRIPTION
This pull request significantly improves support for Docker path translation on Windows, addressing issues where Windows-style paths were not being correctly mapped inside Docker containers. The changes enhance the normalization of file paths, add comprehensive unit and integration tests for various path scenarios, and update documentation and CI configurations to clarify platform coverage.

**Path translation improvements:**

* Enhanced the `NormalizedPath::from_str` method in `src/docker.rs` to correctly handle both standard Windows drive letter paths (e.g., `C:\Users\...`) and MSYS/Git Bash style paths (e.g., `/c/Users/...`), ensuring consistent normalization for Docker environments on Windows.
* Added new unit tests to `src/docker.rs` to verify normalization and prefix stripping for both Windows and MSYS-style paths, as well as translation logic for container paths. [[1]](diffhunk://#diff-4cf895b046f53b02266b843eb9440dec88b857e039a624a5310502e3dd7eb858R152-R157) [[2]](diffhunk://#diff-4cf895b046f53b02266b843eb9440dec88b857e039a624a5310502e3dd7eb858R214-R248)

**Integration and end-to-end testing:**

* Introduced a new integration test module, `docker_path_translation.rs`, which validates that the MCP server correctly translates host paths to container paths under Docker, covering scenarios such as finding the git repository, code health scoring, pre-commit safeguards, and code health reviews.
* Registered and invoked these new Docker path translation tests in the main E2E test suite (`tests/e2e/main.rs` and `tests/e2e/tests/mod.rs`). [[1]](diffhunk://#diff-0548e7fc7e05b403a2434d663fd9426feda8b45fd28897ad0e50db353797ef9cR641-R661) [[2]](diffhunk://#diff-c0fb3bfb2ec2777a3a0e8eb4cfd99f3bae19e08ac819f8bb3d4181ec3acf7617R27)

**Documentation and CI configuration:**

* Updated `.github/workflows/e2e-docker.yml` comments to clarify that Windows GitHub runners only support Windows containers and that Windows path translation is covered by unit tests, not by the Docker E2E workflow.

**Other test hygiene:**

* Ensured environment variables are properly cleaned up in `codescene_links.rs` tests to avoid side effects.