### PR TITLE
Update Claude Code plugin to 1.3.0

### DIFF
--- a/claude-code-plugin/.claude-plugin/plugin.json
+++ b/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codescene",
   "description": "CodeScene Code Health analysis \u2014 review, refactor, and safeguard code quality with AI-friendly tools.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "author": {
     "name": "CodeScene",
     "url": "https://codescene.com"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "codehealth-mcp",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "CodeScene's Code Health analysis as local AI-friendly tools.",
   "author": {
     "name": "CodeScene",


### PR DESCRIPTION
This PR updates the Claude Code plugin to version 1.3.0:
- Version strings in `manifest.json` and `plugin.json`
- Skills synced from `skills/`
- README skills table regenerated