### PR TITLE
Delegate OAuth credential resolution to the embedded CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,34 @@ The repository also includes a downloadable set of public agent skills in [skill
 
 Want AI to perform the setup? Start with [skills/installing-and-activating-codescene-mcp/SKILL.md](skills/installing-and-activating-codescene-mcp/SKILL.md).
 
-1. Get an Access Token for the MCP Server — see [Getting a Personal Access Token](docs/getting-a-personal-access-token.md).
+1. **Authenticate** with CodeScene using OAuth (recommended) or a Personal Access Token — see [Authentication](#authentication) below.
 2. Install the MCP Server using one of the [installation options](#installation) below.
 3. Add the MCP Server to your AI assistant. See the detailed instructions for your environment in the installation guide.
 4. Copy the agent guidance that matches your license into your repository: [AGENTS-full.md](docs/AGENTS-full.md) for CodeScene Core users, [AGENTS-standalone.md](docs/AGENTS-standalone.md) for standalone license users, or [.amazonq/rules](.amazonq/rules) for Amazon Q. Also copy any relevant public [skills](skills) for reusable workflow prompts.
 5. Explore the [available tools](docs/tools.md) to see what the MCP Server can do and which tools are available for your license.
+
+## Authentication
+
+The MCP server supports OAuth authentication to CodeScene. You do not need to paste a token into your MCP config for interactive desktop use.
+
+For on-prem Enterprise, configure your instance first:
+
+Set the environment variable `CS_ONPREM_URL`
+
+or alternatively, set the in-repository configuration file using the `cs` CLI.
+
+In-repository configuration file
+```bash
+cs auth configure --onprem-url https://your.codescene.com
+```
+
+### Personal Access Token or standalone license
+
+Set `CS_ACCESS_TOKEN` in your MCP client configuration or use `set_config(key="access_token", ...)`. See [Getting a Personal Access Token](docs/getting-a-personal-access-token.md).
+
+`CS_ACCESS_TOKEN` overrides stored OAuth when set (useful for CI).
+
+**Precedence:** `CS_ACCESS_TOKEN` env → config file `access_token` → OAuth.
 
 ## Installation
 

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -41,7 +41,11 @@ Environment variables set by your MCP client always take precedence over values 
 | **Sensitive** | Yes (value is masked in tool output) |
 | **Required** | Yes, for most functionality |
 
-The primary authentication credential for the CodeScene MCP Server. This can be either a **Personal Access Token (PAT)** obtained from your CodeScene instance, or a **standalone access token** (if you purchased MCP separately).
+The primary authentication credential for the CodeScene MCP Server. This can be:
+
+- **OAuth access token** (recommended) — sign in with OAuth to CodeScene via browser.
+- **Personal Access Token (PAT)** — obtained from your CodeScene instance.
+- **Standalone access token** — if you purchased MCP separately.
 
 The type of token determines which tools are available:
 
@@ -51,6 +55,8 @@ The type of token determines which tools are available:
 Changing this value may require a **server restart** for tool registration changes to take effect.
 
 See [Getting a Personal Access Token](getting-a-personal-access-token.md) for instructions on creating a PAT.
+
+**Precedence:** `CS_ACCESS_TOKEN` environment variable overrides stored OAuth credentials.
 
 ## `onprem_url`
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
+use crate::auth::CredentialResolver;
 use crate::errors::ApiError;
 use crate::http::{HttpClient, HttpRequest, HttpResponse, Method};
 
@@ -18,29 +19,51 @@ pub fn get_api_url() -> Result<String, ApiError> {
 pub async fn query_api_with_client(
     endpoint: &str,
     client: &dyn HttpClient,
+    credentials: Option<&CredentialResolver>,
 ) -> Result<Value, ApiError> {
     let url = format!("{}/{}", get_api_url()?, endpoint.trim_start_matches('/'));
-    query_api_url_with_client(&url, client).await
+    query_api_url_with_client(&url, client, credentials).await
 }
 
-async fn query_api_url_with_client(url: &str, client: &dyn HttpClient) -> Result<Value, ApiError> {
-    let token = std::env::var("CS_ACCESS_TOKEN").unwrap_or_default();
-    let token = token.trim();
+async fn query_api_url_with_client(
+    url: &str,
+    client: &dyn HttpClient,
+    credentials: Option<&CredentialResolver>,
+) -> Result<Value, ApiError> {
+    let mut retried = false;
+    loop {
+        let token = std::env::var("CS_ACCESS_TOKEN").unwrap_or_default();
+        let token = token.trim();
 
-    let request = HttpRequest {
-        method: Method::Get,
-        url: url.to_string(),
-        headers: build_api_headers(token),
-        body: None,
-        timeout_secs: 30,
-    };
+        let request = HttpRequest {
+            method: Method::Get,
+            url: url.to_string(),
+            headers: build_api_headers(token),
+            body: None,
+            timeout_secs: 30,
+        };
 
-    let resp = client
-        .send(request)
-        .await
-        .map_err(|e| ApiError::Transport(e))?;
+        let resp = client
+            .send(request)
+            .await
+            .map_err(|e| ApiError::Transport(e))?;
 
-    parse_api_response(resp)
+        match parse_api_response(resp) {
+            Ok(value) => return Ok(value),
+            Err(ApiError::Status { status: 401, body })
+                if !retried && credentials.is_some_and(|c| c.oauth_managed()) =>
+            {
+                if let Some(creds) = credentials {
+                    if creds.on_unauthorized().await.unwrap_or(false) {
+                        retried = true;
+                        continue;
+                    }
+                }
+                return Err(ApiError::Status { status: 401, body });
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 fn build_api_headers(token: &str) -> HashMap<String, String> {
@@ -74,6 +97,7 @@ fn parse_api_response(resp: HttpResponse) -> Result<Value, ApiError> {
 pub async fn query_api_list_with_client(
     endpoint: &str,
     client: &dyn HttpClient,
+    credentials: Option<&CredentialResolver>,
 ) -> Result<Vec<Value>, ApiError> {
     let mut results = Vec::new();
     let mut page = 1;
@@ -81,7 +105,7 @@ pub async fn query_api_list_with_client(
     loop {
         let sep = if endpoint.contains('?') { '&' } else { '?' };
         let paged = format!("{endpoint}{sep}page={page}");
-        let data = query_api_with_client(&paged, client).await?;
+        let data = query_api_with_client(&paged, client, credentials).await?;
 
         let items = match data.as_array() {
             Some(arr) => arr,
@@ -102,6 +126,7 @@ pub async fn query_api_keyed_list_with_client(
     params: &[(String, String)],
     key: &str,
     client: &dyn HttpClient,
+    credentials: Option<&CredentialResolver>,
 ) -> Result<Vec<Value>, ApiError> {
     let mut all_items = Vec::new();
     let mut current_page: i64 = 1;
@@ -111,7 +136,7 @@ pub async fn query_api_keyed_list_with_client(
         upsert_query_param(&mut query_params, "page", &current_page.to_string());
 
         let url = endpoint_with_query_params(endpoint, &query_params)?;
-        let data = query_api_url_with_client(&url, client).await?;
+        let data = query_api_url_with_client(&url, client, credentials).await?;
 
         let items = data
             .get(key)
@@ -142,9 +167,10 @@ pub async fn query_api_keyed_list_with_client(
 pub async fn get_latest_analysis_id(
     project_id: i64,
     client: &dyn HttpClient,
+    credentials: Option<&CredentialResolver>,
 ) -> Result<i64, ApiError> {
     let endpoint = format!("v2/projects/{project_id}/analyses/latest");
-    let data = query_api_with_client(&endpoint, client).await?;
+    let data = query_api_with_client(&endpoint, client, credentials).await?;
     data.get("id")
         .and_then(|v| v.as_i64())
         .ok_or_else(|| ApiError::Transport("Missing 'id' in analysis response".into()))
@@ -265,7 +291,7 @@ mod tests {
     async fn query_api_success() {
         let _g = lock_api_env("test-token");
         let mock = MockHttpClient::always(HttpResponse::ok(r#"{"projects":[]}"#));
-        let result = query_api_with_client("v2/projects", &mock).await.unwrap();
+        let result = query_api_with_client("v2/projects", &mock, None).await.unwrap();
         assert_eq!(result["projects"], serde_json::json!([]));
         cleanup_api_env();
     }
@@ -277,9 +303,9 @@ mod tests {
         let captured = mock.captured_requests.clone();
 
         // First request: normal endpoint
-        let _ = query_api_with_client("v2/test", &mock).await;
+        let _ = query_api_with_client("v2/test", &mock, None).await;
         // Second request: leading-slash endpoint
-        let _ = query_api_with_client("/v2/test", &mock).await;
+        let _ = query_api_with_client("/v2/test", &mock, None).await;
 
         let reqs = captured.lock().unwrap();
         assert_eq!(reqs.len(), 2);
@@ -307,7 +333,7 @@ mod tests {
         let mock = MockHttpClient::always(HttpResponse::ok(r#"{}"#));
         let captured = mock.captured_requests.clone();
 
-        let _ = query_api_with_client("v2/test", &mock).await;
+        let _ = query_api_with_client("v2/test", &mock, None).await;
 
         let reqs = captured.lock().unwrap();
         assert_eq!(reqs.len(), 1);
@@ -337,7 +363,7 @@ mod tests {
     }
 
     async fn assert_query_api_error(mock: MockHttpClient) {
-        match query_api_with_client("v2/projects", &mock)
+        match query_api_with_client("v2/projects", &mock, None)
             .await
             .unwrap_err()
         {
@@ -352,7 +378,7 @@ mod tests {
         endpoint: &str,
     ) -> Result<Vec<Value>, ApiError> {
         let mock = MockHttpClient::new(responses);
-        query_api_list_with_client(endpoint, &mock).await
+        query_api_list_with_client(endpoint, &mock, None).await
     }
 
     async fn run_keyed_list_query(
@@ -362,7 +388,7 @@ mod tests {
         key: &str,
     ) -> Result<Vec<Value>, ApiError> {
         let mock = MockHttpClient::new(responses);
-        query_api_keyed_list_with_client(endpoint, params, key, &mock).await
+        query_api_keyed_list_with_client(endpoint, params, key, &mock, None).await
     }
 
     #[tokio::test]
@@ -415,7 +441,7 @@ mod tests {
         let _g = lock_api_env("tok");
         let mock = MockHttpClient::new(vec![HttpResponse::ok(r#"[]"#)]);
         let captured = mock.captured_requests.clone();
-        let _ = query_api_list_with_client("v2/items?filter=test", &mock).await;
+        let _ = query_api_list_with_client("v2/items?filter=test", &mock, None).await;
         let reqs = captured.lock().unwrap();
         // Should use '&' since '?' already exists
         assert!(reqs[0].url.contains("filter=test&page=1"));
@@ -495,7 +521,7 @@ mod tests {
         let _g = lock_api_env("tok");
         let mock =
             MockHttpClient::always(HttpResponse::ok(r#"{"id":37888,"name":"latest analysis"}"#));
-        let id = get_latest_analysis_id(147, &mock).await.unwrap();
+        let id = get_latest_analysis_id(147, &mock, None).await.unwrap();
         assert_eq!(id, 37888);
         cleanup_api_env();
     }
@@ -504,7 +530,7 @@ mod tests {
     async fn get_latest_analysis_id_missing_id_field() {
         let _g = lock_api_env("tok");
         let mock = MockHttpClient::always(HttpResponse::ok(r#"{"name":"no id here"}"#));
-        let err = get_latest_analysis_id(147, &mock).await.unwrap_err();
+        let err = get_latest_analysis_id(147, &mock, None).await.unwrap_err();
         match err {
             ApiError::Transport(msg) => assert!(msg.contains("Missing 'id'")),
             other => panic!("Expected Transport error, got {other:?}"),
@@ -516,7 +542,7 @@ mod tests {
     async fn get_latest_analysis_id_api_error() {
         let _g = lock_api_env("tok");
         let mock = MockHttpClient::new(vec![HttpResponse::error(500, "Server Error")]);
-        assert!(get_latest_analysis_id(147, &mock).await.is_err());
+        assert!(get_latest_analysis_id(147, &mock, None).await.is_err());
         cleanup_api_env();
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,298 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde::Deserialize;
+
+use crate::cli::CliRunner;
+use crate::config::{self, ConfigData};
+
+const REFRESH_BUFFER_MS: i64 = 60_000;
+const MCP_OAUTH_CLIENT: &str = "mcp";
+
+#[derive(Debug, Clone)]
+pub(crate) struct CachedCredential {
+    pub(crate) access_token: String,
+    pub(crate) expires_at: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CliTokenResponse {
+    state: String,
+    #[serde(rename = "access-token")]
+    access_token: Option<String>,
+    #[serde(rename = "expires-at")]
+    expires_at: Option<i64>,
+    #[serde(rename = "onprem-url")]
+    onprem_url: Option<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AuthError {
+    #[error("CLI auth command failed: {0}")]
+    Cli(#[from] crate::errors::CliError),
+
+    #[error("Failed to parse CLI auth token JSON: {0}")]
+    Parse(#[from] serde_json::Error),
+
+    #[error("Not signed in ({state})")]
+    NotSignedIn { state: String },
+}
+
+/// Resolves OAuth credentials via the embedded CLI (`cs auth token`).
+/// Static tokens from env or config file are left untouched.
+#[derive(Clone)]
+pub(crate) struct CredentialResolver {
+    cli_runner: Arc<dyn CliRunner>,
+    oauth_managed: Arc<AtomicBool>,
+    cache: Arc<Mutex<Option<CachedCredential>>>,
+}
+
+pub(crate) fn access_token_from_env() -> Option<String> {
+    std::env::var("CS_ACCESS_TOKEN")
+        .ok()
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+}
+
+pub(crate) fn access_token_configured(config: &ConfigData) -> bool {
+    if access_token_from_env().is_some() {
+        return true;
+    }
+    config::find_option("access_token")
+        .and_then(|opt| config::get_effective(opt, config))
+        .map(|t| !t.trim().is_empty())
+        .unwrap_or(false)
+}
+
+impl CredentialResolver {
+    pub(crate) fn new(cli_runner: Arc<dyn CliRunner>, oauth_managed: bool) -> Self {
+        Self {
+            cli_runner,
+            oauth_managed: Arc::new(AtomicBool::new(oauth_managed)),
+            cache: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub(crate) fn oauth_managed(&self) -> bool {
+        self.oauth_managed.load(Ordering::Relaxed)
+    }
+
+    pub(crate) async fn bootstrap_with_config(&self, config: &ConfigData) -> Result<(), AuthError> {
+        if access_token_configured(config) {
+            self.oauth_managed.store(false, Ordering::Relaxed);
+            return Ok(());
+        }
+        self.oauth_managed.store(true, Ordering::Relaxed);
+        self.refresh_from_cli().await
+    }
+
+    pub(crate) async fn ensure_fresh(&self) -> Result<(), AuthError> {
+        if access_token_from_env().is_some() {
+            self.oauth_managed.store(false, Ordering::Relaxed);
+            return Ok(());
+        }
+        if !self.oauth_managed() {
+            return Ok(());
+        }
+        let needs_refresh = self
+            .cache
+            .lock()
+            .map(|guard| {
+                guard.as_ref().map_or(true, |cred| token_near_expiry(cred.expires_at))
+            })
+            .unwrap_or(true);
+        if needs_refresh {
+            self.refresh_from_cli().await?;
+        }
+        Ok(())
+    }
+
+    /// Re-resolve OAuth after HTTP 401. Returns true when a new token was applied.
+    pub(crate) async fn on_unauthorized(&self) -> Result<bool, AuthError> {
+        if !self.oauth_managed() {
+            return Ok(false);
+        }
+        {
+            let mut guard = self.cache.lock().unwrap_or_else(|e| e.into_inner());
+            *guard = None;
+        }
+        self.refresh_from_cli().await?;
+        Ok(true)
+    }
+
+    pub(crate) async fn auth_status_json(&self) -> Result<String, AuthError> {
+        Ok(self
+            .cli_runner
+            .run(
+                &[
+                    "auth",
+                    "status",
+                    "--client",
+                    MCP_OAUTH_CLIENT,
+                    "--output-format",
+                    "json",
+                ],
+                None,
+            )
+            .await?)
+    }
+
+    async fn refresh_from_cli(&self) -> Result<(), AuthError> {
+        let output = self
+            .cli_runner
+            .run(
+                &[
+                    "auth",
+                    "token",
+                    "--client",
+                    MCP_OAUTH_CLIENT,
+                    "--output-format",
+                    "json",
+                ],
+                None,
+            )
+            .await?;
+        let parsed: CliTokenResponse = serde_json::from_str(output.trim())?;
+        if parsed.state != "signed_in" {
+            return Err(AuthError::NotSignedIn {
+                state: parsed.state,
+            });
+        }
+        let access_token = parsed
+            .access_token
+            .filter(|t| !t.trim().is_empty())
+            .ok_or(AuthError::NotSignedIn {
+                state: "signed_out".to_string(),
+            })?;
+        apply_token_to_env(&access_token, parsed.onprem_url.as_deref());
+        let cached = CachedCredential {
+            access_token,
+            expires_at: parsed.expires_at,
+        };
+        if let Ok(mut guard) = self.cache.lock() {
+            *guard = Some(cached);
+        }
+        Ok(())
+    }
+}
+
+fn token_near_expiry(expires_at: Option<i64>) -> bool {
+    expires_at.map_or(false, |exp| exp <= now_ms() + REFRESH_BUFFER_MS)
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn apply_token_to_env(access_token: &str, onprem_url: Option<&str>) {
+    std::env::set_var("CS_ACCESS_TOKEN", access_token.trim());
+    if std::env::var("CS_ONPREM_URL").is_err() {
+        if let Some(url) = onprem_url.filter(|u| !u.trim().is_empty()) {
+            std::env::set_var("CS_ONPREM_URL", url.trim());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    struct MockCliRunner {
+        responses: Mutex<Vec<Result<String, crate::errors::CliError>>>,
+    }
+
+    impl MockCliRunner {
+        fn with_responses(responses: Vec<Result<String, crate::errors::CliError>>) -> Arc<Self> {
+            Arc::new(Self {
+                responses: Mutex::new(responses),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl CliRunner for MockCliRunner {
+        async fn run(
+            &self,
+            _args: &[&str],
+            _working_dir: Option<&Path>,
+        ) -> Result<String, crate::errors::CliError> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop()
+                .unwrap_or_else(|| Ok(String::new()))
+        }
+    }
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        config::lock_test_env()
+    }
+
+    fn clear_token_env() {
+        std::env::remove_var("CS_ACCESS_TOKEN");
+        std::env::remove_var("CS_ONPREM_URL");
+    }
+
+    #[test]
+    fn token_near_expiry_within_buffer() {
+        let soon = now_ms() + 30_000;
+        assert!(token_near_expiry(Some(soon)));
+        let later = now_ms() + 120_000;
+        assert!(!token_near_expiry(Some(later)));
+    }
+
+    #[tokio::test]
+    async fn refresh_from_cli_applies_env_and_cache() {
+        let _lock = lock_env();
+        clear_token_env();
+
+        let json = r#"{"state":"signed_in","access-token":"oat_test","expires-at":9999999999999,"onprem-url":"https://onprem.example.com"}"#;
+        let cli = MockCliRunner::with_responses(vec![Ok(json.to_string())]);
+        let resolver = CredentialResolver::new(cli, true);
+        resolver.refresh_from_cli().await.unwrap();
+
+        assert_eq!(
+            access_token_from_env().as_deref(),
+            Some("oat_test")
+        );
+        assert_eq!(
+            std::env::var("CS_ONPREM_URL").ok().as_deref(),
+            Some("https://onprem.example.com")
+        );
+        let cached = resolver.cache.lock().unwrap();
+        assert_eq!(cached.as_ref().unwrap().access_token, "oat_test");
+        clear_token_env();
+    }
+
+    #[tokio::test]
+    async fn bootstrap_skips_when_env_token_present() {
+        let _lock = lock_env();
+        std::env::set_var("CS_ACCESS_TOKEN", "static-token");
+        let cli = MockCliRunner::with_responses(vec![]);
+        let resolver = CredentialResolver::new(cli, true);
+        let config = ConfigData::default();
+        resolver.bootstrap_with_config(&config).await.unwrap();
+        assert!(!resolver.oauth_managed());
+        clear_token_env();
+    }
+
+    #[tokio::test]
+    async fn on_unauthorized_refreshes_oauth_token() {
+        let _lock = lock_env();
+        clear_token_env();
+
+        let json = r#"{"state":"signed_in","access-token":"oat_new","expires-at":9999999999999}"#;
+        let cli = MockCliRunner::with_responses(vec![Ok(json.to_string())]);
+        let resolver = CredentialResolver::new(cli, true);
+        let refreshed = resolver.on_unauthorized().await.unwrap();
+        assert!(refreshed);
+        assert_eq!(access_token_from_env().as_deref(), Some("oat_new"));
+        clear_token_env();
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -14,10 +14,11 @@ pub enum CliError {
 
     #[error(
         "Access token is invalid or expired.\n\n\
-         Please update your access token using one of these methods:\n\
+         Sign in with OAuth: cs auth login --client mcp\n\n\
+         Or update your access token using one of these methods:\n\
          1. Use the `set_config` tool: set_config(key=\"access_token\", value=\"your-token\")\n\
          2. Set the CS_ACCESS_TOKEN environment variable in your MCP client configuration\n\n\
-         To get a new Access Token, see:\n\
+         To get a new Personal Access Token, see:\n\
          https://github.com/codescene-oss/codescene-mcp-server/blob/main/docs/getting-a-personal-access-token.md"
     )]
     LicenseCheckFailed { stderr: String },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod api_client;
+mod auth;
 mod business_case;
 mod cli;
 mod config;
@@ -51,10 +52,12 @@ use crate::version_checker::VersionChecker;
 
 const TOKEN_MISSING_MSG: &str = "\
 No access token configured.\n\n\
-To use this tool, set your access token using one of these methods:\n\
+To sign in with OAuth, run:\n\
+  cs auth login --client mcp\n\n\
+You can also set your access token using one of these methods:\n\
 1. Use the `set_config` tool: set_config(key=\"access_token\", value=\"your-token\")\n\
 2. Set the CS_ACCESS_TOKEN environment variable in your MCP client configuration\n\n\
-To get an Access Token, see:\n\
+To get a Personal Access Token, see:\n\
 https://github.com/codescene-oss/codescene-mcp-server/blob/main/docs/getting-a-personal-access-token.md";
 
 const _VERSION_NOTICE_SUFFIX: &str = "\n\
@@ -135,6 +138,7 @@ pub(crate) struct ServerDeps {
     pub(crate) cli_runner: Arc<dyn CliRunner>,
     pub(crate) http_client: Arc<dyn HttpClient>,
     pub(crate) validator: Arc<dyn Validator>,
+    pub(crate) credentials: Arc<auth::CredentialResolver>,
 }
 
 #[derive(Clone)]
@@ -147,9 +151,17 @@ pub(crate) struct CodeSceneServer {
     pub(crate) cli_runner: Arc<dyn CliRunner>,
     pub(crate) http_client: Arc<dyn HttpClient>,
     pub(crate) validator: Arc<dyn Validator>,
+    pub(crate) credentials: Arc<auth::CredentialResolver>,
 }
 
 impl CodeSceneServer {
+    pub(crate) async fn ensure_access_token(&self) -> Option<CallToolResult> {
+        if let Err(err) = self.credentials.ensure_fresh().await {
+            tracing::warn!("OAuth token refresh failed: {err}");
+        }
+        self.require_token()
+    }
+
     pub(crate) fn require_token(&self) -> Option<CallToolResult> {
         if std::env::var("CS_ACCESS_TOKEN")
             .map(|v| v.trim().is_empty())
@@ -250,6 +262,7 @@ impl CodeSceneServer {
             cli_runner: deps.cli_runner,
             http_client: deps.http_client,
             validator: deps.validator,
+            credentials: deps.credentials,
         }
     }
 
@@ -546,6 +559,18 @@ async fn main() -> anyhow::Result<()> {
 
     let instance_id = config::instance_id(&config_data);
 
+    let cli_runner = Arc::new(cli::ProductionCliRunner);
+    let oauth_managed = !auth::access_token_configured(&config_data);
+    let credentials = Arc::new(auth::CredentialResolver::new(
+        cli_runner.clone(),
+        oauth_managed,
+    ));
+    if oauth_managed {
+        if let Err(err) = credentials.bootstrap_with_config(&config_data).await {
+            tracing::warn!("OAuth credential bootstrap failed: {err}");
+        }
+    }
+
     let token = std::env::var("CS_ACCESS_TOKEN").unwrap_or_default();
     let is_standalone = !token.is_empty() && license::is_standalone_license(&token);
 
@@ -557,9 +582,10 @@ async fn main() -> anyhow::Result<()> {
         instance_id,
         is_standalone,
         version_checker,
-        cli_runner: Arc::new(cli::ProductionCliRunner),
+        cli_runner,
         http_client: Arc::new(http::ReqwestClient),
         validator: Arc::new(tools::validation::ProductionCliValidator),
+        credentials,
     });
 
     // Covered by e2e test: test_shutdown_during_handshake.py

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -12,6 +12,7 @@ use crate::http::{self};
 use crate::http::tests::MockHttpClient;
 use crate::tools::validation::{CliCheck, ValidationError, Validator};
 use crate::version_checker::VersionChecker;
+use crate::auth;
 use crate::{CodeSceneServer, ServerDeps};
 
 /// Mock validator that always passes. Use [`MockValidator::failing`] to
@@ -56,6 +57,7 @@ pub(crate) struct TestMocks {
 }
 
 pub(crate) fn test_deps(id: &str, is_standalone: bool, mocks: TestMocks) -> ServerDeps {
+    let cli_runner = mocks.cli.clone();
     ServerDeps {
         config_data: ConfigData {
             instance_id: Some(id.to_string()),
@@ -67,6 +69,7 @@ pub(crate) fn test_deps(id: &str, is_standalone: bool, mocks: TestMocks) -> Serv
         cli_runner: mocks.cli,
         http_client: mocks.http,
         validator: mocks.validator,
+        credentials: Arc::new(auth::CredentialResolver::new(cli_runner, false)),
     }
 }
 
@@ -114,6 +117,10 @@ pub(crate) async fn make_server_with_version(
         cli_runner: Arc::new(cli::ProductionCliRunner),
         http_client: Arc::new(http::ReqwestClient),
         validator: Arc::new(MockValidator::passing()),
+        credentials: Arc::new(auth::CredentialResolver::new(
+            Arc::new(cli::ProductionCliRunner),
+            false,
+        )),
     })
 }
 
@@ -575,6 +582,10 @@ mod tests {
             cli_runner: Arc::new(cli::ProductionCliRunner),
             http_client: Arc::new(http::ReqwestClient),
             validator: Arc::new(MockValidator::passing()),
+            credentials: Arc::new(auth::CredentialResolver::new(
+                Arc::new(cli::ProductionCliRunner),
+                false,
+            )),
         })
     }
 

--- a/src/tools/analyze_change_set.rs
+++ b/src/tools/analyze_change_set.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ChangeSetParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/code_health_refactoring_business_case.rs
+++ b/src/tools/code_health_refactoring_business_case.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: FilePathParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/code_health_review.rs
+++ b/src/tools/code_health_review.rs
@@ -14,7 +14,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: FilePathParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/code_health_score.rs
+++ b/src/tools/code_health_score.rs
@@ -14,7 +14,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: FilePathParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/code_ownership_for_path.rs
+++ b/src/tools/code_ownership_for_path.rs
@@ -14,7 +14,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: OwnershipParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     if server.is_standalone {
@@ -23,6 +23,7 @@ pub(crate) async fn handle(
         ));
     }
     server.version_checker.check_in_background();
+    let creds = Some(server.credentials.as_ref());
     let path = docker::adapt_path_for_docker(Path::new(&params.path));
     let relative = make_relative_for_api(Path::new(&path));
     let endpoint = format!("v2/projects/{}/analyses/latest/files", params.project_id);
@@ -35,6 +36,7 @@ pub(crate) async fn handle(
         &query_params,
         "files",
         &*server.http_client,
+        creds,
     )
     .await;
     match result {

--- a/src/tools/explain_code_health.rs
+++ b/src/tools/explain_code_health.rs
@@ -6,7 +6,7 @@ use crate::resources;
 use crate::CodeSceneServer;
 
 pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/explain_code_health_productivity.rs
+++ b/src/tools/explain_code_health_productivity.rs
@@ -6,7 +6,7 @@ use crate::resources;
 use crate::CodeSceneServer;
 
 pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/list_technical_debt_goals_for_project.rs
+++ b/src/tools/list_technical_debt_goals_for_project.rs
@@ -13,7 +13,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     if server.is_standalone {
@@ -22,8 +22,13 @@ pub(crate) async fn handle(
         ));
     }
     server.version_checker.check_in_background();
+    let creds = Some(server.credentials.as_ref());
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
+    let analysis_id = api_client::get_latest_analysis_id(
+        params.project_id,
+        &*server.http_client,
+        creds,
+    )
         .await
         .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
@@ -45,6 +50,7 @@ pub(crate) async fn handle(
         &query_params,
         "files",
         &*server.http_client,
+        creds,
     )
     .await;
     match result {

--- a/src/tools/list_technical_debt_goals_for_project_file.rs
+++ b/src/tools/list_technical_debt_goals_for_project_file.rs
@@ -16,7 +16,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectFileParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     if server.is_standalone {
@@ -25,8 +25,13 @@ pub(crate) async fn handle(
         ));
     }
     server.version_checker.check_in_background();
+    let creds = Some(server.credentials.as_ref());
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
+    let analysis_id = api_client::get_latest_analysis_id(
+        params.project_id,
+        &*server.http_client,
+        creds,
+    )
         .await
         .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
@@ -49,6 +54,7 @@ pub(crate) async fn handle(
         &query_params,
         "files",
         &*server.http_client,
+        creds,
     )
     .await;
     match result {

--- a/src/tools/list_technical_debt_hotspots_for_project.rs
+++ b/src/tools/list_technical_debt_hotspots_for_project.rs
@@ -13,7 +13,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     if server.is_standalone {
@@ -22,8 +22,13 @@ pub(crate) async fn handle(
         ));
     }
     server.version_checker.check_in_background();
+    let creds = Some(server.credentials.as_ref());
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
+    let analysis_id = api_client::get_latest_analysis_id(
+        params.project_id,
+        &*server.http_client,
+        creds,
+    )
         .await
         .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
@@ -47,6 +52,7 @@ pub(crate) async fn handle(
         &query_params,
         "result",
         &*server.http_client,
+        creds,
     )
     .await;
     match result {

--- a/src/tools/list_technical_debt_hotspots_for_project_file.rs
+++ b/src/tools/list_technical_debt_hotspots_for_project_file.rs
@@ -16,7 +16,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectFileParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     if server.is_standalone {
@@ -25,8 +25,13 @@ pub(crate) async fn handle(
         ));
     }
     server.version_checker.check_in_background();
+    let creds = Some(server.credentials.as_ref());
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
+    let analysis_id = api_client::get_latest_analysis_id(
+        params.project_id,
+        &*server.http_client,
+        creds,
+    )
         .await
         .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
@@ -52,6 +57,7 @@ pub(crate) async fn handle(
         &query_params,
         "result",
         &*server.http_client,
+        creds,
     )
     .await;
     match result {

--- a/src/tools/pre_commit_code_health_safeguard.rs
+++ b/src/tools/pre_commit_code_health_safeguard.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: GitRepoParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/select_project.rs
+++ b/src/tools/select_project.rs
@@ -8,7 +8,7 @@ use crate::tools::common::tool_error;
 use crate::CodeSceneServer;
 
 pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.ensure_access_token().await {
         return Ok(r);
     }
     if server.is_standalone {
@@ -17,7 +17,7 @@ pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, E
         ));
     }
     server.version_checker.check_in_background();
-    let result = run_select_project(&*server.http_client).await;
+    let result = run_select_project(&*server.http_client, Some(server.credentials.as_ref())).await;
     match &result {
         Ok(output) => {
             let props = event_properties::select_project_properties();
@@ -37,6 +37,7 @@ pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, E
 
 pub(crate) async fn run_select_project(
     http_client: &dyn crate::http::HttpClient,
+    credentials: Option<&crate::auth::CredentialResolver>,
 ) -> Result<serde_json::Value, String> {
     let link = std::env::var("CS_ONPREM_URL")
         .ok()
@@ -55,7 +56,7 @@ pub(crate) async fn run_select_project(
         }
     }
 
-    let data = api_client::query_api_list_with_client("v2/projects", http_client)
+    let data = api_client::query_api_list_with_client("v2/projects", http_client, credentials)
         .await
         .map_err(|e| format!("Error: {e}"))?;
 
@@ -97,7 +98,7 @@ mod tests {
     async fn run_with_default_project_id() {
         let _g = set_token("test-token");
         std::env::set_var("CS_DEFAULT_PROJECT_ID", "42");
-        let result = run_select_project(&crate::http::ReqwestClient).await;
+        let result = run_select_project(&crate::http::ReqwestClient, None).await;
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         let value = result.unwrap();
         assert_eq!(value["id"], 42);
@@ -108,7 +109,7 @@ mod tests {
     async fn run_default_id_empty_falls_through() {
         let _g = set_token("test-token");
         std::env::set_var("CS_DEFAULT_PROJECT_ID", "");
-        let result = run_select_project(&crate::http::ReqwestClient).await;
+        let result = run_select_project(&crate::http::ReqwestClient, None).await;
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         match result {
             Ok(val) => assert!(val.get("projects").is_some()),
@@ -141,7 +142,7 @@ mod tests {
         let _g = set_token("tok");
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         let http = make_api_mock(HttpResponse::ok(r#"[{"id":99,"name":"TestProject"}]"#));
-        let result = run_select_project(&http).await.unwrap();
+        let result = run_select_project(&http, None).await.unwrap();
         assert!(result["projects"].as_array().unwrap().len() > 0);
         assert_eq!(result["projects"][0]["name"], "TestProject");
     }
@@ -151,7 +152,7 @@ mod tests {
         let _g = set_token("tok");
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         let http = MockHttpClient::new(vec![HttpResponse::error(500, "fail")]);
-        let result = run_select_project(&http).await;
+        let result = run_select_project(&http, None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Error"));
     }

--- a/src/tools/verify_installation.rs
+++ b/src/tools/verify_installation.rs
@@ -5,6 +5,7 @@ use rmcp::ErrorData;
 use serde_json::json;
 
 use crate::api_client;
+use crate::auth;
 use crate::cli;
 use crate::cli::CliRunner;
 use crate::docker;
@@ -19,9 +20,9 @@ pub(crate) async fn handle(
     params: GitRepoParam,
 ) -> Result<CallToolResult, ErrorData> {
     server.version_checker.check_in_background();
+    let _ = server.credentials.ensure_fresh().await;
     let project_root = docker::adapt_path_for_docker(Path::new(&params.git_repository_path));
-    let checks =
-        run_all_checks(&project_root, &*server.cli_runner, &*server.http_client, server.is_standalone).await;
+    let checks = run_all_checks(&project_root, server).await;
     let text = format_results(&checks);
     server.track("verify-installation", json!({}));
     let text = server.maybe_version_warning(&text).await;
@@ -36,20 +37,20 @@ struct CheckResult {
 
 const TOKEN_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-async fn run_all_checks(
-    project_root: &str,
-    cli_runner: &dyn CliRunner,
-    http_client: &dyn HttpClient,
-    is_standalone: bool,
-) -> Vec<CheckResult> {
+async fn run_all_checks(project_root: &str, server: &CodeSceneServer) -> Vec<CheckResult> {
     let path = Path::new(project_root);
+    let cli_runner = &*server.cli_runner;
     let mut checks = vec![
         check_git_repository(path),
-        check_token_via_cli(path, cli_runner, TOKEN_CHECK_TIMEOUT).await,
+        check_token_via_cli(path, cli_runner, &server.credentials, TOKEN_CHECK_TIMEOUT).await,
         check_cli_connectivity(path, cli_runner, TOKEN_CHECK_TIMEOUT).await,
     ];
-    if !is_standalone {
-        checks.push(check_api_connectivity(http_client).await);
+    if !server.is_standalone {
+        checks.push(check_api_connectivity(
+            &*server.http_client,
+            Some(server.credentials.as_ref()),
+        )
+        .await);
     }
     checks.push(check_environment());
     checks
@@ -79,16 +80,30 @@ fn is_connectivity_error(stderr: &str) -> bool {
 async fn check_token_via_cli(
     repo_path: &Path,
     cli_runner: &dyn CliRunner,
+    credentials: &auth::CredentialResolver,
     timeout: std::time::Duration,
 ) -> CheckResult {
-    let token = std::env::var("CS_ACCESS_TOKEN")
-        .map(|v| v.trim().to_string())
-        .unwrap_or_default();
+    let token = auth::access_token_from_env().unwrap_or_default();
     if token.is_empty() {
-        return CheckResult {
-            name: "Access Token",
-            passed: false,
-            detail: "CS_ACCESS_TOKEN is not set or empty.".to_string(),
+        return match credentials.auth_status_json().await {
+            Ok(json) => {
+                let state = oauth_status_state(&json).unwrap_or_else(|| "signed_out".to_string());
+                CheckResult {
+                    name: "Access Token",
+                    passed: false,
+                    detail: format!(
+                        "Not signed in ({state}). Run: cs auth login --client mcp"
+                    ),
+                }
+            }
+            Err(err) => CheckResult {
+                name: "Access Token",
+                passed: false,
+                detail: format!(
+                    "CS_ACCESS_TOKEN is not set and OAuth status check failed: {err}. \
+                     Run: cs auth login --client mcp"
+                ),
+            },
         };
     }
     // Use `review` on a known source file instead of `delta` because
@@ -185,18 +200,18 @@ async fn check_cli_connectivity(
 /// certificate misconfiguration that the CLI check alone might miss
 /// (since the CLI and the MCP server build their TLS stacks
 /// independently).
-async fn check_api_connectivity(http_client: &dyn HttpClient) -> CheckResult {
-    let token = std::env::var("CS_ACCESS_TOKEN")
-        .map(|v| v.trim().to_string())
-        .unwrap_or_default();
-    if token.is_empty() {
+async fn check_api_connectivity(
+    http_client: &dyn HttpClient,
+    credentials: Option<&auth::CredentialResolver>,
+) -> CheckResult {
+    if auth::access_token_from_env().is_none() {
         return CheckResult {
             name: "API Connectivity",
             passed: false,
-            detail: "Skipped — CS_ACCESS_TOKEN is not set.".to_string(),
+            detail: "Skipped — no access token configured.".to_string(),
         };
     }
-    match api_client::query_api_with_client("v2/projects", http_client).await {
+    match api_client::query_api_with_client("v2/projects", http_client, credentials).await {
         Ok(_) => CheckResult {
             name: "API Connectivity",
             passed: true,
@@ -241,6 +256,12 @@ fn token_pass() -> CheckResult {
     }
 }
 
+fn oauth_status_state(json: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(json)
+        .ok()
+        .and_then(|v| v.get("state").and_then(|s| s.as_str()).map(str::to_string))
+}
+
 fn check_git_repository(path: &Path) -> CheckResult {
     match cli::find_git_root(path) {
         Some(root) => CheckResult {
@@ -282,6 +303,8 @@ fn format_results(checks: &[CheckResult]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use crate::http::tests::MockHttpClient;
     use crate::http::HttpResponse;
     use crate::tests::{
@@ -315,22 +338,63 @@ mod tests {
         MockCliRunner::with_responses(vec![Ok("{}".into()), Ok("{}".into())])
     }
 
+    fn mock_credentials(cli: MockCliRunner) -> auth::CredentialResolver {
+        auth::CredentialResolver::new(Arc::new(cli), false)
+    }
+
+    async fn assert_token_check_connectivity_failure(cli: MockCliRunner, error_fragment: &str) {
+        let _g = set_token("tok");
+        let creds = mock_credentials(MockCliRunner::with_ok(""));
+        let result = check_token_via_cli(Path::new("/tmp"), &cli, &creds, TEST_TIMEOUT).await;
+        assert!(!result.passed, "detail: {}", result.detail);
+        assert!(result.detail.contains("TLS/network"), "detail: {}", result.detail);
+        assert!(
+            result.detail.contains(error_fragment),
+            "should include original error: {}",
+            result.detail
+        );
+    }
+
+    struct HandleVerificationCase {
+        standalone: bool,
+        cli: MockCliRunner,
+        http: MockHttpClient,
+        must_contain: &'static [&'static str],
+        must_not_contain: &'static [&'static str],
+    }
+
+    async fn run_handle_verification(case: HandleVerificationCase) {
+        let _g = set_token("tok");
+        let server = make_server_with_mocks(case.standalone, case.cli, case.http);
+        let result = handle(&server, repo_param("/tmp")).await.unwrap();
+        assert!(result.is_error.is_none() || result.is_error == Some(false));
+        let text = crate::tests::result_text(&result);
+        for fragment in case.must_contain {
+            assert!(text.contains(fragment), "expected '{fragment}' in: {text}");
+        }
+        for fragment in case.must_not_contain {
+            assert!(!text.contains(fragment), "unexpected '{fragment}' in: {text}");
+        }
+    }
+
     // -- check_token_via_cli -------------------------------------------------
 
     #[tokio::test]
     async fn token_missing_reports_fail() {
         let _g = clear_token();
+        let creds = mock_credentials(MockCliRunner::with_ok(r#"{"state":"signed_out"}"#));
         let cli = MockCliRunner::with_ok("");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &cli, &creds, TEST_TIMEOUT).await;
         assert!(!result.passed);
-        assert!(result.detail.contains("not set"));
+        assert!(result.detail.contains("cs auth login"));
     }
 
     #[tokio::test]
     async fn token_valid_reports_pass() {
         let _g = set_token("tok");
         let cli = MockCliRunner::with_ok("{}");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let creds = mock_credentials(MockCliRunner::with_ok(""));
+        let result = check_token_via_cli(Path::new("/tmp"), &cli, &creds, TEST_TIMEOUT).await;
         assert!(result.passed);
         assert!(result.detail.contains("authenticated"));
     }
@@ -339,7 +403,8 @@ mod tests {
     async fn token_invalid_reports_fail() {
         let _g = set_token("bad");
         let cli = mock_license_failure("License check failed: [401]");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let creds = mock_credentials(MockCliRunner::with_ok(""));
+        let result = check_token_via_cli(Path::new("/tmp"), &cli, &creds, TEST_TIMEOUT).await;
         assert!(!result.passed);
         assert!(result.detail.contains("invalid or expired"));
     }
@@ -348,7 +413,8 @@ mod tests {
     async fn non_license_error_still_passes_auth() {
         let _g = set_token("tok");
         let cli = MockCliRunner::with_err(1, "no changes found");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let creds = mock_credentials(MockCliRunner::with_ok(""));
+        let result = check_token_via_cli(Path::new("/tmp"), &cli, &creds, TEST_TIMEOUT).await;
         assert!(result.passed);
     }
 
@@ -356,7 +422,8 @@ mod tests {
     async fn tls_error_from_cli_reports_connectivity_failure() {
         let _g = set_token("tok");
         let cli = MockCliRunner::with_err(1, "SSL certificate problem: unable to get local issuer certificate");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let creds = mock_credentials(MockCliRunner::with_ok(""));
+        let result = check_token_via_cli(Path::new("/tmp"), &cli, &creds, TEST_TIMEOUT).await;
         assert!(!result.passed);
         assert!(result.detail.contains("TLS/network"), "detail: {}", result.detail);
     }
@@ -365,31 +432,30 @@ mod tests {
     async fn connection_refused_from_cli_reports_connectivity_failure() {
         let _g = set_token("tok");
         let cli = MockCliRunner::with_err(1, "connection refused");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let creds = mock_credentials(MockCliRunner::with_ok(""));
+        let result = check_token_via_cli(Path::new("/tmp"), &cli, &creds, TEST_TIMEOUT).await;
         assert!(!result.passed);
         assert!(result.detail.contains("TLS/network"), "detail: {}", result.detail);
     }
 
     #[tokio::test]
     async fn license_check_with_ssl_handshake_reports_connectivity_failure() {
-        let _g = set_token("tok");
-        let cli = mock_license_failure(SSL_HANDSHAKE_STDERR);
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
-        assert!(!result.passed, "should detect TLS error: {}", result.detail);
-        assert!(result.detail.contains("TLS/network"), "detail: {}", result.detail);
-        assert!(result.detail.contains("SSLHandshakeException"), "should include original error: {}", result.detail);
+        assert_token_check_connectivity_failure(
+            mock_license_failure(SSL_HANDSHAKE_STDERR),
+            "SSLHandshakeException",
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn license_check_with_unreachable_server_reports_connectivity_failure() {
-        let _g = set_token("tok");
-        let cli = mock_license_failure(
-            "License check failed, could not reach CodeScene servers (https://wrong.ee/api/v2/tool-license/cli)"
-        );
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
-        assert!(!result.passed, "should detect unreachable server: {}", result.detail);
-        assert!(result.detail.contains("TLS/network"), "detail: {}", result.detail);
-        assert!(result.detail.contains("could not reach"), "should include original error: {}", result.detail);
+        assert_token_check_connectivity_failure(
+            mock_license_failure(
+                "License check failed, could not reach CodeScene servers (https://wrong.ee/api/v2/tool-license/cli)",
+            ),
+            "could not reach",
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -408,7 +474,8 @@ mod tests {
 
         let _g = set_token("tok");
         let short = std::time::Duration::from_millis(50);
-        let result = check_token_via_cli(Path::new("/tmp"), &HangingCli, short).await;
+        let creds = mock_credentials(MockCliRunner::with_ok(""));
+        let result = check_token_via_cli(Path::new("/tmp"), &HangingCli, &creds, short).await;
         assert!(!result.passed);
         assert!(result.detail.contains("timed out"));
     }
@@ -419,7 +486,7 @@ mod tests {
     async fn api_connectivity_succeeds() {
         let _g = set_token("tok");
         let http = MockHttpClient::always(HttpResponse::ok(r#"[{"id":1}]"#));
-        let result = check_api_connectivity(&http).await;
+        let result = check_api_connectivity(&http, None).await;
         assert!(result.passed);
         assert!(result.detail.contains("successfully"), "detail: {}", result.detail);
     }
@@ -428,7 +495,7 @@ mod tests {
     async fn api_connectivity_fails_on_transport_error() {
         let _g = set_token("tok");
         let http = MockHttpClient::new(vec![]);
-        let result = check_api_connectivity(&http).await;
+        let result = check_api_connectivity(&http, None).await;
         assert!(!result.passed);
         assert!(result.detail.contains("Could not reach"), "detail: {}", result.detail);
     }
@@ -437,7 +504,7 @@ mod tests {
     async fn api_connectivity_skipped_without_token() {
         let _g = clear_token();
         let http = MockHttpClient::new(vec![]);
-        let result = check_api_connectivity(&http).await;
+        let result = check_api_connectivity(&http, None).await;
         assert!(!result.passed);
         assert!(result.detail.contains("Skipped"), "detail: {}", result.detail);
     }
@@ -446,7 +513,7 @@ mod tests {
     async fn api_connectivity_fails_on_auth_error() {
         let _g = set_token("bad-token");
         let http = MockHttpClient::always(HttpResponse::error(401, "Unauthorized"));
-        let result = check_api_connectivity(&http).await;
+        let result = check_api_connectivity(&http, None).await;
         assert!(!result.passed);
         assert!(result.detail.contains("401"), "detail: {}", result.detail);
     }
@@ -631,31 +698,25 @@ mod tests {
 
     #[tokio::test]
     async fn handle_returns_success_result() {
-        let _g = set_token("tok");
-        let server = make_server_with_mocks(
-            false,
-            mock_cli_all_ok(),
-            MockHttpClient::always(HttpResponse::ok(r#"[{"id":1}]"#)),
-        );
-        let result = handle(&server, repo_param("/tmp")).await.unwrap();
-        assert!(result.is_error.is_none() || result.is_error == Some(false));
-        let text = crate::tests::result_text(&result);
-        assert!(text.contains("CLI Connectivity"), "API mode should also run CLI check: {text}");
-        assert!(text.contains("API Connectivity"), "API mode should run API check: {text}");
+        run_handle_verification(HandleVerificationCase {
+            standalone: false,
+            cli: mock_cli_all_ok(),
+            http: MockHttpClient::always(HttpResponse::ok(r#"[{"id":1}]"#)),
+            must_contain: &["CLI Connectivity", "API Connectivity"],
+            must_not_contain: &[],
+        })
+        .await;
     }
 
     #[tokio::test]
     async fn handle_runs_cli_connectivity_for_standalone() {
-        let _g = set_token("tok");
-        let server = make_server_with_mocks(
-            true,
-            mock_cli_all_ok(),
-            MockHttpClient::new(vec![]),
-        );
-        let result = handle(&server, repo_param("/tmp")).await.unwrap();
-        assert!(result.is_error.is_none() || result.is_error == Some(false));
-        let text = crate::tests::result_text(&result);
-        assert!(text.contains("CLI Connectivity"), "standalone should run CLI check: {text}");
-        assert!(!text.contains("API Connectivity"), "standalone should NOT run API check: {text}");
+        run_handle_verification(HandleVerificationCase {
+            standalone: true,
+            cli: mock_cli_all_ok(),
+            http: MockHttpClient::new(vec![]),
+            must_contain: &["CLI Connectivity"],
+            must_not_contain: &["API Connectivity"],
+        })
+        .await;
     }
 }


### PR DESCRIPTION
## Summary

- Add a `CredentialResolver` that obtains OAuth tokens from `cs auth token --client mcp`, caches expiry, and refreshes on 401.
- Wire OAuth bootstrap into MCP startup, API client retries, and `verify_installation` diagnostics.
- Document OAuth as the recommended auth path in README and configuration options; `CS_ACCESS_TOKEN` / config `access_token` still take precedence for CI and standalone use.

## Test plan

- [x] `cargo test --bin cs-mcp` (626 unit tests)
- [x] `pre_commit_code_health_safeguard` passes
- [ ] Sign in with `cs auth login --client mcp` (requires CLI build with `auth token`; set `CS_CLI_PATH` until embedded CLI is bumped)
- [ ] Run `verify_installation` without `CS_ACCESS_TOKEN` and confirm OAuth diagnostics + API/CLI checks pass
- [ ] Confirm PAT / `CS_ACCESS_TOKEN` still overrides OAuth when set