### PR TITLE
Revert "CS-11372: Replace Java truststore with CS_CERTS passthrough"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
+dependencies = [
+ "crypto-common 0.2.1",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04097e08a47d9ad181c2e1f4a5fabc9ae06ce8839a333ba9a949bcb0d31fd2a3"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +209,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +237,15 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cbc"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab1412b9ae2463ede01f1e591412dfbcfeacecf40e8c4c3e0655814c19065c38"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -210,6 +272,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +303,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
+name = "cipher"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
+ "inout",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,10 +323,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+
+[[package]]
+name = "cms"
+version = "0.3.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758d5272932ff167e96ec9641a04d96ab1901cccc5ea9f47c15b4cbaa6f9ea53"
+dependencies = [
+ "const-oid 0.10.2",
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
+ "x509-cert",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -251,10 +359,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -294,6 +417,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cs-mcp"
 version = "1.0.0"
 dependencies = [
@@ -305,6 +437,7 @@ dependencies = [
  "gray_matter",
  "hex",
  "libc",
+ "p12-keystore",
  "rcgen",
  "regex",
  "reqwest",
@@ -314,7 +447,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tiny_http",
@@ -327,15 +460,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fee683dd898fbd052617b4514bc31f98bc32081a83b69ec46adef3b1ef4ae36f"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -399,7 +550,20 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -415,6 +579,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -438,13 +613,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "des"
+version = "0.9.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3214053e68a813b9c06ef61075c844f3a1cdeb307d8998ea8555c063caa52fa9"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -497,7 +693,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature",
 ]
 
@@ -510,7 +706,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -557,6 +753,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -723,8 +925,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -775,6 +987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +1039,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1031,6 +1261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,10 +1480,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "p12-keystore"
+version = "0.3.0-rc3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d971d169fedcb72cfb410cef5784542e136972b54ee8d14c9e46c2bf60d6b8bb"
+dependencies = [
+ "cbc",
+ "cms",
+ "der 0.8.0",
+ "des",
+ "hex",
+ "hmac",
+ "pkcs12",
+ "pkcs5",
+ "pkcs8 0.11.0-rc.11",
+ "rand 0.10.0",
+ "rc2",
+ "sha1",
+ "sha2 0.11.0",
+ "thiserror",
+ "x509-parser",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f24f3eb2f4471b1730d59e4b730b747939960a8c7eb0c33c5a9076f2d3dddea"
+dependencies = [
+ "digest 0.11.2",
+ "hmac",
+]
 
 [[package]]
 name = "pem"
@@ -1253,6 +1526,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1274,13 +1556,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs12"
+version = "0.2.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8059bd79345d1d1c125656025814704bab5cdd204b1cefd5fab59b0fdd7476d2"
+dependencies = [
+ "cms",
+ "const-oid 0.10.2",
+ "der 0.8.0",
+ "digest 0.11.2",
+ "spki 0.8.0-rc.4",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.8.0-rc.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a777c6e26664bc9504b3ce3f6133f8f20d9071f130a4f9fcbd3186959d8dd6"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "der 0.8.0",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.11.0",
+ "spki 0.8.0-rc.4",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1355,7 +1689,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1413,6 +1747,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1783,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rc2"
+version = "0.9.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe878524f5ecf745fcb78bd7860c1932f7abddbe1565d3863ce5f0b233fa7"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1698,6 +2058,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
+dependencies = [
+ "cfg-if",
+ "cipher",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +2091,18 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn",
+]
+
+[[package]]
+name = "scrypt"
+version = "0.12.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e03ed5b54ed5fcc8e016cd94301416bc2c01c05c87a6742b97468337c8804598"
+dependencies = [
+ "cfg-if",
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1796,14 +2178,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1875,7 +2279,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]
@@ -2221,6 +2635,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.1",
+ "ctutils",
+]
 
 [[package]]
 name = "untrusted"
@@ -2726,6 +3150,17 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x509-cert"
+version = "0.3.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e21aad3a769f25f3d2d0cbf30ea8b50a1d602354bd6ab687fad112821608ba6"
+dependencies = [
+ "const-oid 0.10.2",
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
+]
 
 [[package]]
 name = "x509-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 # Cryptography (SHA-256 hashing)
 sha2 = "0.10"
 
+# Pure Rust truststore generation from PEM certificates
+p12-keystore = "0.3.0-rc3"
+rustls-pemfile = "2.2.0"
+
 # File system paths
 dirs = "6"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,9 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Output;
 
+use p12_keystore::{Certificate as P12Certificate, KeyStore as P12KeyStore, KeyStoreEntry};
+use sha2::{Digest, Sha256};
+
 use crate::environment;
 use crate::errors::CliError;
 
@@ -25,6 +28,7 @@ const CLI_ZIP: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/cs-cli.zip"));
 const CLI_BINARY_NAME: &str = if cfg!(windows) { "cs.exe" } else { "cs" };
 
 const DOCKER_CLI_PATH: &str = "/home/mcp/.local/bin/cs";
+const SSL_TRUSTSTORE_PASSWORD: &str = "changeit";
 
 /// Resolve the path to the `cs` CLI binary.
 ///
@@ -99,6 +103,7 @@ async fn run_cli_process(
     disable_tracking: bool,
 ) -> Result<Output, CliError> {
     let mut cmd = tokio::process::Command::new(cli_path);
+    let effective_args = with_ssl_cli_args_if_needed(cli_path, args);
 
     // Scrub sensitive env vars (tokens) from the inherited environment so
     // child processes that don't need them can't read them from /proc or
@@ -108,7 +113,7 @@ async fn run_cli_process(
         cmd.env_remove(var);
     }
 
-    cmd.args(args)
+    cmd.args(&effective_args)
         .env("CS_CONTEXT", "mcp-server")
         .env("CS_DISABLE_VERSION_CHECK", "1");
 
@@ -127,14 +132,6 @@ async fn run_cli_process(
         cmd.env("CS_ONPREM_URL", url);
     }
 
-    // Pass custom CA certificates to the CLI via its native CS_CERTS
-    // mechanism. The CLI appends these to its trust store, preserving
-    // system CA trust (unlike the Java -D truststore approach which
-    // replaces the default trust store entirely).
-    if let Some(ca_path) = selected_ca_bundle_path_from_env() {
-        cmd.env("CS_CERTS", ca_path);
-    }
-
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
     }
@@ -144,6 +141,45 @@ async fn run_cli_process(
 
 fn should_retry_after_telemetry_flush_error(stderr: &str) -> bool {
     stderr.contains("NoSuchFileException") && stderr.contains("codescene-cli.log.jsonl")
+}
+
+fn with_ssl_cli_args_if_needed(cli_path: &Path, args: &[&str]) -> Vec<String> {
+    let mut effective_args = Vec::new();
+
+    if is_cs_cli_binary(cli_path) {
+        effective_args.extend(ssl_cli_args_from_env());
+    }
+
+    effective_args.extend(args.iter().map(|a| a.to_string()));
+    effective_args
+}
+
+fn is_cs_cli_binary(cli_path: &Path) -> bool {
+    let Some(name) = cli_path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+
+    let lower = name.to_ascii_lowercase();
+    lower == "cs" || lower == "cs.exe"
+}
+
+fn ssl_cli_args_from_env() -> Vec<String> {
+    let Some(ca_bundle_path) = selected_ca_bundle_path_from_env() else {
+        return Vec::new();
+    };
+
+    let Some(truststore_path) = create_or_get_truststore_from_pem(&ca_bundle_path) else {
+        return Vec::new();
+    };
+
+    vec![
+        format!(
+            "-Djavax.net.ssl.trustStore={}",
+            truststore_path.to_string_lossy()
+        ),
+        "-Djavax.net.ssl.trustStoreType=PKCS12".to_string(),
+        format!("-Djavax.net.ssl.trustStorePassword={SSL_TRUSTSTORE_PASSWORD}"),
+    ]
 }
 
 fn selected_ca_bundle_path_from_env() -> Option<PathBuf> {
@@ -182,6 +218,172 @@ fn selected_ca_bundle_path_from_env() -> Option<PathBuf> {
     }
 
     result.map(|(_, p)| p)
+}
+
+fn create_or_get_truststore_from_pem(ca_bundle_path: &Path) -> Option<PathBuf> {
+    let pem_data = std::fs::read(ca_bundle_path).ok()?;
+    let truststore_path = truststore_path_for_pem(&pem_data);
+    if truststore_path.exists() {
+        if is_owned_by_current_user(&truststore_path) {
+            return Some(truststore_path);
+        }
+        // Pre-existing file not owned by us — refuse to use it, try to recreate
+        let _ = std::fs::remove_file(&truststore_path);
+    }
+
+    if write_pkcs12_truststore_from_pem(&pem_data, &truststore_path) {
+        return Some(truststore_path);
+    }
+
+    None
+}
+
+/// On Unix, check that the file is owned by the current user and has
+/// restrictive permissions (not world-writable).
+/// On non-Unix, always returns true (no ownership check available).
+fn is_owned_by_current_user(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let file_meta = match std::fs::metadata(path) {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+        // Compare file owner against the owner of our cache directory
+        let cache_dir = truststore_cache_dir();
+        let dir_meta = match std::fs::metadata(&cache_dir) {
+            Ok(m) => m,
+            Err(_) => return false,
+        };
+        if file_meta.uid() != dir_meta.uid() {
+            return false;
+        }
+        // Reject world-writable files
+        let mode = file_meta.mode();
+        if mode & 0o002 != 0 {
+            return false;
+        }
+        true
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        true
+    }
+}
+
+fn truststore_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("codehealth-mcp")
+        .join("truststores")
+}
+
+fn truststore_path_for_pem(pem_data: &[u8]) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(pem_data);
+    let digest = hasher.finalize();
+    let digest_hex = format!("{:x}", digest);
+    let short_hash = &digest_hex[..16];
+    truststore_cache_dir().join(format!("cs-mcp-truststore-{short_hash}.p12"))
+}
+
+fn write_pkcs12_truststore_from_pem(pem_data: &[u8], truststore_path: &Path) -> bool {
+    let Some(()) = ensure_parent_dir(truststore_path) else {
+        return false;
+    };
+    restrict_dir_permissions(truststore_path.parent().unwrap());
+    let Some(pkcs12) = build_pkcs12_truststore_bytes(pem_data) else {
+        return false;
+    };
+    atomic_write_with_restricted_permissions(truststore_path, &pkcs12)
+}
+
+/// Write data to a temp file in the same directory, set 0600 permissions, then
+/// atomically rename into place.  This avoids TOCTOU races where an attacker
+/// could swap in a malicious truststore between creation and use.
+fn atomic_write_with_restricted_permissions(target: &Path, data: &[u8]) -> bool {
+    let parent = match target.parent() {
+        Some(p) => p,
+        None => return false,
+    };
+
+    // Write to a temp file in the same directory (same filesystem for rename)
+    let tmp_path = parent.join(format!(".tmp-{}-{:?}", std::process::id(), std::thread::current().id()));
+    if std::fs::write(&tmp_path, data).is_err() {
+        return false;
+    }
+
+    // Restrict permissions before rename so the file is never world-readable
+    restrict_file_permissions(&tmp_path);
+
+    // Atomic rename
+    if std::fs::rename(&tmp_path, target).is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        return false;
+    }
+
+    true
+}
+
+/// Set file permissions to 0600 (owner read/write only) on Unix.
+fn restrict_file_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+/// Set directory permissions to 0700 (owner only) on Unix.
+fn restrict_dir_permissions(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+fn ensure_parent_dir(path: &Path) -> Option<()> {
+    let parent = path.parent()?;
+    std::fs::create_dir_all(parent).ok()
+}
+
+fn build_pkcs12_truststore_bytes(pem_data: &[u8]) -> Option<Vec<u8>> {
+    let certs = parse_pem_certificates(pem_data)?;
+    if certs.is_empty() {
+        return None;
+    }
+
+    let mut keystore = P12KeyStore::new();
+    for (idx, cert) in certs.into_iter().enumerate() {
+        keystore.add_entry(&format!("ca-{idx}"), KeyStoreEntry::Certificate(cert));
+    }
+
+    keystore.writer(SSL_TRUSTSTORE_PASSWORD).write().ok()
+}
+
+fn parse_pem_certificates(pem_data: &[u8]) -> Option<Vec<P12Certificate>> {
+    let mut reader = std::io::BufReader::new(pem_data);
+    let certs = rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    if certs.is_empty() {
+        return None;
+    }
+
+    certs
+        .iter()
+        .map(|cert_der| P12Certificate::from_der(cert_der.as_ref()).ok())
+        .collect()
 }
 
 fn is_license_check_failure(stderr: &str) -> bool {
@@ -347,6 +549,10 @@ mod tests {
     use std::os::windows::process::ExitStatusExt;
     use std::process::ExitStatus;
 
+    /// Serialize tests that touch the shared truststore cache directory
+    /// to prevent parallel filesystem races on the same hash-derived path.
+    static TRUSTSTORE_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// Create a temp directory containing a `.git` dir and an optional subdirectory.
     /// Returns `(tempdir_handle, repo_root_path)`.
     fn make_git_repo(subdir: Option<&str>) -> (tempfile::TempDir, PathBuf) {
@@ -421,6 +627,14 @@ mod tests {
     }
 
     #[test]
+    fn is_cs_cli_binary_detects_cs_names() {
+        assert!(is_cs_cli_binary(Path::new("/tmp/cs")));
+        assert!(is_cs_cli_binary(Path::new("C:/tools/cs.exe")));
+        assert!(is_cs_cli_binary(Path::new("cs")));
+        assert!(!is_cs_cli_binary(Path::new("/bin/sh")));
+    }
+
+    #[test]
     fn selected_ca_bundle_prefers_requests_ca_bundle() {
         let requests = tempfile::NamedTempFile::new().unwrap();
         let ssl_cert_file = tempfile::NamedTempFile::new().unwrap();
@@ -450,6 +664,240 @@ mod tests {
             &[("REQUESTS_CA_BUNDLE", Some("/nonexistent/ca-bundle.pem")), ("SSL_CERT_FILE", Some(r)), ("CURL_CA_BUNDLE", None)],
             || assert_eq!(selected_ca_bundle_path_from_env().unwrap(), real_file.path()),
         );
+    }
+
+    #[test]
+    fn ssl_cli_args_use_existing_truststore_file() {
+        let _lock = config::lock_test_env();
+        let mut pem = tempfile::NamedTempFile::new().unwrap();
+        let pem_contents = format!(
+            "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----\n",
+            pem.path().display()
+        );
+        use std::io::Write;
+        pem.write_all(pem_contents.as_bytes()).unwrap();
+
+        std::env::set_var("REQUESTS_CA_BUNDLE", pem.path());
+        std::env::remove_var("SSL_CERT_FILE");
+        std::env::remove_var("CURL_CA_BUNDLE");
+
+        let truststore = truststore_path_for_pem(pem_contents.as_bytes());
+        std::fs::write(&truststore, b"dummy").unwrap();
+
+        let args = ssl_cli_args_from_env();
+        assert_eq!(args.len(), 3);
+        assert!(args[0].contains("-Djavax.net.ssl.trustStore="));
+        assert!(args[1].contains("-Djavax.net.ssl.trustStoreType=PKCS12"));
+        assert!(args[2].contains("-Djavax.net.ssl.trustStorePassword=changeit"));
+        assert!(args[0].contains(truststore.to_string_lossy().as_ref()));
+
+        std::fs::remove_file(&truststore).ok();
+        std::env::remove_var("REQUESTS_CA_BUNDLE");
+    }
+
+    #[test]
+    fn is_cs_cli_binary_returns_false_when_no_file_name() {
+        assert!(!is_cs_cli_binary(Path::new("/")));
+    }
+
+    #[test]
+    fn with_ssl_cli_args_only_applies_to_cs_binary() {
+        let _lock = config::lock_test_env();
+        std::env::remove_var("REQUESTS_CA_BUNDLE");
+        std::env::remove_var("SSL_CERT_FILE");
+        std::env::remove_var("CURL_CA_BUNDLE");
+
+        let args = with_ssl_cli_args_if_needed(Path::new("/bin/sh"), &["-c", "echo ok"]);
+        assert_eq!(args, vec!["-c".to_string(), "echo ok".to_string()]);
+
+        let cs_args = with_ssl_cli_args_if_needed(Path::new("/tmp/cs"), &["review"]);
+        assert_eq!(cs_args, vec!["review".to_string()]);
+    }
+
+    #[test]
+    fn ssl_cli_args_from_env_returns_empty_without_ca_env_vars() {
+        let _lock = config::lock_test_env();
+        std::env::remove_var("REQUESTS_CA_BUNDLE");
+        std::env::remove_var("SSL_CERT_FILE");
+        std::env::remove_var("CURL_CA_BUNDLE");
+
+        assert!(ssl_cli_args_from_env().is_empty());
+    }
+
+    #[test]
+    fn ssl_cli_args_from_env_returns_empty_when_truststore_creation_fails() {
+        let _lock = config::lock_test_env();
+        let pem = tempfile::NamedTempFile::new().unwrap();
+        let pem_data = b"not-a-valid-certificate";
+        std::fs::write(pem.path(), pem_data).unwrap();
+
+        let truststore = truststore_path_for_pem(pem_data);
+        std::fs::remove_file(&truststore).ok();
+
+        std::env::set_var("REQUESTS_CA_BUNDLE", pem.path());
+        std::env::remove_var("SSL_CERT_FILE");
+        std::env::remove_var("CURL_CA_BUNDLE");
+
+        assert!(ssl_cli_args_from_env().is_empty());
+
+        std::env::remove_var("REQUESTS_CA_BUNDLE");
+    }
+
+    #[test]
+    fn create_or_get_truststore_from_pem_returns_none_on_invalid_input() {
+        let pem = tempfile::NamedTempFile::new().unwrap();
+        let pem_data = b"invalid";
+        std::fs::write(pem.path(), pem_data).unwrap();
+
+        let truststore = truststore_path_for_pem(pem_data);
+        std::fs::remove_file(&truststore).ok();
+
+        let result = create_or_get_truststore_from_pem(pem.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn create_or_get_truststore_from_pem_creates_pkcs12_truststore() {
+        let _lock = TRUSTSTORE_TEST_MUTEX.lock().unwrap();
+        let pem = tempfile::NamedTempFile::new().unwrap();
+        let cert_pem = TEST_CA_CERT_PEM.as_bytes();
+        std::fs::write(pem.path(), cert_pem).unwrap();
+
+        let truststore = truststore_path_for_pem(cert_pem);
+        std::fs::remove_file(&truststore).ok();
+
+        let result = create_or_get_truststore_from_pem(pem.path());
+        assert!(result.is_some(), "expected truststore creation to succeed");
+        let created = result.unwrap();
+        assert!(created.exists());
+
+        std::fs::remove_file(created).ok();
+    }
+
+    #[test]
+    fn is_owned_by_current_user_returns_true_for_own_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.p12");
+        std::fs::write(&file, b"data").unwrap();
+        // Ensure cache dir exists so uid comparison works
+        let cache = truststore_cache_dir();
+        std::fs::create_dir_all(&cache).unwrap();
+        assert!(is_owned_by_current_user(&file));
+    }
+
+    #[test]
+    fn is_owned_by_current_user_returns_false_for_nonexistent_file() {
+        assert!(!is_owned_by_current_user(Path::new("/nonexistent/file.p12")));
+    }
+
+    #[test]
+    fn is_owned_by_current_user_rejects_world_writable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("world-writable.p12");
+        std::fs::write(&file, b"data").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o666)).unwrap();
+        // Ensure cache dir exists
+        let cache = truststore_cache_dir();
+        std::fs::create_dir_all(&cache).unwrap();
+        assert!(!is_owned_by_current_user(&file));
+    }
+
+    #[test]
+    fn is_owned_by_current_user_returns_false_when_cache_dir_missing() {
+        // Point to a file whose "cache dir" doesn't exist by testing with
+        // a path that won't match the real cache dir uid. We can test the
+        // Err branch by ensuring the cache dir metadata call fails.
+        // This is hard to test without mocking, so we test via the
+        // nonexistent file path which hits line 207.
+        assert!(!is_owned_by_current_user(Path::new("/no/such/path")));
+    }
+
+    #[test]
+    fn create_or_get_truststore_rejects_world_writable_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let _lock = TRUSTSTORE_TEST_MUTEX.lock().unwrap();
+        let pem = tempfile::NamedTempFile::new().unwrap();
+        let cert_pem = TEST_CA_CERT_PEM.as_bytes();
+        std::fs::write(pem.path(), cert_pem).unwrap();
+
+        let truststore = truststore_path_for_pem(cert_pem);
+        std::fs::create_dir_all(truststore.parent().unwrap()).unwrap();
+        // Pre-create a world-writable file
+        std::fs::write(&truststore, b"malicious").unwrap();
+        std::fs::set_permissions(&truststore, std::fs::Permissions::from_mode(0o666)).unwrap();
+
+        let result = create_or_get_truststore_from_pem(pem.path());
+        // Should recreate with proper permissions, not return the tainted file
+        assert!(result.is_some());
+        let created = result.unwrap();
+        let mode = std::fs::metadata(&created).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600, "truststore should be 0600");
+        // Content should not be "malicious"
+        let content = std::fs::read(&created).unwrap();
+        assert_ne!(content, b"malicious");
+
+        std::fs::remove_file(created).ok();
+    }
+
+    #[test]
+    fn atomic_write_returns_false_for_path_without_parent() {
+        // A bare filename has no parent directory
+        assert!(!atomic_write_with_restricted_permissions(
+            Path::new(""),
+            b"data"
+        ));
+    }
+
+    #[test]
+    fn atomic_write_returns_false_when_dir_not_writable() {
+        // Write to a nonexistent directory
+        let target = Path::new("/nonexistent/dir/file.p12");
+        assert!(!atomic_write_with_restricted_permissions(target, b"data"));
+    }
+
+    #[test]
+    fn atomic_write_sets_restricted_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("truststore.p12");
+        assert!(atomic_write_with_restricted_permissions(&target, b"test"));
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    #[test]
+    fn write_pkcs12_truststore_from_pem_returns_false_when_parent_is_not_directory() {
+        let parent_file = tempfile::NamedTempFile::new().unwrap();
+        let cert = TEST_CA_CERT_PEM.as_bytes();
+
+        let impossible_truststore = parent_file.path().join("truststore.p12");
+        let ok = write_pkcs12_truststore_from_pem(cert, &impossible_truststore);
+        assert!(!ok);
+    }
+
+    #[test]
+    fn ensure_parent_dir_returns_none_for_root_path() {
+        assert!(ensure_parent_dir(Path::new("/")).is_none());
+    }
+
+    #[test]
+    fn parse_pem_certificates_returns_some_for_valid_pem() {
+        let certs = parse_pem_certificates(TEST_CA_CERT_PEM.as_bytes());
+        assert!(certs.is_some());
+        assert_eq!(certs.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn parse_pem_certificates_returns_none_for_invalid_pem() {
+        let certs = parse_pem_certificates(b"not-a-pem");
+        assert!(certs.is_none());
+    }
+
+    #[test]
+    fn build_pkcs12_truststore_bytes_returns_none_for_invalid_pem() {
+        let bytes = build_pkcs12_truststore_bytes(b"invalid");
+        assert!(bytes.is_none());
     }
 
     #[test]
@@ -711,6 +1159,28 @@ mod tests {
     fn open_zip(data: &[u8]) -> zip::ZipArchive<std::io::Cursor<&[u8]>> {
         zip::ZipArchive::new(std::io::Cursor::new(data)).unwrap()
     }
+
+    const TEST_CA_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----
+MIIDPzCCAiegAwIBAgIUdGj465l77xx7Je8KqOESIqx9zXYwDQYJKoZIhvcNAQEL
+BQAwTzELMAkGA1UEBhMCVVMxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx
+EDAOBgNVBAoMB1Rlc3QgQ0ExEDAOBgNVBAMMB1Rlc3QgQ0EwHhcNMjYwMTE2MDky
+OTQ5WhcNMjcwMTE2MDkyOTQ5WjBPMQswCQYDVQQGEwJVUzENMAsGA1UECAwEVGVz
+dDENMAsGA1UEBwwEVGVzdDEQMA4GA1UECgwHVGVzdCBDQTEQMA4GA1UEAwwHVGVz
+dCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMqoClSXXim/fiI9
+Lc3X/4D4rHK6cWAnKVPA+CetSJiGrMrfeJZMSTWUv19M8aKlmbZsQxN4X4neycWE
+UxH9y3XaqV9grmGvutTgw98t6fhawevGrjmcA+ygQ5S37reRQOHtc9ob51b8b9Rr
+nyE8qIU2dkZ115VpFN+/woG2LG23iGj2dJ3AaZc/R8X0UQu5tQCDwTOeO/zMWPGG
+xjzDpnFs4u7IAwPECEgEuxHH8PHapUoc0d+Aq/wBKM015qdohoaydrztzXp6DKJ5
+RBv/cn+lTpFdvJQS0CceIo+hOUa46ONq63VM3SQhT7enOWToONBxrZpof18bITFd
+2h4XxoMCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOC
+AQEAHDWTjJILOtrCBRFksVyvniUGFR8ioz2cE4R8xcKAFxNOPKLuxwm+ilbUBX3A
+8VOCJjR6IimsLMhAUEi5FGDiVVhOwIp1+pULEigTG7r72yOCr2xnw8NrX9UbJNnx
+rlyCjEN9URBpriiGGegixH6AoLVW0SjEsJ7CgfqmfWzKU+nsPIunvePtFhSw5jHC
+mHwYTxYcxYW33TK9qQxs119A9+qG5Z+cJlDtYrfHirHwPZQeuQ25jhKE5FUUiuiq
+iblIIstcPF4n6wQ0ieNajmj5nHXQEypkek8D/ANbwwhlVQ3u/hldcAyj4qD7G5oJ
+sC0Nc9QdNQt5Tos5Je5S7CWL0w==
+-----END CERTIFICATE-----
+";
 
     #[test]
     fn extract_cli_binary_extracts_matching_entry() {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -919,20 +919,20 @@ fn test_skill_sync_tool() {
     tests::skill_resources::test_sync_skills_tool();
 }
 
-// --- SSL CLI Certificate Passthrough ---
+// --- SSL CLI Truststore ---
 #[test]
-fn test_ssl_cs_certs_passed_to_cli() {
-    tests::ssl_cli_truststore::test_cs_certs_passed_to_cli();
+fn test_ssl_truststore_args_injected() {
+    tests::ssl_cli_truststore::test_truststore_args_are_injected();
 }
 
 #[test]
-fn test_ssl_cs_certs_missing_without_ca_bundle() {
-    tests::ssl_cli_truststore::test_cs_certs_missing_without_ca_bundle();
+fn test_ssl_truststore_args_missing_without_cert() {
+    tests::ssl_cli_truststore::test_truststore_args_missing_without_cert();
 }
 
 #[test]
-fn test_ssl_cs_certs_not_set_when_ca_bundle_path_invalid() {
-    tests::ssl_cli_truststore::test_cs_certs_not_set_when_ca_bundle_path_invalid();
+fn test_ssl_truststore_args_not_injected_when_ca_bundle_path_invalid() {
+    tests::ssl_cli_truststore::test_truststore_args_not_injected_when_ca_bundle_path_invalid();
 }
 
 // --- SSL API CA Bundle ---

--- a/tests/e2e/tests/ssl_cli_truststore.rs
+++ b/tests/e2e/tests/ssl_cli_truststore.rs
@@ -1,12 +1,11 @@
-//! SSL certificate CLI integration tests.
+//! SSL truststore CLI integration tests.
 //!
-//! Validates that the MCP server passes custom CA certificates to the CLI
-//! via the `CS_CERTS` environment variable:
-//! - When `REQUESTS_CA_BUNDLE` is set, `CS_CERTS` is forwarded to the CLI.
-//! - When `REQUESTS_CA_BUNDLE` is missing, `CS_CERTS` is not set.
+//! Validates the full MCP -> embedded CLI argument path for SSL:
+//! - When `REQUESTS_CA_BUNDLE` is set, MCP injects Java truststore args.
+//! - When `REQUESTS_CA_BUNDLE` is missing, truststore args are not injected.
 //!
 //! Uses a fake CLI binary compiled from Rust source at runtime that checks
-//! whether `CS_CERTS` is present and points to a valid file.
+//! whether `-Djavax.net.ssl.trustStore=...` is present and valid.
 
 use super::*;
 use std::process::Command;
@@ -38,8 +37,17 @@ use std::process;
 
 fn main() {
     let mut cmd = String::new();
+    let mut has_truststore = false;
 
     for arg in env::args().skip(1) {
+        if let Some(ts) = arg.strip_prefix("-Djavax.net.ssl.trustStore=") {
+            if !Path::new(ts).is_file() {
+                eprintln!("truststore file missing: {ts}");
+                process::exit(21);
+            }
+            has_truststore = true;
+            continue;
+        }
         if arg.starts_with("-D") {
             continue;
         }
@@ -48,19 +56,10 @@ fn main() {
         }
     }
 
-    let require = env::var("REQUIRE_CS_CERTS").unwrap_or_else(|_| "0".to_string()) == "1";
-    if require {
-        match env::var("CS_CERTS") {
-            Ok(path) if Path::new(&path).is_file() => {}
-            Ok(path) => {
-                eprintln!("CS_CERTS file missing: {path}");
-                process::exit(21);
-            }
-            Err(_) => {
-                eprintln!("CS_CERTS not set");
-                process::exit(22);
-            }
-        }
+    let require = env::var("REQUIRE_TRUSTSTORE").unwrap_or_else(|_| "0".to_string()) == "1";
+    if require && !has_truststore {
+        eprintln!("missing truststore arg");
+        process::exit(22);
     }
 
     match cmd.as_str() {
@@ -161,7 +160,7 @@ fn local_setup() -> (
         .chain([
             ("CS_ACCESS_TOKEN".to_string(), "test-token".to_string()),
             ("CS_CLI_PATH".to_string(), fake_cli.to_string_lossy().to_string()),
-            ("REQUIRE_CS_CERTS".to_string(), "1".to_string()),
+            ("REQUIRE_TRUSTSTORE".to_string(), "1".to_string()),
             ("CS_DISABLE_VERSION_CHECK".to_string(), "1".to_string()),
             ("CS_DISABLE_TRACKING".to_string(), "1".to_string()),
         ])
@@ -175,9 +174,9 @@ fn local_setup() -> (
 // Tests
 // ---------------------------------------------------------------------------
 
-/// When `REQUESTS_CA_BUNDLE` points to a valid cert, the MCP server passes
-/// `CS_CERTS` to the CLI and the fake CLI succeeds with a score.
-pub fn test_cs_certs_passed_to_cli() {
+/// When `REQUESTS_CA_BUNDLE` points to a valid cert, the MCP server injects
+/// truststore args and the fake CLI succeeds with a score.
+pub fn test_truststore_args_are_injected() {
     if is_docker() { return skip_if_docker("fake CLI binary not available in container"); }
     let (command, env, repo_dir, cert_path, _tmp) = local_setup();
 
@@ -197,9 +196,9 @@ pub fn test_cs_certs_passed_to_cli() {
     );
 }
 
-/// Without `REQUESTS_CA_BUNDLE`, `CS_CERTS` is not set and the fake CLI
-/// (with `REQUIRE_CS_CERTS=1`) exits with an error.
-pub fn test_cs_certs_missing_without_ca_bundle() {
+/// Without `REQUESTS_CA_BUNDLE`, no truststore args are injected and the
+/// fake CLI (with `REQUIRE_TRUSTSTORE=1`) exits with an error.
+pub fn test_truststore_args_missing_without_cert() {
     if is_docker() { return skip_if_docker("fake CLI binary not available in container"); }
     let (command, env, repo_dir, _cert_path, _tmp) = local_setup();
 
@@ -212,17 +211,17 @@ pub fn test_cs_certs_missing_without_ca_bundle() {
 
     let result = call_score_tool(&command, &env, &repo_dir);
     assert!(
-        result.to_lowercase().contains("cs_certs not set"),
-        "Should report CS_CERTS not set, got: {result}"
+        result.to_lowercase().contains("missing truststore arg"),
+        "Should report missing truststore arg, got: {result}"
     );
 }
 
 /// When `REQUESTS_CA_BUNDLE` points to a non-existent file, the MCP server
-/// should NOT pass `CS_CERTS` to the CLI. This simulates a common Windows
+/// should NOT inject truststore args to the CLI. This simulates a common Windows
 /// misconfiguration where backslashes in JSON config are not properly escaped
 /// (e.g. `C:\Users\cert.pem` instead of `C:\\Users\\cert.pem`), causing the
 /// path to be mangled and the file to not be found.
-pub fn test_cs_certs_not_set_when_ca_bundle_path_invalid() {
+pub fn test_truststore_args_not_injected_when_ca_bundle_path_invalid() {
     if is_docker() { return skip_if_docker("fake CLI binary not available in container"); }
     let (command, env, repo_dir, _cert_path, _tmp) = local_setup();
 
@@ -239,7 +238,7 @@ pub fn test_cs_certs_not_set_when_ca_bundle_path_invalid() {
 
     let result = call_score_tool(&command, &env, &repo_dir);
     assert!(
-        result.to_lowercase().contains("cs_certs not set"),
-        "When REQUESTS_CA_BUNDLE points to a non-existent file, CS_CERTS should not be set. Got: {result}"
+        result.to_lowercase().contains("missing truststore arg"),
+        "When REQUESTS_CA_BUNDLE points to a non-existent file, truststore args should not be injected. Got: {result}"
     );
 }


### PR DESCRIPTION
This reverts commit 0f1f2f22939cbe873645080645c87d0605483958.

Customers report problems with the CS_CERTS passthrough approach. Restore the Java truststore generation from PEM certificates, which generates a PKCS12 truststore and passes it via -Djavax.net.ssl.* JVM args.

Also updates the e2e test added in f43648b to match truststore behavior (check for missing truststore arg instead of CS_CERTS).