### PR TITLE
fix: upgrade GitHub Actions to resolve Node.js 20 deprecation

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Upload Executable Artifact (zipped binary)
         if: (github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant) && (github.event_name == 'push' || inputs.upload_binaries)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-name }}.zip
@@ -320,7 +320,7 @@ jobs:
 
       - name: Upload Executable Artifact
         if: github.event_name == 'push' || inputs.upload_binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cs-mcp-windows-amd64
           path: cs-mcp-windows-amd64.exe
@@ -336,7 +336,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -344,7 +344,7 @@ jobs:
         run: npm install -g @anthropic-ai/mcpb
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./all-binaries
           merge-multiple: true
@@ -456,7 +456,7 @@ jobs:
           mcpb pack "$STAGING_DIR" "./all-binaries/codehealth-mcp-${RELEASE_VERSION}.mcpb"
 
       - name: Upload MCPB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: codehealth-mcp-mcpb
           path: ./all-binaries/codehealth-mcp-*.mcpb

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -109,7 +109,7 @@ jobs:
         run: npx @vscode/vsce package --target ${{ matrix.vscode-target }}
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vsix-${{ matrix.vscode-target }}
           path: vscode/*.vsix
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all VSIX artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: vsix-*
           path: ./vsix-artifacts

--- a/.github/workflows/e2e-npm.yml
+++ b/.github/workflows/e2e-npm.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
         run: npm run test:ci
         working-directory: npm
       - name: Upload npm coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-coverage-report
           path: npm/coverage/cobertura-coverage.xml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Install dependencies
@@ -49,7 +49,7 @@ jobs:
         run: npm run test:ci
         working-directory: vscode
       - name: Upload vscode coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vscode-coverage-report
           path: vscode/coverage/cobertura-coverage.xml
@@ -67,7 +67,7 @@ jobs:
       - name: Run Rust tests with cobertura coverage
         run: cargo llvm-cov --bin cs-mcp --cobertura --output-path coverage.xml
       - name: Upload Rust coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rust-coverage-report
           path: coverage.xml
@@ -82,7 +82,7 @@ jobs:
           # fetch everything so that `cs-coverage check` can find merge-base
           fetch-depth: 0
       - name: download coverage
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           path: coverage/
       - uses: ./.github/actions/check-coverage


### PR DESCRIPTION
Upgrade actions that targeted Node.js 20:
- actions/setup-node: v4 -> v6
- actions/upload-artifact: v4 -> v7
- actions/download-artifact: v4/v5 -> v7

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/