### PR TITLE
Add CodeScene CLI pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .venv
 __pycache__
 .DS_Store
+.vscode
 npm/node_modules/
 npm/coverage/
 npm/.cache/

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,9 @@ format:
 .PHONY: format-check
 format-check:
 	cargo fmt -- --check
+
+.PHONY: install-hooks
+install-hooks:
+	cp hooks/pre-commit .git/hooks/pre-commit
+	chmod +x .git/hooks/pre-commit
+	@echo "Git hooks installed."

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,36 +7,20 @@ if ! command -v cs > /dev/null 2>&1; then
 fi
 
 if ! command -v jq > /dev/null 2>&1; then
-  printf 'CodeScene health gate: jq is not installed (required for JSON parsing).\n' >&2
+  printf 'CodeScene health gate: jq is not installed.\n' >&2
   exit 1
 fi
 
 output=$(cs delta --output-format=json 2>/dev/null)
 
-degraded_count=$(printf '%s' "$output" | jq -r '
-  [.[] | select(
+degraded=$(printf '%s' "$output" | jq -r '
+  .[] | select(
     (.["old-score"] == null and .["new-score"] != null) or
     (.["old-score"] != null and .["new-score"] != null and .["new-score"] < .["old-score"])
-  )] | length
+  ) | "  \(.name)  —  Code Health \(.["new-score"])/10"
 ' 2>/dev/null)
 
-if [ -z "$degraded_count" ] || [ "$degraded_count" -eq 0 ]; then
-  echo "CodeScene health gate OK"
-  exit 0
-fi
+[ -z "$degraded" ] && { echo "CodeScene health gate OK"; exit 0; }
 
-printf '%s' "$output" | jq -r '
-  .[] |
-  select(
-    (.["old-score"] == null and .["new-score"] != null) or
-    (.["old-score"] != null and .["new-score"] != null and .["new-score"] < .["old-score"])
-  ) |
-  "\n  \(.name)  —  Code Health \(.["new-score"] // "n/a")/10",
-  (.findings[]? |
-    "  [\(.category)]",
-    (.functions[]? | "    \(.title) (\(.details // ""), lines \(.["start-line"])–\(.["end-line"]))")
-  )
-' >&2
-
-printf '\nCodeScene health gate failed — modified files must not degrade Code Health before committing.\n\nTo fix: use the CodeScene MCP tool `code_health_review` on each failing file for a detailed\nbreakdown, then follow the `codescene:guiding-refactoring-with-code-health` skill to work\nthrough the issues in small, verifiable steps.\n' >&2
+printf 'CodeScene health gate failed:\n%s\n\nRun the `code_health_review` MCP tool on each failing file, then follow the\n`codescene:guiding-refactoring-with-code-health` skill to fix the issues.\n' "$degraded" >&2
 exit 1

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,42 @@
+#!/bin/sh
+export PATH="$HOME/.local/bin:$PATH"
+
+if ! command -v cs > /dev/null 2>&1; then
+  printf 'CodeScene health gate: cs is not installed.\nInstall from https://codescene.io/docs/cli/index.html\n' >&2
+  exit 1
+fi
+
+if ! command -v jq > /dev/null 2>&1; then
+  printf 'CodeScene health gate: jq is not installed (required for JSON parsing).\n' >&2
+  exit 1
+fi
+
+output=$(cs delta --output-format=json 2>/dev/null)
+
+degraded_count=$(printf '%s' "$output" | jq -r '
+  [.[] | select(
+    (.["old-score"] == null and .["new-score"] != null) or
+    (.["old-score"] != null and .["new-score"] != null and .["new-score"] < .["old-score"])
+  )] | length
+' 2>/dev/null)
+
+if [ -z "$degraded_count" ] || [ "$degraded_count" -eq 0 ]; then
+  echo "CodeScene health gate OK"
+  exit 0
+fi
+
+printf '%s' "$output" | jq -r '
+  .[] |
+  select(
+    (.["old-score"] == null and .["new-score"] != null) or
+    (.["old-score"] != null and .["new-score"] != null and .["new-score"] < .["old-score"])
+  ) |
+  "\n  \(.name)  —  Code Health \(.["new-score"] // "n/a")/10",
+  (.findings[]? |
+    "  [\(.category)]",
+    (.functions[]? | "    \(.title) (\(.details // ""), lines \(.["start-line"])–\(.["end-line"]))")
+  )
+' >&2
+
+printf '\nCodeScene health gate failed — modified files must not degrade Code Health before committing.\n\nTo fix: use the CodeScene MCP tool `code_health_review` on each failing file for a detailed\nbreakdown, then follow the `codescene:guiding-refactoring-with-code-health` skill to work\nthrough the issues in small, verifiable steps.\n' >&2
+exit 1


### PR DESCRIPTION
## Added a pre-commit hook which runs `cs delta`

This method of gating code health prevents agents or humans from committing unhealthy code from the codebase and is more reliable than using `AGENTS.md` as there is no way around it. The output on failure directs the programmer to use CodeScene MCP to resolve the issues.

## Tested locally

<img width="938" height="142" alt="image" src="https://github.com/user-attachments/assets/7856a2e3-3aa4-486d-bdb0-02bd993bb46b" />

``` rust
pub fn process(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) -> i32 {
    if a > 0 {
        if b > 0 {
            if c > 0 {
                if d > 0 {
                    if e > 0 {
                        if f > 0 {
                            return a + b + c + d + e + f;
                        } else {
                            return a + b + c + d + e - f;
                        }
                    } else {
                        if f > 0 {
                            return a + b + c + d - e + f;
                        } else {
                            return a + b + c + d - e - f;
                        }
                    }
                } else {
                    if e > 0 {
                        if f > 0 {
                            return a + b + c - d + e + f;
                        } else {
                            return a + b + c - d + e - f;
                        }
                    } else {
                        return a + b + c - d - e - f;
                    }
                }
            } else {
                if d > 0 {
                    if e > 0 {
                        return a + b - c + d + e + f;
                    } else {
                        return a + b - c + d - e + f;
                    }
                } else {
                    return a + b - c - d - e - f;
                }
```