### PR TITLE
Update Homebrew formula to 1.3.4

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.3.3"
+  version "1.3.4"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "41e4e0be8c743c9e1c1aa25795a02f418bbc8b458c8fe73cc6dee787c13326e1"
+      sha256 "aed4331a2011abee9aef7b4ef6b44de7cb91ae165a20363344e2f4d838ff6ca6"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "41362e73e1962c5e2f63494c470dcf093ad207986caed95927eded8f3e0e9882"
+      sha256 "923bf9eed406b29f50a6fbc20c9d78251cc2db07db68303c106410d4dd87a29a"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "e76a721fb1c055e631219f90ec2e2a7f90adc27e42eaeac83dcf4905d8fb84d3"
+      sha256 "d271755cf8192058fab59b179d8eecc0f97de6479a1e26c7b02d33404fcce043"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "82d57c41af46a9c3cb90ad3670d563eb8dbd8567ce0aa34d1b091cbd3de5b4a6"
+      sha256 "33923f35193c82efbab009e92a3ead25c9067379f9d50d4afce337428b35f631"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.3.4.

## Checksums
- macOS ARM64: `aed4331a2011abee9aef7b4ef6b44de7cb91ae165a20363344e2f4d838ff6ca6`
- macOS AMD64: `923bf9eed406b29f50a6fbc20c9d78251cc2db07db68303c106410d4dd87a29a`
- Linux ARM64: `d271755cf8192058fab59b179d8eecc0f97de6479a1e26c7b02d33404fcce043`
- Linux AMD64: `33923f35193c82efbab009e92a3ead25c9067379f9d50d4afce337428b35f631`