### PR TITLE
Update Homebrew formula to 1.3.1

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.3.0"
+  version "1.3.1"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "d1d921d3f0c9641257debd7ddbb828a2b4db97c48be02ab3751dc0190202caab"
+      sha256 "c37963ccf7bb46c9c9de1f7ffc8945eeac64cf28efaa3bcfe2abd1f945468d9a"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "d13b5c9a64587bd8f9321a1dd570e55717ed5961819da91e4552c455d6e3ae9b"
+      sha256 "5e8ee225bcfa42f3cc5927e787ae5b737c59e0828bca33bd91f5285bf26ce036"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "6f3f797a5d04ca5ba265f100ca7e9275ab013f877dca1576bb20fa1e1681b199"
+      sha256 "4664653c3177b84dea1ba7ab450b5c28678d3c05e5bc7be7e3e07c6647cad39c"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "ae007a84376d92688988ac2a5ab23a71fdc3c255262eb379f19319e9146910de"
+      sha256 "3236f7da00eb0898e0d8cb5bcb77516bdfd0b7af4b15d03c5d64e1a043dbf14f"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.3.1.

## Checksums
- macOS ARM64: `c37963ccf7bb46c9c9de1f7ffc8945eeac64cf28efaa3bcfe2abd1f945468d9a`
- macOS AMD64: `5e8ee225bcfa42f3cc5927e787ae5b737c59e0828bca33bd91f5285bf26ce036`
- Linux ARM64: `4664653c3177b84dea1ba7ab450b5c28678d3c05e5bc7be7e3e07c6647cad39c`
- Linux AMD64: `3236f7da00eb0898e0d8cb5bcb77516bdfd0b7af4b15d03c5d64e1a043dbf14f`