### PR TITLE
Update Homebrew formula to 1.3.6

### DIFF
--- a/Formula/cs-mcp.rb
+++ b/Formula/cs-mcp.rb
@@ -4,13 +4,13 @@
 class CsMcp < Formula
   desc "MCP Server exposing Code Health analysis as AI-friendly tools"
   homepage "https://github.com/codescene-oss/codescene-mcp-server"
-  version "1.3.4"
+  version "1.3.6"
   license "MIT"
 
   on_macos do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-aarch64.zip"
-      sha256 "aed4331a2011abee9aef7b4ef6b44de7cb91ae165a20363344e2f4d838ff6ca6"
+      sha256 "184132f0a53d772aafa2fe590423603911b31c611ae241afb63ef06556798e26"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-aarch64" => "cs-mcp"
@@ -19,7 +19,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-macos-amd64.zip"
-      sha256 "923bf9eed406b29f50a6fbc20c9d78251cc2db07db68303c106410d4dd87a29a"
+      sha256 "a5c468d11bdc675b62776eeed35979d885e0cd94983cabe40cd0aa23aaf9feaf"
 
       define_method(:install) do
         bin.install "cs-mcp-macos-amd64" => "cs-mcp"
@@ -30,7 +30,7 @@ class CsMcp < Formula
   on_linux do
     on_arm do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-aarch64.zip"
-      sha256 "d271755cf8192058fab59b179d8eecc0f97de6479a1e26c7b02d33404fcce043"
+      sha256 "66e9f62d2bec8fe819c41f68bc12204e8105ff14e831a6ffd05c40131b16c2c8"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-aarch64" => "cs-mcp"
@@ -39,7 +39,7 @@ class CsMcp < Formula
 
     on_intel do
       url "https://github.com/codescene-oss/codescene-mcp-server/releases/download/MCP-#{version}/cs-mcp-linux-amd64.zip"
-      sha256 "33923f35193c82efbab009e92a3ead25c9067379f9d50d4afce337428b35f631"
+      sha256 "47e9ed27065cadbedc15e359080b125e6aa975b52ebe71d6c6009e663b2ac960"
 
       define_method(:install) do
         bin.install "cs-mcp-linux-amd64" => "cs-mcp"


### PR DESCRIPTION
This PR updates the Homebrew formula to version 1.3.6.

## Checksums
- macOS ARM64: `184132f0a53d772aafa2fe590423603911b31c611ae241afb63ef06556798e26`
- macOS AMD64: `a5c468d11bdc675b62776eeed35979d885e0cd94983cabe40cd0aa23aaf9feaf`
- Linux ARM64: `66e9f62d2bec8fe819c41f68bc12204e8105ff14e831a6ffd05c40131b16c2c8`
- Linux AMD64: `47e9ed27065cadbedc15e359080b125e6aa975b52ebe71d6c6009e663b2ac960`