### PR TITLE
docs: add brew trust step to Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Then open the `.mcpb` file with Claude Desktop to install the MCP server.
 
 ```bash
 brew tap codescene-oss/codescene-mcp-server https://github.com/codescene-oss/codescene-mcp-server
+brew trust codescene-oss/codescene-mcp-server
 brew install cs-mcp
 ```
 

--- a/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
@@ -31,7 +31,7 @@ Do not use this skill for configuring tokens, URLs, or other server options. Use
 
 1. Choose the installation method that fits the user environment:
    - `npx @codescene/codehealth-mcp` or `npm install -g @codescene/codehealth-mcp`
-   - `brew tap codescene-oss/codescene-mcp-server https://github.com/codescene-oss/codescene-mcp-server && brew install cs-mcp`
+   - `brew tap codescene-oss/codescene-mcp-server https://github.com/codescene-oss/codescene-mcp-server && brew trust codescene-oss/codescene-mcp-server && brew install cs-mcp`
    - Windows PowerShell installer
    - Manual binary download
    - Docker image

--- a/docs/homebrew-installation.md
+++ b/docs/homebrew-installation.md
@@ -13,9 +13,14 @@ You can install the CodeScene MCP Server using Homebrew on macOS and Linux.
 # Add the CodeScene tap
 brew tap codescene-oss/codescene-mcp-server https://github.com/codescene-oss/codescene-mcp-server
 
+# Trust the tap (required for Homebrew 5.1.4+)
+brew trust codescene-oss/codescene-mcp-server
+
 # Install CodeScene MCP Server
 brew install cs-mcp
 ```
+
+> **Note:** The `brew trust` step is required by Homebrew's [tap trust enforcement](https://github.com/Homebrew/brew/pull/22470). If your Homebrew version predates this feature, the `brew trust` command will fail harmlessly — you can safely ignore the error and proceed with `brew install`.
 
 ## Usage
 
@@ -148,6 +153,26 @@ q mcp add --name codescene-mcp --command cs-mcp
 For additional configuration — including CodeScene on-prem, custom SSL/TLS certificates, and more — see [Configuration Options](configuration-options.md).
 
 ## Troubleshooting
+
+### Untrusted tap error
+
+If you see an error like:
+
+```
+Error: Refusing to load formula codescene-oss/codescene-mcp-server/cs-mcp from untrusted tap codescene-oss/codescene-mcp-server.
+```
+
+Run the following to trust the tap:
+
+```bash
+brew trust codescene-oss/codescene-mcp-server
+```
+
+This is required by Homebrew's [tap trust enforcement](https://github.com/Homebrew/brew/pull/22470), which prevents loading formulas from third-party taps that haven't been explicitly trusted. You can also trust just the formula instead of the entire tap:
+
+```bash
+brew trust --formula codescene-oss/codescene-mcp-server/cs-mcp
+```
 
 ### Binary not found after installation
 

--- a/skills/installing-and-activating-codescene-mcp/SKILL.md
+++ b/skills/installing-and-activating-codescene-mcp/SKILL.md
@@ -31,7 +31,7 @@ Do not use this skill for configuring tokens, URLs, or other server options. Use
 
 1. Choose the installation method that fits the user environment:
    - `npx @codescene/codehealth-mcp` or `npm install -g @codescene/codehealth-mcp`
-   - `brew tap codescene-oss/codescene-mcp-server https://github.com/codescene-oss/codescene-mcp-server && brew install cs-mcp`
+   - `brew tap codescene-oss/codescene-mcp-server https://github.com/codescene-oss/codescene-mcp-server && brew trust codescene-oss/codescene-mcp-server && brew install cs-mcp`
    - Windows PowerShell installer
    - Manual binary download
    - Docker image


### PR DESCRIPTION
Homebrew merged tap trust enforcement (Homebrew/brew#22470) which requires third-party taps to be explicitly trusted before their formulas can be loaded. This is currently opt-in but will become the default in a future Homebrew release.

Add the brew trust step to all installation docs and a new troubleshooting section for users who hit the untrusted tap error.