### PR TITLE
Add OAuth login tool and persist OAuth tokens

### DIFF
--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -41,16 +41,22 @@ Environment variables set by your MCP client always take precedence over values 
 | **Sensitive** | Yes (value is masked in tool output) |
 | **Required** | Yes, for most functionality |
 
-The primary authentication credential for the CodeScene MCP Server. This can be either a **Personal Access Token (PAT)** obtained from your CodeScene instance, or a **standalone access token** (if you purchased MCP separately).
+The primary authentication credential for the CodeScene MCP Server. This can be:
+
+- **OAuth access token** (recommended for interactive use) — obtained automatically via the `login` tool. No manual token handling required.
+- **Personal Access Token (PAT)** — obtained from your CodeScene instance. Suitable for CI/CD and headless environments.
+- **Standalone access token** — if you purchased MCP separately.
+
+When `CS_ACCESS_TOKEN` is set it always takes precedence over a stored OAuth session.
 
 The type of token determines which tools are available:
 
-- **CodeScene Personal Access Token** -- Enables the full tool set, including project-level features such as technical debt hotspots, goals, and code ownership lookups.
-- **Standalone access token** -- Enables local Code Health analysis tools only (scoring, review, refactoring). Project-level and API-dependent features are not available.
+- **OAuth / Personal Access Token** — Enables the full tool set, including project-level features such as technical debt hotspots, goals, and code ownership lookups.
+- **Standalone access token** — Enables local Code Health analysis tools only (scoring, review, refactoring). Project-level and API-dependent features are not available.
 
 Changing this value may require a **server restart** for tool registration changes to take effect.
 
-See [Getting a Personal Access Token](getting-a-personal-access-token.md) for instructions on creating a PAT.
+See [Authentication](getting-a-personal-access-token.md) for the recommended login flow and instructions on creating a PAT.
 
 ## `onprem_url`
 

--- a/docs/getting-a-personal-access-token.md
+++ b/docs/getting-a-personal-access-token.md
@@ -1,20 +1,48 @@
-# Getting an Access Token
+# Authentication
 
-An access token is required to authenticate with the CodeScene MCP Server.
+The CodeScene MCP Server supports two authentication methods.
 
-## 1) Standalone MCP Token
+## Recommended: OAuth Login
+
+For interactive desktop use, no token needs to be manually obtained or configured. Simply ask your AI assistant:
+
+> "Log me in to CodeScene"
+
+The assistant will call the `login` tool, which opens your browser to complete the OAuth flow. Once done, the MCP server is authenticated for the session.
+
+**For CodeScene Cloud:** no extra configuration needed — just call `login`.
+
+**For CodeScene on-prem:** configure your instance URL first, then log in:
+
+> "Set my CodeScene on-prem URL to https://codescene.mycompany.com"
+
+> "Log me in to CodeScene"
+
+---
+
+## Alternative: Personal Access Token (PAT)
+
+Use a PAT when OAuth is not suitable — for example in CI/CD pipelines, headless environments, or when you prefer a static credential.
+
+Set the token by asking your AI assistant:
+
+> "Set my CodeScene access token to &lt;your-token&gt;"
+
+Or set `CS_ACCESS_TOKEN` directly in your MCP client configuration. `CS_ACCESS_TOKEN` always takes precedence over a stored OAuth session when set.
+
+### Standalone MCP Token
 
 If you want a standalone MCP token (without connecting through a CodeScene Cloud or on-prem instance), sign up here:
 
 👉 **[CodeScene MCP Server](https://codescene.com/product/mcp-server)**
 
-## 2) CodeScene Cloud Personal Access Token (PAT)
+### CodeScene Cloud PAT
 
 If you're using CodeScene Cloud, create your token here:
 
 👉 **[Create a Personal Access Token](https://codescene.io/users/me/pat)**
 
-## 3) CodeScene On-Prem Personal Access Token (PAT)
+### CodeScene On-Prem PAT
 
 If you're using CodeScene on-prem, follow these steps to create a Personal Access Token:
 
@@ -30,14 +58,16 @@ If you're using CodeScene on-prem, follow these steps to create a Personal Acces
 4. **Create a new Personal Access Token**  
    Click **Personal Access Tokens** under the Authentication & User Management section to create a new token.
 
-Alternatively, you can navigate directly to:
+Alternatively, navigate directly to:
 
 ```
 https://<your-cs-host><:port>/configuration/user/token
 ```
 
-## Using Your Token
+---
 
-Once you have your token, see [Configuration Options](configuration-options.md) for how to set it up with the MCP server.
+## Further Configuration
+
+See [Configuration Options](configuration-options.md) for all available settings.
 
 > ⚠️ **Keep your token secure!** Treat it like a password and never commit it to version control.

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -2,30 +2,37 @@ use std::collections::HashMap;
 
 use serde_json::Value;
 
+use crate::auth::AuthCredential;
 use crate::errors::ApiError;
 use crate::http::{HttpClient, HttpRequest, HttpResponse, Method};
 
-pub fn get_api_url() -> Result<String, ApiError> {
-    if let Ok(url) = std::env::var("CS_ONPREM_URL") {
-        crate::config::require_https("CS_ONPREM_URL", &url)
-            .map_err(|e| ApiError::Transport(e.into()))?;
-        Ok(format!("{}/api", url.trim_end_matches('/')))
-    } else {
-        Ok("https://api.codescene.io".to_string())
-    }
-}
-
+#[cfg(test)]
 pub async fn query_api_with_client(
     endpoint: &str,
     client: &dyn HttpClient,
 ) -> Result<Value, ApiError> {
-    let url = format!("{}/{}", get_api_url()?, endpoint.trim_start_matches('/'));
-    query_api_url_with_client(&url, client).await
+    query_api_with_auth(endpoint, client, None).await
 }
 
-async fn query_api_url_with_client(url: &str, client: &dyn HttpClient) -> Result<Value, ApiError> {
-    let token = std::env::var("CS_ACCESS_TOKEN").unwrap_or_default();
-    let token = token.trim();
+pub async fn query_api_with_auth(
+    endpoint: &str,
+    client: &dyn HttpClient,
+    credential: Option<&AuthCredential>,
+) -> Result<Value, ApiError> {
+    let url = format!(
+        "{}/{}",
+        api_url_for(credential)?,
+        endpoint.trim_start_matches('/')
+    );
+    query_api_url_with_auth(&url, client, credential).await
+}
+
+async fn query_api_url_with_auth(
+    url: &str,
+    client: &dyn HttpClient,
+    credential: Option<&AuthCredential>,
+) -> Result<Value, ApiError> {
+    let token = credential.map(AuthCredential::access_token).unwrap_or("");
 
     let request = HttpRequest {
         method: Method::Get,
@@ -71,9 +78,18 @@ fn parse_api_response(resp: HttpResponse) -> Result<Value, ApiError> {
     })
 }
 
+#[cfg(test)]
 pub async fn query_api_list_with_client(
     endpoint: &str,
     client: &dyn HttpClient,
+) -> Result<Vec<Value>, ApiError> {
+    query_api_list_with_auth(endpoint, client, None).await
+}
+
+pub async fn query_api_list_with_auth(
+    endpoint: &str,
+    client: &dyn HttpClient,
+    credential: Option<&AuthCredential>,
 ) -> Result<Vec<Value>, ApiError> {
     let mut results = Vec::new();
     let mut page = 1;
@@ -81,7 +97,7 @@ pub async fn query_api_list_with_client(
     loop {
         let sep = if endpoint.contains('?') { '&' } else { '?' };
         let paged = format!("{endpoint}{sep}page={page}");
-        let data = query_api_with_client(&paged, client).await?;
+        let data = query_api_with_auth(&paged, client, credential).await?;
 
         let items = match data.as_array() {
             Some(arr) => arr,
@@ -97,11 +113,22 @@ pub async fn query_api_list_with_client(
     Ok(results)
 }
 
+#[cfg(test)]
 pub async fn query_api_keyed_list_with_client(
     endpoint: &str,
     params: &[(String, String)],
     key: &str,
     client: &dyn HttpClient,
+) -> Result<Vec<Value>, ApiError> {
+    query_api_keyed_list_with_auth(endpoint, params, key, client, None).await
+}
+
+pub async fn query_api_keyed_list_with_auth(
+    endpoint: &str,
+    params: &[(String, String)],
+    key: &str,
+    client: &dyn HttpClient,
+    credential: Option<&AuthCredential>,
 ) -> Result<Vec<Value>, ApiError> {
     let mut all_items = Vec::new();
     let mut current_page: i64 = 1;
@@ -110,8 +137,8 @@ pub async fn query_api_keyed_list_with_client(
         let mut query_params = params.to_vec();
         upsert_query_param(&mut query_params, "page", &current_page.to_string());
 
-        let url = endpoint_with_query_params(endpoint, &query_params)?;
-        let data = query_api_url_with_client(&url, client).await?;
+        let url = endpoint_with_query_params(endpoint, &query_params, credential)?;
+        let data = query_api_url_with_auth(&url, client, credential).await?;
 
         let items = data
             .get(key)
@@ -139,12 +166,21 @@ pub async fn query_api_keyed_list_with_client(
     Ok(all_items)
 }
 
+#[cfg(test)]
 pub async fn get_latest_analysis_id(
     project_id: i64,
     client: &dyn HttpClient,
 ) -> Result<i64, ApiError> {
+    get_latest_analysis_id_with_auth(project_id, client, None).await
+}
+
+pub async fn get_latest_analysis_id_with_auth(
+    project_id: i64,
+    client: &dyn HttpClient,
+    credential: Option<&AuthCredential>,
+) -> Result<i64, ApiError> {
     let endpoint = format!("v2/projects/{project_id}/analyses/latest");
-    let data = query_api_with_client(&endpoint, client).await?;
+    let data = query_api_with_auth(&endpoint, client, credential).await?;
     data.get("id")
         .and_then(|v| v.as_i64())
         .ok_or_else(|| ApiError::Transport("Missing 'id' in analysis response".into()))
@@ -153,8 +189,13 @@ pub async fn get_latest_analysis_id(
 fn endpoint_with_query_params(
     endpoint: &str,
     params: &[(String, String)],
+    credential: Option<&AuthCredential>,
 ) -> Result<String, ApiError> {
-    let base = format!("{}/{}", get_api_url()?, endpoint.trim_start_matches('/'));
+    let base = format!(
+        "{}/{}",
+        api_url_for(credential)?,
+        endpoint.trim_start_matches('/')
+    );
     let mut url = reqwest::Url::parse(&base)
         .map_err(|e| ApiError::Transport(format!("invalid API URL: {e}")))?;
     {
@@ -164,6 +205,13 @@ fn endpoint_with_query_params(
         }
     }
     Ok(url.to_string())
+}
+
+fn api_url_for(credential: Option<&AuthCredential>) -> Result<String, ApiError> {
+    match credential {
+        Some(auth) => auth.api_root(),
+        None => crate::auth::default_api_root(),
+    }
 }
 
 fn upsert_query_param(params: &mut Vec<(String, String)>, key: &str, value: &str) {
@@ -199,6 +247,10 @@ mod tests {
         std::env::remove_var("CS_ACCESS_TOKEN");
     }
 
+    fn configured_auth() -> crate::auth::AuthCredential {
+        crate::auth::configured_credential().unwrap()
+    }
+
     fn assert_status_error(err: ApiError, expected_status: u16) {
         match err {
             ApiError::Status { status, .. } => assert_eq!(status, expected_status),
@@ -207,33 +259,45 @@ mod tests {
     }
 
     #[test]
-    fn get_api_url_default() {
+    fn default_api_root_cloud() {
         let _lock = config::lock_test_env();
         std::env::remove_var("CS_ONPREM_URL");
-        assert_eq!(get_api_url().unwrap(), "https://api.codescene.io");
+        assert_eq!(
+            crate::auth::default_api_root().unwrap(),
+            "https://api.codescene.io"
+        );
     }
 
     #[test]
-    fn get_api_url_onprem() {
+    fn default_api_root_onprem() {
         let _lock = config::lock_test_env();
         std::env::set_var("CS_ONPREM_URL", "https://my-instance.com");
-        assert_eq!(get_api_url().unwrap(), "https://my-instance.com/api");
+        assert_eq!(
+            crate::auth::default_api_root().unwrap(),
+            "https://my-instance.com/api"
+        );
         std::env::remove_var("CS_ONPREM_URL");
     }
 
     #[test]
-    fn get_api_url_onprem_trailing_slash() {
+    fn default_api_root_onprem_trailing_slash() {
         let _lock = config::lock_test_env();
         std::env::set_var("CS_ONPREM_URL", "https://my-instance.com/");
-        assert_eq!(get_api_url().unwrap(), "https://my-instance.com/api");
+        assert_eq!(
+            crate::auth::default_api_root().unwrap(),
+            "https://my-instance.com/api"
+        );
         std::env::remove_var("CS_ONPREM_URL");
     }
 
     #[test]
-    fn get_api_url_onprem_http_blocked() {
+    fn default_api_root_onprem_http_blocked() {
         let _lock = config::lock_test_env();
         std::env::set_var("CS_ONPREM_URL", "http://my-instance.com");
-        assert!(get_api_url().is_err(), "HTTP URLs should be blocked");
+        assert!(
+            crate::auth::default_api_root().is_err(),
+            "HTTP URLs should be blocked"
+        );
         std::env::remove_var("CS_ONPREM_URL");
     }
 
@@ -277,9 +341,10 @@ mod tests {
         let captured = mock.captured_requests.clone();
 
         // First request: normal endpoint
-        let _ = query_api_with_client("v2/test", &mock).await;
+        let auth = configured_auth();
+        let _ = query_api_with_auth("v2/test", &mock, Some(&auth)).await;
         // Second request: leading-slash endpoint
-        let _ = query_api_with_client("/v2/test", &mock).await;
+        let _ = query_api_with_auth("/v2/test", &mock, Some(&auth)).await;
 
         let reqs = captured.lock().unwrap();
         assert_eq!(reqs.len(), 2);
@@ -307,7 +372,8 @@ mod tests {
         let mock = MockHttpClient::always(HttpResponse::ok(r#"{}"#));
         let captured = mock.captured_requests.clone();
 
-        let _ = query_api_with_client("v2/test", &mock).await;
+        let auth = configured_auth();
+        let _ = query_api_with_auth("v2/test", &mock, Some(&auth)).await;
 
         let reqs = captured.lock().unwrap();
         assert_eq!(reqs.len(), 1);
@@ -455,11 +521,11 @@ mod tests {
     fn endpoint_with_query_params_appends_correct_separator() {
         let _g = lock_api_env("tok");
         let params = vec![("a".to_string(), "1".to_string())];
-        let one = endpoint_with_query_params("v2/test", &params).unwrap();
+        let one = endpoint_with_query_params("v2/test", &params, None).unwrap();
         assert!(one.starts_with("https://api.codescene.io/v2/test?"));
         assert!(one.contains("a=1"));
 
-        let two = endpoint_with_query_params("v2/test?x=y", &params).unwrap();
+        let two = endpoint_with_query_params("v2/test?x=y", &params, None).unwrap();
         assert!(two.starts_with("https://api.codescene.io/v2/test?"));
         assert!(two.contains("x=y"));
         assert!(two.contains("a=1"));

--- a/src/auth/manager.rs
+++ b/src/auth/manager.rs
@@ -1,7 +1,3 @@
-use std::sync::Arc;
-
-use tokio::sync::{Mutex, RwLock};
-
 use crate::cli::CliRunner;
 
 use super::{
@@ -11,191 +7,380 @@ use super::{
 
 /// Tokens are considered stale this many seconds before their actual `expires-at`.
 /// This avoids making an API call with a token that's about to expire mid-flight.
-/// 120 s was chosen to accommodate typical request round-trip + CLI overhead.
 const TOKEN_EXPIRY_MARGIN_SECS: i64 = 60;
 
-/// When the CLI response does not include `expires-at` (older CLI versions),
-/// we cache the response for this duration before re-checking. 5 minutes is
-/// conservative enough to avoid excess CLI calls while limiting staleness.
-const TOKEN_FALLBACK_TTL_SECS: i64 = 300;
+/// Sentinel value for `CS_OAUTH_EXPIRES_AT` indicating the user is signed out
+/// and we should not retry the CLI until an explicit login is requested.
+const SIGNED_OUT_SENTINEL: &str = "0";
 
-/// Time to cache a "signed out" result to avoid launching the CLI on every
-/// tool call when no credentials are configured.
-const SIGNED_OUT_CACHE_TTL_SECS: i64 = 30;
-
-/// Manages OAuth token lifecycle: caching, expiry-aware refresh, and
-/// serialization of concurrent CLI calls behind a single mutex.
-#[derive(Clone)]
-pub(crate) struct AuthManager {
-    cache: Arc<RwLock<Option<CachedToken>>>,
-    refresh_lock: Arc<Mutex<()>>,
-    /// Timestamp of the last "signed out" response. Used for negative caching.
-    signed_out_at: Arc<RwLock<Option<i64>>>,
-}
-
-#[derive(Clone, Debug)]
-struct CachedToken {
-    response: CliTokenResponse,
-    cached_at: i64,
-}
+/// Manages OAuth token lifecycle using the config env RwLock for all state.
+///
+/// All OAuth state lives in process env vars (backed by config file):
+/// - `CS_OAUTH_TOKEN` — the access token
+/// - `CS_OAUTH_EXPIRES_AT` — expiry as epoch seconds, or "0" for signed-out
+/// - `CS_OAUTH_REFRESH_EXPIRES_AT` — refresh token expiry
+///
+/// The config `RwLock` serializes reads and writes. CLI calls that refresh
+/// tokens hold the write lock for the entire duration (including the CLI
+/// subprocess wait) to prevent concurrent refresh attempts and ensure
+/// consistent state.
+#[derive(Clone, Default)]
+pub(crate) struct AuthManager;
 
 impl AuthManager {
     pub(crate) fn new() -> Self {
-        Self {
-            cache: Arc::new(RwLock::new(None)),
-            refresh_lock: Arc::new(Mutex::new(())),
-            signed_out_at: Arc::new(RwLock::new(None)),
-        }
+        Self
     }
 
+    /// Resolve the best available credential.
+    /// Priority: PAT (CS_ACCESS_TOKEN) > fresh OAuth token > CLI refresh > None.
     pub(crate) async fn resolve_credential(
         &self,
         cli_runner: &dyn CliRunner,
     ) -> Result<Option<AuthCredential>, String> {
+        // PAT takes priority.
         if let Some(credential) = configured_credential() {
+            tracing::info!(source = "configured", "resolved auth credential from configured token");
             return Ok(Some(credential));
         }
-        Ok(self
-            .current_token(cli_runner)
-            .await?
-            .and_then(|resp| credential_from_response(&resp)))
+        // Check persisted OAuth token.
+        if let Some(cred) = Self::fresh_oauth_credential() {
+            tracing::info!(
+                source = "oauth_cache",
+                has_onprem_url = cred.api_root().ok().is_some(),
+                "resolved auth credential from cached OAuth token"
+            );
+            return Ok(Some(cred));
+        }
+        // Token missing or expired — try to refresh via CLI.
+        tracing::info!(
+            has_oauth_token = crate::config::try_read_env("CS_OAUTH_TOKEN").is_some(),
+            oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT"),
+            signed_out_sentinel = Self::is_signed_out(),
+            "no usable cached credential; attempting CLI auth token refresh"
+        );
+        self.refresh_token(cli_runner).await
     }
 
-    /// Get the current OAuth token (from cache or by refreshing via CLI).
+    /// Get the current OAuth token if it exists and is fresh.
     /// Does NOT check `configured_credential()` — callers that need to prefer
     /// a user-configured PAT should use `resolve_credential` instead.
-    /// Used directly by `login::try_existing_session` which has already
-    /// short-circuited on configured credentials at the handler level.
     pub(crate) async fn current_token(
         &self,
         cli_runner: &dyn CliRunner,
     ) -> Result<Option<CliTokenResponse>, String> {
-        if let Some(cached) = self.fresh_cached_token().await {
-            return Ok(Some(cached.response));
+        // Check if we have a fresh token in env.
+        if Self::has_fresh_oauth_token() {
+            // Build a synthetic CliTokenResponse from env for compatibility.
+            return Ok(Self::token_response_from_env());
         }
-
-        if self.recently_signed_out().await {
+        // If signed out (sentinel), don't retry automatically.
+        if Self::is_signed_out() {
             return Ok(None);
         }
-
-        let _guard = self.refresh_lock.lock().await;
-        if let Some(cached) = self.fresh_cached_token().await {
-            return Ok(Some(cached.response));
+        // Refresh via CLI under write lock.
+        match self.refresh_token_raw(cli_runner).await? {
+            Some(resp) => Ok(Some(resp)),
+            None => Ok(None),
         }
-        if self.recently_signed_out().await {
-            return Ok(None);
-        }
-
-        let token = fetch_token(cli_runner).await?;
-        if let Some(resp) = token.as_ref() {
-            self.store_at(resp.clone(), now_epoch_secs()).await;
-        } else {
-            self.mark_signed_out().await;
-        }
-        Ok(token)
     }
 
-    /// Run the interactive login flow. Serialized with token refreshes.
+    /// Run the interactive login flow. Holds the config write lock for the
+    /// entire duration (browser flow may take up to 2 minutes).
     pub(crate) async fn login(
         &self,
         cli_runner: &dyn CliRunner,
     ) -> Result<CliTokenResponse, String> {
-        let _guard = self.refresh_lock.lock().await;
+        let guard = crate::config::acquire_write_lock().await;
+
+        // Double-check: maybe another call just completed login.
+        if Self::guard_has_fresh_oauth_token(&guard) {
+            let cached = Self::build_token_response_from_guard(&guard);
+            tracing::info!(
+                oauth_expires_at = cached.expires_at,
+                has_oauth_token = cached
+                    .access_token
+                    .as_deref()
+                    .is_some_and(|token| !token.trim().is_empty()),
+                "skipping interactive login because a fresh cached OAuth token already exists"
+            );
+            return Ok(cached);
+        }
+
         let resp = run_login(cli_runner).await?;
         if resp.is_signed_in() {
-            self.store_at(resp.clone(), now_epoch_secs()).await;
+            let persisted = if response_has_access_token(&resp) {
+                Self::persist_response(&guard, &resp);
+                resp.clone()
+            } else {
+                tracing::info!(
+                    status = %resp.status,
+                    "login response did not include an access token; fetching token export from CLI"
+                );
+                let token_resp = fetch_token(cli_runner).await?.ok_or_else(|| {
+                    "CLI login succeeded but token export remained unavailable".to_string()
+                })?;
+                Self::persist_response(&guard, &token_resp);
+                token_resp
+            };
+            tracing::info!(
+                status = %persisted.status,
+                has_access_token = response_has_access_token(&persisted),
+                expires_at = persisted.expires_at,
+                refresh_expires_at = persisted.refresh_token_expires_at,
+                "persisted OAuth login response"
+            );
+            return Ok(persisted);
         } else {
-            self.mark_signed_out().await;
+            Self::persist_signed_out(&guard);
+            tracing::info!(status = %resp.status, "login response was not signed in; persisted signed-out sentinel");
         }
         Ok(resp)
     }
 
-    async fn fresh_cached_token(&self) -> Option<CachedToken> {
-        let guard = self.cache.read().await;
-        guard.as_ref().filter(|cached| cached.is_fresh()).cloned()
-    }
-
-    async fn recently_signed_out(&self) -> bool {
-        let guard = self.signed_out_at.read().await;
-        guard
-            .map(|ts| now_epoch_secs() - ts < SIGNED_OUT_CACHE_TTL_SECS)
-            .unwrap_or(false)
-    }
-
-    async fn mark_signed_out(&self) {
-        // Clear cache and mark signed-out together to avoid a window where
-        // a reader sees empty cache + recently_signed_out == false.
-        {
-            let mut guard = self.cache.write().await;
-            *guard = None;
+    /// Try to read a fresh OAuth credential from env.
+    fn fresh_oauth_credential() -> Option<AuthCredential> {
+        let vals = crate::config::try_read_env_multi(&[
+            "CS_OAUTH_TOKEN",
+            "CS_OAUTH_EXPIRES_AT",
+            "CS_ONPREM_URL",
+        ])?;
+        let token = vals[0].as_deref()?.trim().to_string();
+        if token.is_empty() {
+            tracing::info!(
+                oauth_expires_at = vals[1].clone(),
+                "cached OAuth state has no access token"
+            );
+            return None;
         }
-        let mut guard = self.signed_out_at.write().await;
-        *guard = Some(now_epoch_secs());
-    }
-
-    async fn store_at(&self, response: CliTokenResponse, cached_at: i64) {
-        {
-            let mut guard = self.cache.write().await;
-            *guard = Some(CachedToken {
-                response,
-                cached_at,
-            });
+        // Check expiry.
+        if let Some(expires_str) = vals[1].as_deref() {
+            if let Ok(expires_at) = expires_str.parse::<i64>() {
+                if expires_at <= now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS {
+                    tracing::info!(oauth_expires_at = expires_at, "cached OAuth token is expired or within refresh margin");
+                    return None; // expired or signed-out sentinel
+                }
+            }
         }
-        // A successful store invalidates any negative cache.
-        let mut signed_out = self.signed_out_at.write().await;
-        *signed_out = None;
+        let onprem_url = vals[2]
+            .as_deref()
+            .map(|v| v.trim().trim_end_matches('/').to_string())
+            .filter(|v| !v.is_empty());
+        Some(AuthCredential::OAuth {
+            access_token: token,
+            onprem_url,
+        })
     }
 
-    /// Synchronously try to read the cached OAuth credentials for tracking.
-    /// Returns `(access_token, normalized_api_root)` if the cache is available and populated.
-    /// Returns `(None, None)` if the cache is empty or contended.
-    /// Used for fire-and-forget operations (like tracking) that can't await.
-    fn try_cached_auth_info(&self) -> (Option<String>, Option<String>) {
-        let Some(guard) = self.cache.try_read().ok() else {
-            return (None, None);
+    /// Check if we have a non-expired OAuth token in env.
+    fn has_fresh_oauth_token() -> bool {
+        Self::fresh_oauth_credential().is_some()
+    }
+
+    fn guard_has_fresh_oauth_token(guard: &crate::config::ConfigEnvWriteGuard) -> bool {
+        let Some(token) = guard.read_env("CS_OAUTH_TOKEN") else {
+            return false;
         };
-        let Some(cached) = guard.as_ref() else {
-            return (None, None);
+        if token.trim().is_empty() {
+            return false;
+        }
+        let Some(expires_str) = guard.read_env("CS_OAUTH_EXPIRES_AT") else {
+            return false;
         };
-        let token = cached
-            .response
+        let Ok(expires_at) = expires_str.parse::<i64>() else {
+            return false;
+        };
+        expires_at > now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS
+    }
+
+    /// Check if the signed-out sentinel is set.
+    fn is_signed_out() -> bool {
+        crate::config::try_read_env("CS_OAUTH_EXPIRES_AT")
+            .as_deref()
+            == Some(SIGNED_OUT_SENTINEL)
+    }
+
+    /// Build a synthetic `CliTokenResponse` from env vars (for compatibility
+    /// with callers that expect a response object).
+    fn token_response_from_env() -> Option<CliTokenResponse> {
+        let vals = crate::config::try_read_env_multi(&[
+            "CS_OAUTH_TOKEN",
+            "CS_OAUTH_EXPIRES_AT",
+            "CS_OAUTH_REFRESH_EXPIRES_AT",
+            "CS_ONPREM_URL",
+        ])?;
+        let token = vals[0].clone()?;
+        let expires_at = vals[1].as_deref().and_then(|s| s.parse::<i64>().ok());
+        let refresh_expires_at = vals[2].as_deref().and_then(|s| s.parse::<i64>().ok());
+        let api_url = vals[3]
+            .as_deref()
+            .map(|u| format!("{}/api", u.trim_end_matches('/')));
+        Some(CliTokenResponse {
+            status: "signed_in".into(),
+            access_token: Some(token),
+            api_url,
+            expires_at,
+            refresh_token_expires_at: refresh_expires_at,
+        })
+    }
+
+    /// Refresh token via CLI, acquiring the config write lock.
+    /// Returns the resolved credential or None.
+    async fn refresh_token(
+        &self,
+        cli_runner: &dyn CliRunner,
+    ) -> Result<Option<AuthCredential>, String> {
+        let resp = self.refresh_token_raw(cli_runner).await?;
+        let credential = resp.and_then(|r| credential_from_response(&r));
+        tracing::info!(resolved = credential.is_some(), "completed CLI auth token refresh");
+        Ok(credential)
+    }
+
+    /// Refresh token via CLI under the config write lock.
+    /// Returns the raw CliTokenResponse.
+    async fn refresh_token_raw(
+        &self,
+        cli_runner: &dyn CliRunner,
+    ) -> Result<Option<CliTokenResponse>, String> {
+        let guard = crate::config::acquire_write_lock().await;
+
+        // Double-check under write lock: another thread may have refreshed.
+        if Self::guard_has_fresh_oauth_token(&guard) {
+            let cached = Self::build_token_response_from_guard(&guard);
+            tracing::info!(
+                oauth_expires_at = cached.expires_at,
+                has_oauth_token = cached
+                    .access_token
+                    .as_deref()
+                    .is_some_and(|token| !token.trim().is_empty()),
+                "reusing OAuth token that appeared while waiting for auth lock"
+            );
+            return Ok(Some(cached));
+        }
+
+        if guard.read_env("CS_OAUTH_EXPIRES_AT").as_deref() == Some(SIGNED_OUT_SENTINEL) {
+            tracing::info!("skipping CLI auth token refresh because signed-out sentinel is set");
+            return Ok(None);
+        }
+
+        tracing::info!("running CLI auth token refresh");
+        let token = fetch_token(cli_runner).await?;
+        match token {
+            Some(resp) if resp.is_signed_in() => {
+                Self::persist_response(&guard, &resp);
+                tracing::info!(
+                    status = %resp.status,
+                    has_access_token = resp.access_token.as_deref().is_some_and(|t| !t.trim().is_empty()),
+                    expires_at = resp.expires_at,
+                    refresh_expires_at = resp.refresh_token_expires_at,
+                    "CLI auth token refresh succeeded"
+                );
+                Ok(Some(resp))
+            }
+            _ => {
+                Self::persist_signed_out(&guard);
+                tracing::info!("CLI auth token refresh reported signed-out state; persisted sentinel");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Persist a successful token response to env + config under the write lock.
+    fn persist_response(guard: &crate::config::ConfigEnvWriteGuard, response: &CliTokenResponse) {
+        let token = response
             .access_token
             .as_deref()
-            .map(|t| t.trim().to_string())
-            .filter(|t| !t.is_empty());
-        let api_root =
-            credential_from_response(&cached.response).and_then(|cred| cred.api_root().ok());
-        (token, api_root)
+            .unwrap_or("")
+            .trim();
+        let expires_at = response
+            .expires_at
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+        let refresh_expires_at = response
+            .refresh_token_expires_at
+            .map(|v| v.to_string())
+            .unwrap_or_default();
+
+        let entries: &[(&str, &str)] = &[
+            ("oauth_token", token),
+            ("oauth_expires_at", &expires_at),
+            ("oauth_refresh_expires_at", &refresh_expires_at),
+        ];
+
+        if let Err(e) = guard.write_env_multi(entries) {
+            tracing::warn!(error = %e, "failed to persist OAuth state to config file");
+        }
+        tracing::info!(
+            has_access_token = !token.is_empty(),
+            expires_at = %expires_at,
+            refresh_expires_at = %refresh_expires_at,
+            "persisted OAuth state to config-backed environment"
+        );
     }
 
+    /// Write the signed-out sentinel to env + config under the write lock.
+    fn persist_signed_out(guard: &crate::config::ConfigEnvWriteGuard) {
+        let entries: &[(&str, &str)] = &[
+            ("oauth_token", ""),
+            ("oauth_expires_at", SIGNED_OUT_SENTINEL),
+            ("oauth_refresh_expires_at", ""),
+        ];
+        if let Err(e) = guard.write_env_multi(entries) {
+            tracing::warn!(error = %e, "failed to persist signed-out state to config file");
+        }
+        tracing::info!("persisted signed-out sentinel to config-backed environment");
+    }
+
+    /// Build a CliTokenResponse from env while holding the write guard.
+    fn build_token_response_from_guard(
+        guard: &crate::config::ConfigEnvWriteGuard,
+    ) -> CliTokenResponse {
+        let token = guard.read_env("CS_OAUTH_TOKEN");
+        let expires_at = guard
+            .read_env("CS_OAUTH_EXPIRES_AT")
+            .and_then(|s| s.parse::<i64>().ok());
+        let refresh_expires_at = guard
+            .read_env("CS_OAUTH_REFRESH_EXPIRES_AT")
+            .and_then(|s| s.parse::<i64>().ok());
+        let api_url = guard
+            .read_env("CS_ONPREM_URL")
+            .map(|u| format!("{}/api", u.trim_end_matches('/')));
+        CliTokenResponse {
+            status: "signed_in".into(),
+            access_token: token,
+            api_url,
+            expires_at,
+            refresh_token_expires_at: refresh_expires_at,
+        }
+    }
+
+    /// Synchronously try to read the OAuth token for tracking purposes.
+    /// Returns `None` if not available.
     pub(crate) fn try_cached_access_token(&self) -> Option<String> {
-        self.try_cached_auth_info().0
+        crate::config::try_read_env("CS_OAUTH_TOKEN")
     }
 
+    /// Synchronously try to read the OAuth API root for tracking purposes.
     pub(crate) fn try_cached_api_root(&self) -> Option<String> {
-        self.try_cached_auth_info().1
+        Self::fresh_oauth_credential().and_then(|cred| cred.api_root().ok())
     }
 
     #[cfg(test)]
-    pub(crate) async fn set_cached_response(&self, response: CliTokenResponse, cached_at: i64) {
-        self.store_at(response, cached_at).await;
+    pub(crate) async fn set_cached_response(
+        &self,
+        response: CliTokenResponse,
+        _cached_at: i64,
+    ) {
+        let guard = crate::config::acquire_write_lock().await;
+        Self::persist_response(&guard, &response);
     }
 }
 
-impl Default for AuthManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl CachedToken {
-    fn is_fresh(&self) -> bool {
-        let now = now_epoch_secs();
-        match self.response.expires_at {
-            Some(expires_at) => expires_at > now + TOKEN_EXPIRY_MARGIN_SECS,
-            None => self.cached_at + TOKEN_FALLBACK_TTL_SECS > now,
-        }
-    }
+fn response_has_access_token(response: &CliTokenResponse) -> bool {
+    response
+        .access_token
+        .as_deref()
+        .is_some_and(|token| !token.trim().is_empty())
 }
 
 #[cfg(test)]
@@ -223,135 +408,118 @@ mod tests {
         )
     }
 
+    fn clean_oauth_env() {
+        std::env::remove_var("CS_ACCESS_TOKEN");
+        std::env::remove_var("CS_OAUTH_TOKEN");
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+        std::env::remove_var("CS_OAUTH_REFRESH_EXPIRES_AT");
+    }
+
     async fn with_clean_env<F, Fut>(f: F)
     where
         F: FnOnce() -> Fut,
         Fut: std::future::Future<Output = ()>,
     {
         let _lock = with_env_lock();
-        std::env::remove_var("CS_ACCESS_TOKEN");
+        clean_oauth_env();
         f().await;
-        std::env::remove_var("CS_ACCESS_TOKEN");
+        clean_oauth_env();
     }
 
-    struct EnsureTokenCase<'a> {
-        name: &'a str,
-        cached_token: Option<&'a str>,
-        cached_expires_at: Option<i64>,
-        preset_env: Option<&'a str>,
-        cli_response: Option<&'a str>,
-        expect_token: &'a str,
-        expect_cli_calls: usize,
-        expect_env_token: Option<&'a str>,
+    fn empty_cli() -> MockCliRunner {
+        MockCliRunner::with_responses(vec![])
     }
 
-    /// Runs a single resolve_credential scenario: seeds cache, calls auth, checks result.
-    async fn assert_resolve_credential(case: &EnsureTokenCase<'_>) {
-        let _lock = with_env_lock();
-        std::env::remove_var("CS_ACCESS_TOKEN");
+    fn cli_call_count(cli: &MockCliRunner) -> usize {
+        cli.calls().lock().unwrap().len()
+    }
+
+    async fn assert_resolve_credential(
+        setup: impl FnOnce(),
+        cli: MockCliRunner,
+        expected_token: Option<&str>,
+        expected_cli_calls: usize,
+    ) {
         let manager = AuthManager::new();
-        if let Some(token) = case.cached_token {
-            let mut resp = make_response(Some(token), Some("https://api.codescene.io/api"));
-            resp.expires_at = case.cached_expires_at;
-            manager.set_cached_response(resp, now_epoch_secs()).await;
-        }
-        if let Some(env_val) = case.preset_env {
-            std::env::set_var("CS_ACCESS_TOKEN", env_val);
-        }
-        let cli = match case.cli_response {
-            Some(json) => MockCliRunner::with_ok(json),
-            None => MockCliRunner::with_responses(vec![]),
-        };
-        let credential = manager.resolve_credential(&cli).await.unwrap().unwrap();
-        assert_eq!(
-            credential.access_token(),
-            case.expect_token,
-            "{}",
-            case.name
-        );
-        match case.expect_env_token {
-            Some(token) => assert_eq!(std::env::var("CS_ACCESS_TOKEN").unwrap(), token),
-            None => assert!(std::env::var("CS_ACCESS_TOKEN").is_err()),
-        }
-        assert_eq!(
-            cli.calls().lock().unwrap().len(),
-            case.expect_cli_calls,
-            "{}",
-            case.name
-        );
-        std::env::remove_var("CS_ACCESS_TOKEN");
+        setup();
+        let result = manager.resolve_credential(&cli).await.unwrap();
+        assert_eq!(result.as_ref().map(|cred| cred.access_token()), expected_token);
+        assert_eq!(cli_call_count(&cli), expected_cli_calls);
+    }
+
+    async fn assert_current_token(
+        setup: impl FnOnce(),
+        cli: MockCliRunner,
+        expected_token: Option<&str>,
+        expected_cli_calls: usize,
+    ) {
+        let manager = AuthManager::new();
+        setup();
+        let result = manager.current_token(&cli).await.unwrap();
+        assert_eq!(result.as_ref().and_then(|resp| resp.access_token.as_deref()), expected_token);
+        assert_eq!(cli_call_count(&cli), expected_cli_calls);
     }
 
     #[tokio::test]
-    async fn resolve_credential_cache_scenarios() {
-        let fresh = signed_in_json("fresh-token", now_epoch_secs() + 3600);
-        let refreshed = signed_in_json("refreshed", now_epoch_secs() + 7200);
-        let cases = [
-            EnsureTokenCase {
-                name: "fresh cache",
-                cached_token: Some("cached-token"),
-                cached_expires_at: None,
-                preset_env: None,
-                cli_response: None,
-                expect_token: "cached-token",
-                expect_cli_calls: 0,
-                expect_env_token: None,
-            },
-            EnsureTokenCase {
-                name: "expired",
-                cached_token: Some("expired-token"),
-                cached_expires_at: Some(now_epoch_secs() - 10),
-                preset_env: None,
-                cli_response: Some(&fresh),
-                expect_token: "fresh-token",
-                expect_cli_calls: 1,
-                expect_env_token: None,
-            },
-            EnsureTokenCase {
-                name: "configured env",
-                cached_token: Some("expired-token"),
-                cached_expires_at: Some(now_epoch_secs() - 10),
-                preset_env: Some("pat-token"),
-                cli_response: Some(&fresh),
-                expect_token: "pat-token",
-                expect_cli_calls: 0,
-                expect_env_token: Some("pat-token"),
-            },
-            EnsureTokenCase {
-                name: "boundary",
-                cached_token: Some("boundary"),
-                cached_expires_at: Some(now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS),
-                preset_env: None,
-                cli_response: Some(&refreshed),
-                expect_token: "refreshed",
-                expect_cli_calls: 1,
-                expect_env_token: None,
-            },
-            EnsureTokenCase {
-                name: "above margin",
-                cached_token: Some("still-fresh"),
-                cached_expires_at: Some(now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS + 1),
-                preset_env: None,
-                cli_response: None,
-                expect_token: "still-fresh",
-                expect_cli_calls: 0,
-                expect_env_token: None,
-            },
-            EnsureTokenCase {
-                name: "oauth without env mutation",
-                cached_token: Some("oauth-tok"),
-                cached_expires_at: None,
-                preset_env: None,
-                cli_response: None,
-                expect_token: "oauth-tok",
-                expect_cli_calls: 0,
-                expect_env_token: None,
-            },
-        ];
+    async fn cached_auth_short_circuits_without_cli() {
+        with_clean_env(|| async {
+            assert_resolve_credential(
+                || std::env::set_var("CS_ACCESS_TOKEN", "pat-token"),
+                empty_cli(),
+                Some("pat-token"),
+                0,
+            )
+            .await;
 
-        for case in cases {
-            assert_resolve_credential(&case).await;
-        }
+            clean_oauth_env();
+            assert_resolve_credential(
+                || {
+                    std::env::set_var("CS_OAUTH_TOKEN", "oau-fresh");
+                    std::env::set_var(
+                        "CS_OAUTH_EXPIRES_AT",
+                        (now_epoch_secs() + 3600).to_string(),
+                    );
+                },
+                empty_cli(),
+                Some("oau-fresh"),
+                0,
+            )
+            .await;
+
+            clean_oauth_env();
+            assert_resolve_credential(
+                || std::env::set_var("CS_OAUTH_EXPIRES_AT", SIGNED_OUT_SENTINEL),
+                empty_cli(),
+                None,
+                0,
+            )
+            .await;
+
+            clean_oauth_env();
+            assert_current_token(
+                || std::env::set_var("CS_OAUTH_EXPIRES_AT", SIGNED_OUT_SENTINEL),
+                empty_cli(),
+                None,
+                0,
+            )
+            .await;
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn resolve_credential_refreshes_expired_oauth() {
+        with_clean_env(|| async {
+            std::env::set_var("CS_OAUTH_TOKEN", "oau-expired");
+            std::env::set_var(
+                "CS_OAUTH_EXPIRES_AT",
+                (now_epoch_secs() - 10).to_string(),
+            );
+            let fresh = signed_in_json("oau-new", now_epoch_secs() + 3600);
+            let cli = MockCliRunner::with_ok(&fresh);
+            assert_resolve_credential(|| {}, cli, Some("oau-new"), 1).await;
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -369,120 +537,115 @@ mod tests {
             assert!(a.unwrap().is_some());
             assert!(b.unwrap().is_some());
             assert!(c.unwrap().is_some());
-            assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
+            // Only one CLI call should have been made (write lock serialization).
             assert_eq!(calls.lock().unwrap().len(), 1);
         })
         .await;
     }
 
     #[tokio::test]
-    async fn signed_out_is_cached_briefly() {
+    async fn login_persists_and_returns_token() {
         with_clean_env(|| async {
             let manager = AuthManager::new();
-            let signed_out = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
-            let cli =
-                MockCliRunner::with_responses(vec![Ok(signed_out.into()), Ok(signed_out.into())]);
-            let calls = cli.calls();
-            let result = manager.resolve_credential(&cli).await.unwrap();
-            assert!(result.is_none());
-            assert_eq!(calls.lock().unwrap().len(), 1);
-            let result = manager.resolve_credential(&cli).await.unwrap();
-            assert!(result.is_none());
-            assert_eq!(calls.lock().unwrap().len(), 1);
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn login_clears_negative_cache() {
-        with_clean_env(|| async {
-            let manager = AuthManager::new();
-            manager.mark_signed_out().await;
-            let cli = MockCliRunner::with_ok(&signed_in_json("new-tok", now_epoch_secs() + 3600));
+            let cli = MockCliRunner::with_ok(&signed_in_json("login-tok", now_epoch_secs() + 3600));
             let resp = manager.login(&cli).await.unwrap();
             assert!(resp.is_signed_in());
-            let fresh = manager.fresh_cached_token().await;
-            assert!(fresh.is_some());
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn cached_cloud_api_root_is_normalized_for_tracking() {
-        with_clean_env(|| async {
-            let manager = AuthManager::new();
-            manager
-                .store_at(
-                    make_response(Some("oau-cloud"), Some("https://api.codescene.io/api")),
-                    now_epoch_secs(),
-                )
-                .await;
-
+            assert_eq!(resp.access_token.as_deref(), Some("login-tok"));
+            // Verify persisted to env.
             assert_eq!(
-                manager.try_cached_api_root().as_deref(),
-                Some("https://api.codescene.io")
+                std::env::var("CS_OAUTH_TOKEN").ok().as_deref(),
+                Some("login-tok")
             );
         })
         .await;
     }
 
     #[tokio::test]
-    async fn current_token_error_preserves_cache() {
+    async fn login_fetches_token_when_login_response_omits_access_token() {
         with_clean_env(|| async {
             let manager = AuthManager::new();
-            let mut resp = make_response(Some("old-tok"), Some("https://api.codescene.io/api"));
-            resp.expires_at = Some(now_epoch_secs() - 10);
-            manager.set_cached_response(resp, now_epoch_secs()).await;
-            let cli = MockCliRunner::with_err(1, "network error");
-            let err = manager.current_token(&cli).await;
-            assert!(err.is_err());
-            let cache = manager.cache.read().await;
-            assert!(cache.is_some());
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn resolve_credential_clears_oauth_cache_on_signed_out() {
-        with_clean_env(|| async {
-            let manager = AuthManager::new();
-            manager
-                .store_at(
-                    make_response(Some("old-oauth"), Some("https://api.codescene.io/api")),
-                    now_epoch_secs() - 600,
-                )
-                .await;
-            {
-                let mut guard = manager.cache.write().await;
-                if let Some(cached) = guard.as_mut() {
-                    cached.response.expires_at = Some(now_epoch_secs() - 10);
-                }
-            }
-            let signed_out = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
-            let cli = MockCliRunner::with_ok(signed_out);
-            let result = manager.resolve_credential(&cli).await.unwrap();
-            assert!(result.is_none());
-            assert!(manager.cache.read().await.is_none());
-            assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
-        })
-        .await;
-    }
-
-    #[tokio::test]
-    async fn concurrent_login_and_resolve_credential() {
-        with_clean_env(|| async {
-            let manager = AuthManager::new();
-            let cli = MockCliRunner::with_responses(vec![Ok(signed_in_json(
-                "login-token",
+            let login_json = format!(
+                r#"{{"status":"signed_in","access-token":null,"api-url":"https://api.codescene.io/api","expires-at":{},"refresh-token-expires-at":{}}}"#,
                 now_epoch_secs() + 3600,
-            ))]);
-            let calls = cli.calls();
-            let (login_res, ensure_res) =
-                tokio::join!(manager.login(&cli), manager.resolve_credential(&cli),);
-            assert!(login_res.unwrap().is_signed_in());
-            assert!(ensure_res.unwrap().is_some());
-            assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
-            assert_eq!(calls.lock().unwrap().len(), 1);
+                now_epoch_secs() + 7200
+            );
+            let token_json = signed_in_json("fetched-tok", now_epoch_secs() + 3600);
+            let cli = MockCliRunner::with_responses(vec![Ok(login_json), Ok(token_json)]);
+            let resp = manager.login(&cli).await.unwrap();
+            assert!(resp.is_signed_in());
+            assert_eq!(resp.access_token.as_deref(), Some("fetched-tok"));
+            assert_eq!(std::env::var("CS_OAUTH_TOKEN").ok().as_deref(), Some("fetched-tok"));
+            assert_eq!(cli.calls().lock().unwrap().len(), 2);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn login_skips_if_fresh_token_appeared() {
+        with_clean_env(|| async {
+            // Simulate another thread having just completed login.
+            std::env::set_var("CS_OAUTH_TOKEN", "already-fresh");
+            std::env::set_var(
+                "CS_OAUTH_EXPIRES_AT",
+                (now_epoch_secs() + 3600).to_string(),
+            );
+            let manager = AuthManager::new();
+            let cli = MockCliRunner::with_responses(vec![]);
+            let resp = manager.login(&cli).await.unwrap();
+            assert!(resp.is_signed_in());
+            assert_eq!(resp.access_token.as_deref(), Some("already-fresh"));
+            // CLI should not have been called.
+            assert_eq!(cli.calls().lock().unwrap().len(), 0);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn current_token_refreshes_when_expiry_exists_but_token_missing() {
+        with_clean_env(|| async {
+            let cli = MockCliRunner::with_ok(&signed_in_json("recovered-token", now_epoch_secs() + 3600));
+            assert_current_token(
+                || {
+                    std::env::set_var(
+                        "CS_OAUTH_EXPIRES_AT",
+                        (now_epoch_secs() + 3600).to_string(),
+                    );
+                },
+                cli,
+                Some("recovered-token"),
+                1,
+            )
+            .await;
+            assert_eq!(std::env::var("CS_OAUTH_TOKEN").ok().as_deref(), Some("recovered-token"));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn try_cached_access_token_reads_from_env() {
+        with_clean_env(|| async {
+            std::env::set_var("CS_OAUTH_TOKEN", "oau-tracking");
+            let manager = AuthManager::new();
+            assert_eq!(
+                manager.try_cached_access_token().as_deref(),
+                Some("oau-tracking")
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn login_marks_signed_out_on_failure() {
+        with_clean_env(|| async {
+            let signed_out = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+            let manager = AuthManager::new();
+            let cli = MockCliRunner::with_ok(signed_out);
+            let resp = manager.login(&cli).await.unwrap();
+            assert!(!resp.is_signed_in());
+            assert_eq!(
+                std::env::var("CS_OAUTH_EXPIRES_AT").ok().as_deref(),
+                Some(SIGNED_OUT_SENTINEL)
+            );
         })
         .await;
     }

--- a/src/auth/manager.rs
+++ b/src/auth/manager.rs
@@ -1,0 +1,489 @@
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, RwLock};
+
+use crate::cli::CliRunner;
+
+use super::{
+    configured_credential, credential_from_response, fetch_token, now_epoch_secs, run_login,
+    AuthCredential, CliTokenResponse,
+};
+
+/// Tokens are considered stale this many seconds before their actual `expires-at`.
+/// This avoids making an API call with a token that's about to expire mid-flight.
+/// 120 s was chosen to accommodate typical request round-trip + CLI overhead.
+const TOKEN_EXPIRY_MARGIN_SECS: i64 = 60;
+
+/// When the CLI response does not include `expires-at` (older CLI versions),
+/// we cache the response for this duration before re-checking. 5 minutes is
+/// conservative enough to avoid excess CLI calls while limiting staleness.
+const TOKEN_FALLBACK_TTL_SECS: i64 = 300;
+
+/// Time to cache a "signed out" result to avoid launching the CLI on every
+/// tool call when no credentials are configured.
+const SIGNED_OUT_CACHE_TTL_SECS: i64 = 30;
+
+/// Manages OAuth token lifecycle: caching, expiry-aware refresh, and
+/// serialization of concurrent CLI calls behind a single mutex.
+#[derive(Clone)]
+pub(crate) struct AuthManager {
+    cache: Arc<RwLock<Option<CachedToken>>>,
+    refresh_lock: Arc<Mutex<()>>,
+    /// Timestamp of the last "signed out" response. Used for negative caching.
+    signed_out_at: Arc<RwLock<Option<i64>>>,
+}
+
+#[derive(Clone, Debug)]
+struct CachedToken {
+    response: CliTokenResponse,
+    cached_at: i64,
+}
+
+impl AuthManager {
+    pub(crate) fn new() -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(None)),
+            refresh_lock: Arc::new(Mutex::new(())),
+            signed_out_at: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    pub(crate) async fn resolve_credential(
+        &self,
+        cli_runner: &dyn CliRunner,
+    ) -> Result<Option<AuthCredential>, String> {
+        if let Some(credential) = configured_credential() {
+            return Ok(Some(credential));
+        }
+        Ok(self
+            .current_token(cli_runner)
+            .await?
+            .and_then(|resp| credential_from_response(&resp)))
+    }
+
+    /// Get the current OAuth token (from cache or by refreshing via CLI).
+    /// Does NOT check `configured_credential()` — callers that need to prefer
+    /// a user-configured PAT should use `resolve_credential` instead.
+    /// Used directly by `login::try_existing_session` which has already
+    /// short-circuited on configured credentials at the handler level.
+    pub(crate) async fn current_token(
+        &self,
+        cli_runner: &dyn CliRunner,
+    ) -> Result<Option<CliTokenResponse>, String> {
+        if let Some(cached) = self.fresh_cached_token().await {
+            return Ok(Some(cached.response));
+        }
+
+        if self.recently_signed_out().await {
+            return Ok(None);
+        }
+
+        let _guard = self.refresh_lock.lock().await;
+        if let Some(cached) = self.fresh_cached_token().await {
+            return Ok(Some(cached.response));
+        }
+        if self.recently_signed_out().await {
+            return Ok(None);
+        }
+
+        let token = fetch_token(cli_runner).await?;
+        if let Some(resp) = token.as_ref() {
+            self.store_at(resp.clone(), now_epoch_secs()).await;
+        } else {
+            self.mark_signed_out().await;
+        }
+        Ok(token)
+    }
+
+    /// Run the interactive login flow. Serialized with token refreshes.
+    pub(crate) async fn login(
+        &self,
+        cli_runner: &dyn CliRunner,
+    ) -> Result<CliTokenResponse, String> {
+        let _guard = self.refresh_lock.lock().await;
+        let resp = run_login(cli_runner).await?;
+        if resp.is_signed_in() {
+            self.store_at(resp.clone(), now_epoch_secs()).await;
+        } else {
+            self.mark_signed_out().await;
+        }
+        Ok(resp)
+    }
+
+    async fn fresh_cached_token(&self) -> Option<CachedToken> {
+        let guard = self.cache.read().await;
+        guard.as_ref().filter(|cached| cached.is_fresh()).cloned()
+    }
+
+    async fn recently_signed_out(&self) -> bool {
+        let guard = self.signed_out_at.read().await;
+        guard
+            .map(|ts| now_epoch_secs() - ts < SIGNED_OUT_CACHE_TTL_SECS)
+            .unwrap_or(false)
+    }
+
+    async fn mark_signed_out(&self) {
+        // Clear cache and mark signed-out together to avoid a window where
+        // a reader sees empty cache + recently_signed_out == false.
+        {
+            let mut guard = self.cache.write().await;
+            *guard = None;
+        }
+        let mut guard = self.signed_out_at.write().await;
+        *guard = Some(now_epoch_secs());
+    }
+
+    async fn store_at(&self, response: CliTokenResponse, cached_at: i64) {
+        {
+            let mut guard = self.cache.write().await;
+            *guard = Some(CachedToken {
+                response,
+                cached_at,
+            });
+        }
+        // A successful store invalidates any negative cache.
+        let mut signed_out = self.signed_out_at.write().await;
+        *signed_out = None;
+    }
+
+    /// Synchronously try to read the cached OAuth credentials for tracking.
+    /// Returns `(access_token, normalized_api_root)` if the cache is available and populated.
+    /// Returns `(None, None)` if the cache is empty or contended.
+    /// Used for fire-and-forget operations (like tracking) that can't await.
+    fn try_cached_auth_info(&self) -> (Option<String>, Option<String>) {
+        let Some(guard) = self.cache.try_read().ok() else {
+            return (None, None);
+        };
+        let Some(cached) = guard.as_ref() else {
+            return (None, None);
+        };
+        let token = cached
+            .response
+            .access_token
+            .as_deref()
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty());
+        let api_root =
+            credential_from_response(&cached.response).and_then(|cred| cred.api_root().ok());
+        (token, api_root)
+    }
+
+    pub(crate) fn try_cached_access_token(&self) -> Option<String> {
+        self.try_cached_auth_info().0
+    }
+
+    pub(crate) fn try_cached_api_root(&self) -> Option<String> {
+        self.try_cached_auth_info().1
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn set_cached_response(&self, response: CliTokenResponse, cached_at: i64) {
+        self.store_at(response, cached_at).await;
+    }
+}
+
+impl Default for AuthManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CachedToken {
+    fn is_fresh(&self) -> bool {
+        let now = now_epoch_secs();
+        match self.response.expires_at {
+            Some(expires_at) => expires_at > now + TOKEN_EXPIRY_MARGIN_SECS,
+            None => self.cached_at + TOKEN_FALLBACK_TTL_SECS > now,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::MockCliRunner;
+
+    fn with_env_lock() -> impl Drop {
+        crate::config::lock_test_env()
+    }
+
+    fn make_response(access_token: Option<&str>, api_url: Option<&str>) -> CliTokenResponse {
+        CliTokenResponse {
+            status: "signed_in".into(),
+            access_token: access_token.map(Into::into),
+            api_url: api_url.map(Into::into),
+            expires_at: None,
+            refresh_token_expires_at: None,
+        }
+    }
+
+    fn signed_in_json(token: &str, expires_at: i64) -> String {
+        format!(
+            r#"{{"status":"signed_in","access-token":"{token}","api-url":"https://api.codescene.io/api","expires-at":{expires_at}}}"#
+        )
+    }
+
+    async fn with_clean_env<F, Fut>(f: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let _lock = with_env_lock();
+        std::env::remove_var("CS_ACCESS_TOKEN");
+        f().await;
+        std::env::remove_var("CS_ACCESS_TOKEN");
+    }
+
+    struct EnsureTokenCase<'a> {
+        name: &'a str,
+        cached_token: Option<&'a str>,
+        cached_expires_at: Option<i64>,
+        preset_env: Option<&'a str>,
+        cli_response: Option<&'a str>,
+        expect_token: &'a str,
+        expect_cli_calls: usize,
+        expect_env_token: Option<&'a str>,
+    }
+
+    /// Runs a single resolve_credential scenario: seeds cache, calls auth, checks result.
+    async fn assert_resolve_credential(case: &EnsureTokenCase<'_>) {
+        let _lock = with_env_lock();
+        std::env::remove_var("CS_ACCESS_TOKEN");
+        let manager = AuthManager::new();
+        if let Some(token) = case.cached_token {
+            let mut resp = make_response(Some(token), Some("https://api.codescene.io/api"));
+            resp.expires_at = case.cached_expires_at;
+            manager.set_cached_response(resp, now_epoch_secs()).await;
+        }
+        if let Some(env_val) = case.preset_env {
+            std::env::set_var("CS_ACCESS_TOKEN", env_val);
+        }
+        let cli = match case.cli_response {
+            Some(json) => MockCliRunner::with_ok(json),
+            None => MockCliRunner::with_responses(vec![]),
+        };
+        let credential = manager.resolve_credential(&cli).await.unwrap().unwrap();
+        assert_eq!(
+            credential.access_token(),
+            case.expect_token,
+            "{}",
+            case.name
+        );
+        match case.expect_env_token {
+            Some(token) => assert_eq!(std::env::var("CS_ACCESS_TOKEN").unwrap(), token),
+            None => assert!(std::env::var("CS_ACCESS_TOKEN").is_err()),
+        }
+        assert_eq!(
+            cli.calls().lock().unwrap().len(),
+            case.expect_cli_calls,
+            "{}",
+            case.name
+        );
+        std::env::remove_var("CS_ACCESS_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn resolve_credential_cache_scenarios() {
+        let fresh = signed_in_json("fresh-token", now_epoch_secs() + 3600);
+        let refreshed = signed_in_json("refreshed", now_epoch_secs() + 7200);
+        let cases = [
+            EnsureTokenCase {
+                name: "fresh cache",
+                cached_token: Some("cached-token"),
+                cached_expires_at: None,
+                preset_env: None,
+                cli_response: None,
+                expect_token: "cached-token",
+                expect_cli_calls: 0,
+                expect_env_token: None,
+            },
+            EnsureTokenCase {
+                name: "expired",
+                cached_token: Some("expired-token"),
+                cached_expires_at: Some(now_epoch_secs() - 10),
+                preset_env: None,
+                cli_response: Some(&fresh),
+                expect_token: "fresh-token",
+                expect_cli_calls: 1,
+                expect_env_token: None,
+            },
+            EnsureTokenCase {
+                name: "configured env",
+                cached_token: Some("expired-token"),
+                cached_expires_at: Some(now_epoch_secs() - 10),
+                preset_env: Some("pat-token"),
+                cli_response: Some(&fresh),
+                expect_token: "pat-token",
+                expect_cli_calls: 0,
+                expect_env_token: Some("pat-token"),
+            },
+            EnsureTokenCase {
+                name: "boundary",
+                cached_token: Some("boundary"),
+                cached_expires_at: Some(now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS),
+                preset_env: None,
+                cli_response: Some(&refreshed),
+                expect_token: "refreshed",
+                expect_cli_calls: 1,
+                expect_env_token: None,
+            },
+            EnsureTokenCase {
+                name: "above margin",
+                cached_token: Some("still-fresh"),
+                cached_expires_at: Some(now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS + 1),
+                preset_env: None,
+                cli_response: None,
+                expect_token: "still-fresh",
+                expect_cli_calls: 0,
+                expect_env_token: None,
+            },
+            EnsureTokenCase {
+                name: "oauth without env mutation",
+                cached_token: Some("oauth-tok"),
+                cached_expires_at: None,
+                preset_env: None,
+                cli_response: None,
+                expect_token: "oauth-tok",
+                expect_cli_calls: 0,
+                expect_env_token: None,
+            },
+        ];
+
+        for case in cases {
+            assert_resolve_credential(&case).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_credential_serializes_concurrent_refreshes() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            let cli =
+                MockCliRunner::with_ok(&signed_in_json("shared-token", now_epoch_secs() + 3600));
+            let calls = cli.calls();
+            let (a, b, c) = tokio::join!(
+                manager.resolve_credential(&cli),
+                manager.resolve_credential(&cli),
+                manager.resolve_credential(&cli),
+            );
+            assert!(a.unwrap().is_some());
+            assert!(b.unwrap().is_some());
+            assert!(c.unwrap().is_some());
+            assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
+            assert_eq!(calls.lock().unwrap().len(), 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn signed_out_is_cached_briefly() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            let signed_out = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+            let cli =
+                MockCliRunner::with_responses(vec![Ok(signed_out.into()), Ok(signed_out.into())]);
+            let calls = cli.calls();
+            let result = manager.resolve_credential(&cli).await.unwrap();
+            assert!(result.is_none());
+            assert_eq!(calls.lock().unwrap().len(), 1);
+            let result = manager.resolve_credential(&cli).await.unwrap();
+            assert!(result.is_none());
+            assert_eq!(calls.lock().unwrap().len(), 1);
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn login_clears_negative_cache() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            manager.mark_signed_out().await;
+            let cli = MockCliRunner::with_ok(&signed_in_json("new-tok", now_epoch_secs() + 3600));
+            let resp = manager.login(&cli).await.unwrap();
+            assert!(resp.is_signed_in());
+            let fresh = manager.fresh_cached_token().await;
+            assert!(fresh.is_some());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn cached_cloud_api_root_is_normalized_for_tracking() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            manager
+                .store_at(
+                    make_response(Some("oau-cloud"), Some("https://api.codescene.io/api")),
+                    now_epoch_secs(),
+                )
+                .await;
+
+            assert_eq!(
+                manager.try_cached_api_root().as_deref(),
+                Some("https://api.codescene.io")
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn current_token_error_preserves_cache() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            let mut resp = make_response(Some("old-tok"), Some("https://api.codescene.io/api"));
+            resp.expires_at = Some(now_epoch_secs() - 10);
+            manager.set_cached_response(resp, now_epoch_secs()).await;
+            let cli = MockCliRunner::with_err(1, "network error");
+            let err = manager.current_token(&cli).await;
+            assert!(err.is_err());
+            let cache = manager.cache.read().await;
+            assert!(cache.is_some());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn resolve_credential_clears_oauth_cache_on_signed_out() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            manager
+                .store_at(
+                    make_response(Some("old-oauth"), Some("https://api.codescene.io/api")),
+                    now_epoch_secs() - 600,
+                )
+                .await;
+            {
+                let mut guard = manager.cache.write().await;
+                if let Some(cached) = guard.as_mut() {
+                    cached.response.expires_at = Some(now_epoch_secs() - 10);
+                }
+            }
+            let signed_out = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+            let cli = MockCliRunner::with_ok(signed_out);
+            let result = manager.resolve_credential(&cli).await.unwrap();
+            assert!(result.is_none());
+            assert!(manager.cache.read().await.is_none());
+            assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_login_and_resolve_credential() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            let cli = MockCliRunner::with_responses(vec![Ok(signed_in_json(
+                "login-token",
+                now_epoch_secs() + 3600,
+            ))]);
+            let calls = cli.calls();
+            let (login_res, ensure_res) =
+                tokio::join!(manager.login(&cli), manager.resolve_credential(&cli),);
+            assert!(login_res.unwrap().is_signed_in());
+            assert!(ensure_res.unwrap().is_some());
+            assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
+            assert_eq!(calls.lock().unwrap().len(), 1);
+        })
+        .await;
+    }
+}

--- a/src/auth/manager.rs
+++ b/src/auth/manager.rs
@@ -1,17 +1,9 @@
 use crate::cli::CliRunner;
 
 use super::{
-    configured_credential, credential_from_response, fetch_token, now_epoch_secs, run_login,
-    AuthCredential, CliTokenResponse,
+    configured_credential, credential_from_response, fetch_token, run_login, state, AuthCredential,
+    CliTokenResponse,
 };
-
-/// Tokens are considered stale this many seconds before their actual `expires-at`.
-/// This avoids making an API call with a token that's about to expire mid-flight.
-const TOKEN_EXPIRY_MARGIN_SECS: i64 = 60;
-
-/// Sentinel value for `CS_OAUTH_EXPIRES_AT` indicating the user is signed out
-/// and we should not retry the CLI until an explicit login is requested.
-const SIGNED_OUT_SENTINEL: &str = "0";
 
 /// Manages OAuth token lifecycle using the config env RwLock for all state.
 ///
@@ -40,23 +32,30 @@ impl AuthManager {
     ) -> Result<Option<AuthCredential>, String> {
         // PAT takes priority.
         if let Some(credential) = configured_credential() {
-            tracing::info!(source = "configured", "resolved auth credential from configured token");
+            tracing::info!(
+                source = "configured",
+                "resolved auth credential from configured token"
+            );
             return Ok(Some(credential));
         }
         // Check persisted OAuth token.
-        if let Some(cred) = Self::fresh_oauth_credential() {
+        if let Some(cred) = state::fresh_credential() {
+            let has_onprem_url = cred.api_root().ok().is_some();
             tracing::info!(
                 source = "oauth_cache",
-                has_onprem_url = cred.api_root().ok().is_some(),
+                has_onprem_url,
                 "resolved auth credential from cached OAuth token"
             );
             return Ok(Some(cred));
         }
         // Token missing or expired — try to refresh via CLI.
+        let has_oauth_token = crate::config::try_read_env("CS_OAUTH_TOKEN").is_some();
+        let oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT");
+        let signed_out_sentinel = state::is_signed_out();
         tracing::info!(
-            has_oauth_token = crate::config::try_read_env("CS_OAUTH_TOKEN").is_some(),
-            oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT"),
-            signed_out_sentinel = Self::is_signed_out(),
+            has_oauth_token,
+            oauth_expires_at,
+            signed_out_sentinel,
             "no usable cached credential; attempting CLI auth token refresh"
         );
         self.refresh_token(cli_runner).await
@@ -70,12 +69,12 @@ impl AuthManager {
         cli_runner: &dyn CliRunner,
     ) -> Result<Option<CliTokenResponse>, String> {
         // Check if we have a fresh token in env.
-        if Self::has_fresh_oauth_token() {
+        if state::has_fresh_token() {
             // Build a synthetic CliTokenResponse from env for compatibility.
-            return Ok(Self::token_response_from_env());
+            return Ok(state::response_from_env());
         }
         // If signed out (sentinel), don't retry automatically.
-        if Self::is_signed_out() {
+        if state::is_signed_out() {
             return Ok(None);
         }
         // Refresh via CLI under write lock.
@@ -94,14 +93,15 @@ impl AuthManager {
         let guard = crate::config::acquire_write_lock().await;
 
         // Double-check: maybe another call just completed login.
-        if Self::guard_has_fresh_oauth_token(&guard) {
-            let cached = Self::build_token_response_from_guard(&guard);
+        if state::guard_has_fresh_token(&guard) {
+            let cached = state::response_from_guard(&guard);
+            let has_oauth_token = cached
+                .access_token
+                .as_deref()
+                .is_some_and(|token| !token.trim().is_empty());
             tracing::info!(
                 oauth_expires_at = cached.expires_at,
-                has_oauth_token = cached
-                    .access_token
-                    .as_deref()
-                    .is_some_and(|token| !token.trim().is_empty()),
+                has_oauth_token,
                 "skipping interactive login because a fresh cached OAuth token already exists"
             );
             return Ok(cached);
@@ -110,7 +110,7 @@ impl AuthManager {
         let resp = run_login(cli_runner).await?;
         if resp.is_signed_in() {
             let persisted = if response_has_access_token(&resp) {
-                Self::persist_response(&guard, &resp);
+                state::persist_response(&guard, &resp);
                 resp.clone()
             } else {
                 tracing::info!(
@@ -120,108 +120,23 @@ impl AuthManager {
                 let token_resp = fetch_token(cli_runner).await?.ok_or_else(|| {
                     "CLI login succeeded but token export remained unavailable".to_string()
                 })?;
-                Self::persist_response(&guard, &token_resp);
+                state::persist_response(&guard, &token_resp);
                 token_resp
             };
+            let has_access_token = response_has_access_token(&persisted);
             tracing::info!(
                 status = %persisted.status,
-                has_access_token = response_has_access_token(&persisted),
+                has_access_token,
                 expires_at = persisted.expires_at,
                 refresh_expires_at = persisted.refresh_token_expires_at,
                 "persisted OAuth login response"
             );
             return Ok(persisted);
         } else {
-            Self::persist_signed_out(&guard);
+            state::persist_signed_out(&guard);
             tracing::info!(status = %resp.status, "login response was not signed in; persisted signed-out sentinel");
         }
         Ok(resp)
-    }
-
-    /// Try to read a fresh OAuth credential from env.
-    fn fresh_oauth_credential() -> Option<AuthCredential> {
-        let vals = crate::config::try_read_env_multi(&[
-            "CS_OAUTH_TOKEN",
-            "CS_OAUTH_EXPIRES_AT",
-            "CS_ONPREM_URL",
-        ])?;
-        let token = vals[0].as_deref()?.trim().to_string();
-        if token.is_empty() {
-            tracing::info!(
-                oauth_expires_at = vals[1].clone(),
-                "cached OAuth state has no access token"
-            );
-            return None;
-        }
-        // Check expiry.
-        if let Some(expires_str) = vals[1].as_deref() {
-            if let Ok(expires_at) = expires_str.parse::<i64>() {
-                if expires_at <= now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS {
-                    tracing::info!(oauth_expires_at = expires_at, "cached OAuth token is expired or within refresh margin");
-                    return None; // expired or signed-out sentinel
-                }
-            }
-        }
-        let onprem_url = vals[2]
-            .as_deref()
-            .map(|v| v.trim().trim_end_matches('/').to_string())
-            .filter(|v| !v.is_empty());
-        Some(AuthCredential::OAuth {
-            access_token: token,
-            onprem_url,
-        })
-    }
-
-    /// Check if we have a non-expired OAuth token in env.
-    fn has_fresh_oauth_token() -> bool {
-        Self::fresh_oauth_credential().is_some()
-    }
-
-    fn guard_has_fresh_oauth_token(guard: &crate::config::ConfigEnvWriteGuard) -> bool {
-        let Some(token) = guard.read_env("CS_OAUTH_TOKEN") else {
-            return false;
-        };
-        if token.trim().is_empty() {
-            return false;
-        }
-        let Some(expires_str) = guard.read_env("CS_OAUTH_EXPIRES_AT") else {
-            return false;
-        };
-        let Ok(expires_at) = expires_str.parse::<i64>() else {
-            return false;
-        };
-        expires_at > now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS
-    }
-
-    /// Check if the signed-out sentinel is set.
-    fn is_signed_out() -> bool {
-        crate::config::try_read_env("CS_OAUTH_EXPIRES_AT")
-            .as_deref()
-            == Some(SIGNED_OUT_SENTINEL)
-    }
-
-    /// Build a synthetic `CliTokenResponse` from env vars (for compatibility
-    /// with callers that expect a response object).
-    fn token_response_from_env() -> Option<CliTokenResponse> {
-        let vals = crate::config::try_read_env_multi(&[
-            "CS_OAUTH_TOKEN",
-            "CS_OAUTH_EXPIRES_AT",
-            "CS_OAUTH_REFRESH_EXPIRES_AT",
-            "CS_ONPREM_URL",
-        ])?;
-        let token = vals[0].clone()?;
-        let expires_at = vals[1].as_deref().and_then(|s| s.parse::<i64>().ok());
-        let refresh_expires_at = vals[2].as_deref().and_then(|s| s.parse::<i64>().ok());
-        let api_url = vals[3]
-            .as_deref()
-            .map(|u| format!("{}/api", u.trim_end_matches('/')));
-        Some(CliTokenResponse {
-            status: "signed_in".into(),
-            access_token: Some(token),
-            api_url,
-            expires_at,
-            refresh_token_expires_at: refresh_expires_at,
-        })
     }
 
     /// Refresh token via CLI, acquiring the config write lock.
@@ -232,7 +147,8 @@ impl AuthManager {
     ) -> Result<Option<AuthCredential>, String> {
         let resp = self.refresh_token_raw(cli_runner).await?;
         let credential = resp.and_then(|r| credential_from_response(&r));
-        tracing::info!(resolved = credential.is_some(), "completed CLI auth token refresh");
+        let resolved = credential.is_some();
+        tracing::info!(resolved, "completed CLI auth token refresh");
         Ok(credential)
     }
 
@@ -245,20 +161,21 @@ impl AuthManager {
         let guard = crate::config::acquire_write_lock().await;
 
         // Double-check under write lock: another thread may have refreshed.
-        if Self::guard_has_fresh_oauth_token(&guard) {
-            let cached = Self::build_token_response_from_guard(&guard);
+        if state::guard_has_fresh_token(&guard) {
+            let cached = state::response_from_guard(&guard);
+            let has_oauth_token = cached
+                .access_token
+                .as_deref()
+                .is_some_and(|token| !token.trim().is_empty());
             tracing::info!(
                 oauth_expires_at = cached.expires_at,
-                has_oauth_token = cached
-                    .access_token
-                    .as_deref()
-                    .is_some_and(|token| !token.trim().is_empty()),
+                has_oauth_token,
                 "reusing OAuth token that appeared while waiting for auth lock"
             );
             return Ok(Some(cached));
         }
 
-        if guard.read_env("CS_OAUTH_EXPIRES_AT").as_deref() == Some(SIGNED_OUT_SENTINEL) {
+        if state::guard_is_signed_out(&guard) {
             tracing::info!("skipping CLI auth token refresh because signed-out sentinel is set");
             return Ok(None);
         }
@@ -267,10 +184,14 @@ impl AuthManager {
         let token = fetch_token(cli_runner).await?;
         match token {
             Some(resp) if resp.is_signed_in() => {
-                Self::persist_response(&guard, &resp);
+                state::persist_response(&guard, &resp);
+                let has_access_token = resp
+                    .access_token
+                    .as_deref()
+                    .is_some_and(|t| !t.trim().is_empty());
                 tracing::info!(
                     status = %resp.status,
-                    has_access_token = resp.access_token.as_deref().is_some_and(|t| !t.trim().is_empty()),
+                    has_access_token,
                     expires_at = resp.expires_at,
                     refresh_expires_at = resp.refresh_token_expires_at,
                     "CLI auth token refresh succeeded"
@@ -278,79 +199,12 @@ impl AuthManager {
                 Ok(Some(resp))
             }
             _ => {
-                Self::persist_signed_out(&guard);
-                tracing::info!("CLI auth token refresh reported signed-out state; persisted sentinel");
+                state::persist_signed_out(&guard);
+                tracing::info!(
+                    "CLI auth token refresh reported signed-out state; persisted sentinel"
+                );
                 Ok(None)
             }
-        }
-    }
-
-    /// Persist a successful token response to env + config under the write lock.
-    fn persist_response(guard: &crate::config::ConfigEnvWriteGuard, response: &CliTokenResponse) {
-        let token = response
-            .access_token
-            .as_deref()
-            .unwrap_or("")
-            .trim();
-        let expires_at = response
-            .expires_at
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-        let refresh_expires_at = response
-            .refresh_token_expires_at
-            .map(|v| v.to_string())
-            .unwrap_or_default();
-
-        let entries: &[(&str, &str)] = &[
-            ("oauth_token", token),
-            ("oauth_expires_at", &expires_at),
-            ("oauth_refresh_expires_at", &refresh_expires_at),
-        ];
-
-        if let Err(e) = guard.write_env_multi(entries) {
-            tracing::warn!(error = %e, "failed to persist OAuth state to config file");
-        }
-        tracing::info!(
-            has_access_token = !token.is_empty(),
-            expires_at = %expires_at,
-            refresh_expires_at = %refresh_expires_at,
-            "persisted OAuth state to config-backed environment"
-        );
-    }
-
-    /// Write the signed-out sentinel to env + config under the write lock.
-    fn persist_signed_out(guard: &crate::config::ConfigEnvWriteGuard) {
-        let entries: &[(&str, &str)] = &[
-            ("oauth_token", ""),
-            ("oauth_expires_at", SIGNED_OUT_SENTINEL),
-            ("oauth_refresh_expires_at", ""),
-        ];
-        if let Err(e) = guard.write_env_multi(entries) {
-            tracing::warn!(error = %e, "failed to persist signed-out state to config file");
-        }
-        tracing::info!("persisted signed-out sentinel to config-backed environment");
-    }
-
-    /// Build a CliTokenResponse from env while holding the write guard.
-    fn build_token_response_from_guard(
-        guard: &crate::config::ConfigEnvWriteGuard,
-    ) -> CliTokenResponse {
-        let token = guard.read_env("CS_OAUTH_TOKEN");
-        let expires_at = guard
-            .read_env("CS_OAUTH_EXPIRES_AT")
-            .and_then(|s| s.parse::<i64>().ok());
-        let refresh_expires_at = guard
-            .read_env("CS_OAUTH_REFRESH_EXPIRES_AT")
-            .and_then(|s| s.parse::<i64>().ok());
-        let api_url = guard
-            .read_env("CS_ONPREM_URL")
-            .map(|u| format!("{}/api", u.trim_end_matches('/')));
-        CliTokenResponse {
-            status: "signed_in".into(),
-            access_token: token,
-            api_url,
-            expires_at,
-            refresh_token_expires_at: refresh_expires_at,
         }
     }
 
@@ -362,17 +216,7 @@ impl AuthManager {
 
     /// Synchronously try to read the OAuth API root for tracking purposes.
     pub(crate) fn try_cached_api_root(&self) -> Option<String> {
-        Self::fresh_oauth_credential().and_then(|cred| cred.api_root().ok())
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn set_cached_response(
-        &self,
-        response: CliTokenResponse,
-        _cached_at: i64,
-    ) {
-        let guard = crate::config::acquire_write_lock().await;
-        Self::persist_response(&guard, &response);
+        state::fresh_credential().and_then(|cred| cred.api_root().ok())
     }
 }
 
@@ -386,20 +230,13 @@ fn response_has_access_token(response: &CliTokenResponse) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::MockCliRunner;
+    use crate::{auth::now_epoch_secs, test_utils::MockCliRunner};
+    use std::future::Future;
+
+    const SIGNED_OUT_SENTINEL: &str = "0";
 
     fn with_env_lock() -> impl Drop {
         crate::config::lock_test_env()
-    }
-
-    fn make_response(access_token: Option<&str>, api_url: Option<&str>) -> CliTokenResponse {
-        CliTokenResponse {
-            status: "signed_in".into(),
-            access_token: access_token.map(Into::into),
-            api_url: api_url.map(Into::into),
-            expires_at: None,
-            refresh_token_expires_at: None,
-        }
     }
 
     fn signed_in_json(token: &str, expires_at: i64) -> String {
@@ -443,7 +280,10 @@ mod tests {
         let manager = AuthManager::new();
         setup();
         let result = manager.resolve_credential(&cli).await.unwrap();
-        assert_eq!(result.as_ref().map(|cred| cred.access_token()), expected_token);
+        assert_eq!(
+            result.as_ref().map(|cred| cred.access_token()),
+            expected_token
+        );
         assert_eq!(cli_call_count(&cli), expected_cli_calls);
     }
 
@@ -456,13 +296,19 @@ mod tests {
         let manager = AuthManager::new();
         setup();
         let result = manager.current_token(&cli).await.unwrap();
-        assert_eq!(result.as_ref().and_then(|resp| resp.access_token.as_deref()), expected_token);
+        assert_eq!(
+            result
+                .as_ref()
+                .and_then(|resp| resp.access_token.as_deref()),
+            expected_token
+        );
         assert_eq!(cli_call_count(&cli), expected_cli_calls);
     }
 
     #[tokio::test]
     async fn cached_auth_short_circuits_without_cli() {
         with_clean_env(|| async {
+            std::env::remove_var("CS_CONFIG_DIR");
             assert_resolve_credential(
                 || std::env::set_var("CS_ACCESS_TOKEN", "pat-token"),
                 empty_cli(),
@@ -475,10 +321,7 @@ mod tests {
             assert_resolve_credential(
                 || {
                     std::env::set_var("CS_OAUTH_TOKEN", "oau-fresh");
-                    std::env::set_var(
-                        "CS_OAUTH_EXPIRES_AT",
-                        (now_epoch_secs() + 3600).to_string(),
-                    );
+                    std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
                 },
                 empty_cli(),
                 Some("oau-fresh"),
@@ -511,10 +354,7 @@ mod tests {
     async fn resolve_credential_refreshes_expired_oauth() {
         with_clean_env(|| async {
             std::env::set_var("CS_OAUTH_TOKEN", "oau-expired");
-            std::env::set_var(
-                "CS_OAUTH_EXPIRES_AT",
-                (now_epoch_secs() - 10).to_string(),
-            );
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() - 10).to_string());
             let fresh = signed_in_json("oau-new", now_epoch_secs() + 3600);
             let cli = MockCliRunner::with_ok(&fresh);
             assert_resolve_credential(|| {}, cli, Some("oau-new"), 1).await;
@@ -585,10 +425,7 @@ mod tests {
         with_clean_env(|| async {
             // Simulate another thread having just completed login.
             std::env::set_var("CS_OAUTH_TOKEN", "already-fresh");
-            std::env::set_var(
-                "CS_OAUTH_EXPIRES_AT",
-                (now_epoch_secs() + 3600).to_string(),
-            );
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
             let manager = AuthManager::new();
             let cli = MockCliRunner::with_responses(vec![]);
             let resp = manager.login(&cli).await.unwrap();
@@ -603,20 +440,21 @@ mod tests {
     #[tokio::test]
     async fn current_token_refreshes_when_expiry_exists_but_token_missing() {
         with_clean_env(|| async {
-            let cli = MockCliRunner::with_ok(&signed_in_json("recovered-token", now_epoch_secs() + 3600));
+            let cli =
+                MockCliRunner::with_ok(&signed_in_json("recovered-token", now_epoch_secs() + 3600));
             assert_current_token(
                 || {
-                    std::env::set_var(
-                        "CS_OAUTH_EXPIRES_AT",
-                        (now_epoch_secs() + 3600).to_string(),
-                    );
+                    std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
                 },
                 cli,
                 Some("recovered-token"),
                 1,
             )
             .await;
-            assert_eq!(std::env::var("CS_OAUTH_TOKEN").ok().as_deref(), Some("recovered-token"));
+            assert_eq!(
+                std::env::var("CS_OAUTH_TOKEN").ok().as_deref(),
+                Some("recovered-token")
+            );
         })
         .await;
     }
@@ -646,6 +484,175 @@ mod tests {
                 std::env::var("CS_OAUTH_EXPIRES_AT").ok().as_deref(),
                 Some(SIGNED_OUT_SENTINEL)
             );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn current_token_returns_synthetic_response_from_env_when_fresh() {
+        with_clean_env(|| async {
+            std::env::set_var("CS_ONPREM_URL", "https://onprem.example.com/");
+            assert_current_token(
+                || {
+                    std::env::set_var("CS_OAUTH_TOKEN", "fresh-tok");
+                    std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
+                    std::env::set_var("CS_OAUTH_REFRESH_EXPIRES_AT", "9999999999");
+                },
+                empty_cli(),
+                Some("fresh-tok"),
+                0,
+            )
+            .await;
+            // The synthetic response should also carry expiry + api_url built
+            // from env, proving `token_response_from_env` ran (not just a stub).
+            let manager = AuthManager::new();
+            let resp = manager.current_token(&empty_cli()).await.unwrap().unwrap();
+            assert_eq!(resp.refresh_token_expires_at, Some(9999999999));
+            assert_eq!(
+                resp.api_url.as_deref(),
+                Some("https://onprem.example.com/api")
+            );
+            assert!(resp.is_signed_in());
+            std::env::remove_var("CS_ONPREM_URL");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn login_errors_when_token_export_unavailable_after_login_without_token() {
+        with_clean_env(|| async {
+            let manager = AuthManager::new();
+            let login_json = format!(
+                r#"{{"status":"signed_in","access-token":null,"api-url":"https://api.codescene.io/api","expires-at":{}}}"#,
+                now_epoch_secs() + 3600
+            );
+            let signed_out_json = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+            let cli = MockCliRunner::with_responses(vec![
+                Ok(login_json),
+                Ok(signed_out_json.to_string()),
+            ]);
+            let result = manager.login(&cli).await;
+            assert_eq!(
+                result.unwrap_err(),
+                "CLI login succeeded but token export remained unavailable".to_string()
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn fresh_oauth_credential_treats_whitespace_token_as_missing() {
+        with_clean_env(|| async {
+            std::env::set_var("CS_OAUTH_TOKEN", "   ");
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
+            assert!(state::fresh_credential().is_none());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn fresh_oauth_credential_accepts_token_with_unparsable_expiry() {
+        with_clean_env(|| async {
+            std::env::set_var("CS_OAUTH_TOKEN", "tok");
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", "not-a-number");
+            assert!(state::fresh_credential().is_some());
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn refresh_reuses_token_written_while_waiting_for_lock() {
+        with_clean_env(|| async {
+            let guard = crate::config::acquire_write_lock().await;
+            let manager = AuthManager::new();
+            let cli = empty_cli();
+            let mut refresh = std::pin::pin!(manager.resolve_credential(&cli));
+            std::future::poll_fn(|cx| match refresh.as_mut().poll(cx) {
+                std::task::Poll::Ready(_) => panic!("refresh completed while write lock was held"),
+                std::task::Poll::Pending => std::task::Poll::Ready(()),
+            })
+            .await;
+            std::env::set_var("CS_OAUTH_TOKEN", "appeared-token");
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
+            drop(guard);
+
+            let credential = refresh.await.unwrap().unwrap();
+            assert_eq!(credential.access_token(), "appeared-token");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn guard_has_fresh_oauth_token_covers_all_false_branches() {
+        with_clean_env(|| async {
+            let guard = crate::config::acquire_write_lock().await;
+
+            // No token at all.
+            assert!(!state::guard_has_fresh_token(&guard));
+
+            // Whitespace-only token.
+            std::env::set_var("CS_OAUTH_TOKEN", "   ");
+            assert!(!state::guard_has_fresh_token(&guard));
+
+            // Token present, no expiry recorded.
+            std::env::set_var("CS_OAUTH_TOKEN", "tok");
+            std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+            assert!(!state::guard_has_fresh_token(&guard));
+
+            // Token present, unparsable expiry.
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", "not-a-number");
+            assert!(!state::guard_has_fresh_token(&guard));
+
+            // Token present, expired.
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() - 10).to_string());
+            assert!(!state::guard_has_fresh_token(&guard));
+
+            // Token present, fresh.
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
+            assert!(state::guard_has_fresh_token(&guard));
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn persist_response_warns_but_does_not_panic_when_save_fails() {
+        with_clean_env(|| async {
+            let impossible = if cfg!(windows) {
+                r"NUL\impossible"
+            } else {
+                "/dev/null/impossible"
+            };
+            std::env::set_var("CS_CONFIG_DIR", impossible);
+            let manager = AuthManager::new();
+            let cli =
+                MockCliRunner::with_ok(&signed_in_json("resilient-tok", now_epoch_secs() + 3600));
+            // resolve_credential should still surface the token even though
+            // persisting it to the config file fails.
+            let result = manager.resolve_credential(&cli).await.unwrap();
+            assert_eq!(
+                result.map(|c| c.access_token().to_string()),
+                Some("resilient-tok".to_string())
+            );
+            std::env::remove_var("CS_CONFIG_DIR");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn persist_signed_out_warns_but_does_not_panic_when_save_fails() {
+        with_clean_env(|| async {
+            let impossible = if cfg!(windows) {
+                r"NUL\impossible"
+            } else {
+                "/dev/null/impossible"
+            };
+            std::env::set_var("CS_CONFIG_DIR", impossible);
+            let manager = AuthManager::new();
+            let cli = MockCliRunner::with_ok(
+                r#"{"status":"signed_out","access-token":null,"api-url":null}"#,
+            );
+            assert!(!manager.login(&cli).await.unwrap().is_signed_in());
+            std::env::remove_var("CS_CONFIG_DIR");
         })
         .await;
     }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,4 +1,5 @@
 mod manager;
+mod state;
 
 pub(crate) use manager::AuthManager;
 
@@ -187,7 +188,9 @@ fn sanitized_output_preview(output: &str) -> String {
     let compact = output.split_whitespace().collect::<Vec<_>>().join(" ");
     let preview = ["access-token", "refresh-token"]
         .into_iter()
-        .fold(compact, |preview, key| redact_json_string_value(preview, key));
+        .fold(compact, |preview, key| {
+            redact_json_string_value(preview, key)
+        });
     const MAX_PREVIEW_CHARS: usize = 200;
     if preview.chars().count() <= MAX_PREVIEW_CHARS {
         preview
@@ -238,12 +241,8 @@ async fn run_and_parse_auth(
 ) -> Result<CliTokenResponse, String> {
     let output = run_auth_command(cli_runner, command).await?;
     serde_json::from_str(output.trim()).map_err(|e| {
-        tracing::warn!(
-            command,
-            error = %e,
-            output_preview = %sanitized_output_preview(&output),
-            "failed to parse auth response"
-        );
+        let output_preview = sanitized_output_preview(&output);
+        tracing::warn!(command, error = %e, output_preview, "failed to parse auth response");
         format!("Failed to parse {command} response from CLI")
     })
 }
@@ -535,5 +534,98 @@ mod tests {
         );
         let err = run_login(&cli).await.unwrap_err();
         assert!(!err.contains("secret-token"));
+    }
+
+    // -- default_web_root / resolve_web_root -------------------------------
+
+    #[test]
+    fn default_web_root_returns_none_for_cloud() {
+        let _lock = with_env_lock();
+        std::env::remove_var("CS_ONPREM_URL");
+        assert_eq!(default_web_root(), None);
+    }
+
+    #[test]
+    fn default_web_root_returns_url_for_onprem() {
+        let _lock = with_env_lock();
+        std::env::set_var("CS_ONPREM_URL", "https://onprem.example.com/");
+        assert_eq!(
+            default_web_root(),
+            Some("https://onprem.example.com".to_string())
+        );
+        std::env::remove_var("CS_ONPREM_URL");
+    }
+
+    #[test]
+    fn default_web_root_returns_none_when_https_validation_fails() {
+        let _lock = with_env_lock();
+        std::env::set_var("CS_ONPREM_URL", "http://not-localhost.example.com");
+        assert_eq!(default_web_root(), None);
+        std::env::remove_var("CS_ONPREM_URL");
+    }
+
+    #[test]
+    fn resolve_web_root_prefers_credential_over_env() {
+        let _lock = with_env_lock();
+        std::env::set_var("CS_ONPREM_URL", "https://env-onprem.example.com");
+        let credential = AuthCredential::OAuth {
+            access_token: "tok".to_string(),
+            onprem_url: Some("https://cred-onprem.example.com".to_string()),
+        };
+        assert_eq!(
+            resolve_web_root(Some(&credential)),
+            Some("https://cred-onprem.example.com".to_string())
+        );
+        std::env::remove_var("CS_ONPREM_URL");
+    }
+
+    #[test]
+    fn resolve_web_root_falls_back_to_env_when_no_credential() {
+        let _lock = with_env_lock();
+        std::env::set_var("CS_ONPREM_URL", "https://env-onprem.example.com");
+        assert_eq!(
+            resolve_web_root(None),
+            Some("https://env-onprem.example.com".to_string())
+        );
+        std::env::remove_var("CS_ONPREM_URL");
+    }
+
+    // -- sanitized_output_preview / redact_json_string_value ---------------
+
+    #[test]
+    fn sanitized_output_preview_returns_unchanged_when_short() {
+        let raw = r#"{"status":"signed_out"}"#;
+        assert_eq!(sanitized_output_preview(raw), "{\"status\":\"signed_out\"}");
+    }
+
+    #[test]
+    fn redact_json_string_value_stops_at_unterminated_value() {
+        let raw = r#"prefix "access-token":"unterminated"#;
+        // No closing quote after the value start — the loop should break
+        // without redacting or panicking.
+        assert_eq!(
+            redact_json_string_value(raw.to_string(), "access-token"),
+            raw
+        );
+    }
+
+    // -- run_auth_command CLI error mapping --------------------------------
+
+    #[tokio::test]
+    async fn fetch_token_maps_not_found_cli_error() {
+        let cli = MockCliRunner::with_responses(vec![Err(crate::errors::CliError::NotFound(
+            "cs".to_string(),
+        ))]);
+        let err = fetch_token(&cli).await.unwrap_err();
+        assert!(err.contains("CodeScene CLI not found"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn fetch_token_maps_io_cli_error() {
+        let cli = MockCliRunner::with_responses(vec![Err(crate::errors::CliError::Io(
+            std::io::Error::other("permission denied"),
+        ))]);
+        let err = fetch_token(&cli).await.unwrap_err();
+        assert!(err.contains("I/O error"), "got: {err}");
     }
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,0 +1,489 @@
+mod manager;
+
+pub(crate) use manager::AuthManager;
+
+use serde::Deserialize;
+
+use crate::cli::CliRunner;
+
+const MCP_OAUTH_CLIENT: &str = "mcp";
+
+/// Parsed response from `cs auth token --client mcp --output-format json`
+/// and `cs auth login --client mcp --output-format json`.
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct CliTokenResponse {
+    #[serde(rename = "status")]
+    pub(crate) status: String,
+    #[serde(rename = "access-token")]
+    pub(crate) access_token: Option<String>,
+    /// Full API URL, e.g. "https://host/api". Used to derive CS_ONPREM_URL.
+    #[serde(rename = "api-url")]
+    pub(crate) api_url: Option<String>,
+    /// Access token expiry in epoch seconds.
+    #[serde(rename = "expires-at")]
+    pub(crate) expires_at: Option<i64>,
+    /// Refresh token expiry in epoch seconds.
+    #[allow(dead_code)]
+    #[serde(rename = "refresh-token-expires-at")]
+    pub(crate) refresh_token_expires_at: Option<i64>,
+}
+
+impl CliTokenResponse {
+    pub(crate) fn is_signed_in(&self) -> bool {
+        self.status == "signed_in"
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AuthCredential {
+    /// Static credential from `CS_ACCESS_TOKEN` + optional `CS_ONPREM_URL`.
+    /// PATs do not expire in the short-lived sense; this variant is
+    /// reconstructed from env vars on each `resolve_credential()` call.
+    Configured {
+        access_token: String,
+        onprem_url: Option<String>,
+    },
+    /// OAuth credential produced by `AuthManager` from a CLI token response.
+    /// Contains the access token and the on-prem base URL (or `None` for cloud).
+    /// Expiry is managed by `AuthManager` which guarantees freshness before
+    /// producing this value.
+    OAuth {
+        access_token: String,
+        /// On-prem base URL (e.g. `https://host`), or `None` for cloud.
+        /// Derived from the CLI's `api-url` field at construction time.
+        onprem_url: Option<String>,
+    },
+}
+
+impl AuthCredential {
+    pub(crate) fn access_token(&self) -> &str {
+        match self {
+            Self::Configured { access_token, .. } | Self::OAuth { access_token, .. } => {
+                access_token
+            }
+        }
+    }
+
+    /// Returns the API root URL (e.g. `https://api.codescene.io` for cloud,
+    /// or `https://host/api` for on-prem).  Used for HTTP API calls.
+    pub(crate) fn api_root(&self) -> Result<String, crate::errors::ApiError> {
+        match self {
+            Self::Configured { onprem_url, .. } | Self::OAuth { onprem_url, .. } => {
+                api_base_from_onprem(onprem_url.as_deref())
+            }
+        }
+    }
+
+    /// Returns the browser-facing root URL for on-prem instances.
+    ///
+    /// - `Some("https://host")` — on-prem instance.
+    /// - `None` — CodeScene cloud (SaaS).
+    ///
+    /// The `None` vs `Some` distinction carries meaning beyond URL defaulting:
+    /// callers such as `codescene_links` use it to select structurally different
+    /// URL path schemas (on-prem uses `/{id}/analyses/`, cloud uses
+    /// `/projects/{id}/jobs/.../results/`).
+    pub(crate) fn web_root(&self) -> Option<String> {
+        match self {
+            Self::Configured { onprem_url, .. } | Self::OAuth { onprem_url, .. } => {
+                onprem_url.clone()
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn is_configured(&self) -> bool {
+        matches!(self, Self::Configured { .. })
+    }
+}
+
+fn api_base_from_onprem(onprem_url: Option<&str>) -> Result<String, crate::errors::ApiError> {
+    api_base_from_optional_url(onprem_url, "CS_ONPREM_URL", |url| {
+        format!("{}/api", url.trim_end_matches('/'))
+    })
+}
+
+fn api_base_from_optional_url(
+    url: Option<&str>,
+    label: &str,
+    normalize: impl FnOnce(&str) -> String,
+) -> Result<String, crate::errors::ApiError> {
+    let Some(url) = url.filter(|url| !url.trim().is_empty()) else {
+        return Ok("https://api.codescene.io".to_string());
+    };
+    crate::config::require_https(label, url)
+        .map_err(|e| crate::errors::ApiError::Transport(e.into()))?;
+    Ok(normalize(url))
+}
+
+pub(crate) fn configured_credential() -> Option<AuthCredential> {
+    let access_token = std::env::var("CS_ACCESS_TOKEN")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())?;
+    let onprem_url = read_onprem_url();
+    Some(AuthCredential::Configured {
+        access_token,
+        onprem_url,
+    })
+}
+
+/// Fallback API root when no `AuthCredential` is available.
+///
+/// Reads `CS_ONPREM_URL` from the environment to derive the API base
+/// (e.g. `https://host/api`), defaulting to `https://api.codescene.io`
+/// for cloud.  This is the pre-auth path — once a credential exists,
+/// use `credential.api_root()` instead.
+pub(crate) fn default_api_root() -> Result<String, crate::errors::ApiError> {
+    api_base_from_onprem(read_onprem_url().as_deref())
+}
+
+/// Fallback web root when no `AuthCredential` is available.
+///
+/// Reads `CS_ONPREM_URL` from the environment.  Returns `None` for
+/// cloud or if the URL fails HTTPS validation.
+pub(crate) fn default_web_root() -> Option<String> {
+    let url = read_onprem_url()?;
+    if let Err(e) = crate::config::require_https("CS_ONPREM_URL", &url) {
+        tracing::warn!("{e}");
+        return None;
+    }
+    Some(url)
+}
+
+/// Resolve the web root from an optional credential, falling back to
+/// the environment.  Returns `None` for cloud.
+///
+/// This is the standard pattern for obtaining a browser-facing base URL:
+/// use the credential if available, otherwise read `CS_ONPREM_URL`.
+/// The `None` return signals cloud — callers may use it to choose between
+/// cloud and on-prem URL path structures (see `codescene_links`).
+pub(crate) fn resolve_web_root(credential: Option<&AuthCredential>) -> Option<String> {
+    credential
+        .and_then(AuthCredential::web_root)
+        .or_else(default_web_root)
+}
+
+/// Read `CS_ONPREM_URL` from the environment, trimmed and normalized.
+/// Returns `None` if unset or empty.
+fn read_onprem_url() -> Option<String> {
+    std::env::var("CS_ONPREM_URL")
+        .ok()
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty())
+}
+
+pub(crate) fn now_epoch_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Fetch the current OAuth token via `cs auth token --client mcp --output-format json`.
+/// Returns `None` if the CLI reports not signed in.
+/// Returns `Err` on CLI failure or JSON parse error.
+pub(crate) async fn fetch_token(
+    cli_runner: &dyn CliRunner,
+) -> Result<Option<CliTokenResponse>, String> {
+    let parsed = run_and_parse_auth(cli_runner, "token").await?;
+    if !parsed.is_signed_in() {
+        return Ok(None);
+    }
+    Ok(Some(parsed))
+}
+
+/// Run `cs auth login --client mcp --output-format json` (blocking until the
+/// browser flow completes or the CLI's built-in 2-minute timeout fires).
+/// Returns the parsed response on success.
+pub(crate) async fn run_login(cli_runner: &dyn CliRunner) -> Result<CliTokenResponse, String> {
+    run_and_parse_auth(cli_runner, "login").await
+}
+
+async fn run_and_parse_auth(
+    cli_runner: &dyn CliRunner,
+    command: &str,
+) -> Result<CliTokenResponse, String> {
+    let output = run_auth_command(cli_runner, command).await?;
+    serde_json::from_str(output.trim()).map_err(|e| {
+        tracing::debug!(error = %e, command, "failed to parse auth response");
+        format!("Failed to parse {command} response from CLI")
+    })
+}
+
+async fn run_auth_command(cli_runner: &dyn CliRunner, command: &str) -> Result<String, String> {
+    cli_runner
+        .run(
+            &[
+                "auth",
+                command,
+                "--client",
+                MCP_OAUTH_CLIENT,
+                "--output-format",
+                "json",
+            ],
+            None,
+        )
+        .await
+        .map_err(|e| {
+            tracing::debug!(error = %e, command, "auth command failed");
+            match &e {
+                crate::errors::CliError::NotFound(_) => {
+                    "CodeScene CLI not found. Ensure it is installed.".to_string()
+                }
+                crate::errors::CliError::Io(_) => {
+                    format!("Failed to run auth {command}: I/O error")
+                }
+                _ => format!("Auth {command} failed (CLI exited with an error)"),
+            }
+        })
+}
+
+/// Build an `AuthCredential::OAuth` from a CLI token response.
+///
+/// Returns `None` if the response has no access token or only whitespace.
+/// Derives the on-prem base URL from the `api-url` field at construction
+/// time — `None` signals CodeScene cloud.
+/// Does NOT mutate environment variables — OAuth tokens live exclusively in
+/// the `AuthManager`'s in-memory cache and are threaded explicitly to API calls.
+pub(crate) fn credential_from_response(resp: &CliTokenResponse) -> Option<AuthCredential> {
+    let access_token = resp.access_token.as_deref()?.trim();
+    if access_token.is_empty() {
+        return None;
+    }
+    let onprem_url = resp
+        .api_url
+        .as_deref()
+        .and_then(extract_onprem_from_api_url);
+    Some(AuthCredential::OAuth {
+        access_token: access_token.to_string(),
+        onprem_url,
+    })
+}
+
+/// Extract the on-prem base URL (`https://host`) from a full API URL
+/// (`https://host/api`).  Returns `None` for cloud URLs, signaling that
+/// the default `https://api.codescene.io` / `https://codescene.io` should
+/// be used.
+fn extract_onprem_from_api_url(api_url: &str) -> Option<String> {
+    let trimmed = api_url.trim_end_matches('/');
+    // Recognize cloud by hostname.
+    let host_start = trimmed.find("://")? + 3;
+    let host_end = trimmed[host_start..]
+        .find('/')
+        .map(|i| host_start + i)
+        .unwrap_or(trimmed.len());
+    let host = &trimmed[host_start..host_end];
+    if host == "api.codescene.io" {
+        return None;
+    }
+    // Strip path to get scheme://host
+    Some(trimmed[..host_end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::MockCliRunner;
+
+    fn with_env_lock() -> impl Drop {
+        crate::config::lock_test_env()
+    }
+
+    // -- CliTokenResponse parsing -----------------------------------------
+
+    #[test]
+    fn parses_signed_in_response() {
+        let json = r#"{"status":"signed_in","access-token":"oau_abc","api-url":"https://test.example.com/api"}"#;
+        let resp: CliTokenResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.is_signed_in());
+        assert_eq!(resp.access_token.as_deref(), Some("oau_abc"));
+        assert_eq!(
+            resp.api_url.as_deref(),
+            Some("https://test.example.com/api")
+        );
+    }
+
+    #[test]
+    fn parses_signed_out_response() {
+        let json = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+        let resp: CliTokenResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.is_signed_in());
+    }
+
+    #[test]
+    fn parses_expired_status() {
+        let json = r#"{"status":"expired","access-token":null,"api-url":null}"#;
+        let resp: CliTokenResponse = serde_json::from_str(json).unwrap();
+        assert!(!resp.is_signed_in());
+        assert_eq!(resp.status, "expired");
+    }
+
+    #[test]
+    fn parses_real_token_response() {
+        let json = r#"{"refresh-token":"eyJ...","scopes":"cli.access","expires-at":1784044090,"client-id":"cs-cli","api-url":"https://test-env.enterprise.codescene.io/api","user-id":8,"source":"oauth","account-id":null,"status":"signed_in","client-url":"https://test-env.enterprise.codescene.io/oauth2/token","refresh-token-expires-at":1815576430,"storage-file":"/home/user/.codescene/creds.json","access-token":"oau_AAAA"}"#;
+        let resp: CliTokenResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.is_signed_in());
+        assert_eq!(resp.access_token.as_deref(), Some("oau_AAAA"));
+        assert_eq!(
+            resp.api_url.as_deref(),
+            Some("https://test-env.enterprise.codescene.io/api")
+        );
+        assert_eq!(resp.expires_at, Some(1784044090));
+        assert_eq!(resp.refresh_token_expires_at, Some(1815576430));
+    }
+
+    #[test]
+    fn expiry_fields_optional() {
+        let json = r#"{"status":"signed_in","access-token":"oau_x","api-url":null}"#;
+        let resp: CliTokenResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.expires_at.is_none());
+        assert!(resp.refresh_token_expires_at.is_none());
+    }
+
+    // -- extract_onprem_from_api_url ----------------------------------------
+
+    #[test]
+    fn extract_onprem_strips_path() {
+        assert_eq!(
+            extract_onprem_from_api_url("https://my.company.com/api"),
+            Some("https://my.company.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_onprem_returns_none_for_cloud() {
+        assert_eq!(
+            extract_onprem_from_api_url("https://api.codescene.io/api"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_onprem_no_path_returns_host() {
+        // A URL without /api still returns the host (on-prem without path)
+        assert_eq!(
+            extract_onprem_from_api_url("https://my.company.com"),
+            Some("https://my.company.com".to_string())
+        );
+    }
+
+    // -- credential helpers -----------------------------------------------
+
+    fn make_response(access_token: Option<&str>, api_url: Option<&str>) -> CliTokenResponse {
+        CliTokenResponse {
+            status: "signed_in".into(),
+            access_token: access_token.map(Into::into),
+            api_url: api_url.map(Into::into),
+            expires_at: None,
+            refresh_token_expires_at: None,
+        }
+    }
+
+    #[test]
+    fn credential_from_response_trims_and_preserves_api_url() {
+        let resp = make_response(Some("  oau_trimmed  "), Some("https://my.company.com/api"));
+        let credential = credential_from_response(&resp).unwrap();
+        assert_eq!(credential.access_token(), "oau_trimmed");
+        assert_eq!(credential.api_root().unwrap(), "https://my.company.com/api");
+        assert_eq!(
+            credential.web_root().as_deref(),
+            Some("https://my.company.com")
+        );
+    }
+
+    #[test]
+    fn oauth_cloud_api_url_drops_api_suffix() {
+        let resp = make_response(Some("oau_cloud"), Some("https://api.codescene.io/api"));
+        let credential = credential_from_response(&resp).unwrap();
+        assert_eq!(credential.api_root().unwrap(), "https://api.codescene.io");
+        assert_eq!(credential.web_root(), None);
+    }
+
+    #[test]
+    fn credential_from_response_requires_token() {
+        assert!(credential_from_response(&make_response(None, None)).is_none());
+        assert!(credential_from_response(&make_response(Some("   "), None)).is_none());
+    }
+
+    #[test]
+    fn configured_credential_reads_user_env_only() {
+        let _lock = with_env_lock();
+        std::env::set_var("CS_ACCESS_TOKEN", "  pat-token  ");
+        std::env::set_var("CS_ONPREM_URL", "https://my.company.com/");
+        let credential = configured_credential().unwrap();
+        assert!(credential.is_configured());
+        assert_eq!(credential.access_token(), "pat-token");
+        assert_eq!(credential.api_root().unwrap(), "https://my.company.com/api");
+        std::env::remove_var("CS_ACCESS_TOKEN");
+        std::env::remove_var("CS_ONPREM_URL");
+    }
+
+    // -- fetch_token / run_login ------------------------------------------
+
+    #[tokio::test]
+    async fn fetch_token_returns_some_when_signed_in() {
+        let json = r#"{"status":"signed_in","access-token":"oau_tok","api-url":"https://api.codescene.io/api"}"#;
+        let cli = MockCliRunner::with_ok(json);
+        let result = fetch_token(&cli).await.unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().access_token.as_deref(), Some("oau_tok"));
+    }
+
+    #[tokio::test]
+    async fn fetch_token_returns_none_when_signed_out() {
+        let json = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+        let cli = MockCliRunner::with_ok(json);
+        assert!(fetch_token(&cli).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_token_returns_none_when_expired() {
+        let json = r#"{"status":"expired","access-token":null,"api-url":null}"#;
+        let cli = MockCliRunner::with_ok(json);
+        assert!(fetch_token(&cli).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_token_returns_err_on_cli_failure() {
+        let cli = MockCliRunner::with_err(1, "connection refused");
+        assert!(fetch_token(&cli).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn fetch_token_returns_err_on_invalid_json() {
+        let cli = MockCliRunner::with_ok("not json");
+        assert!(fetch_token(&cli).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_login_returns_response_on_success() {
+        let json = r#"{"status":"signed_in","access-token":"oau_new","api-url":"https://api.codescene.io/api","expires-at":9999999999,"refresh-token-expires-at":9999999999}"#;
+        let cli = MockCliRunner::with_ok(json);
+        let result = run_login(&cli).await.unwrap();
+        assert!(result.is_signed_in());
+        assert_eq!(result.access_token.as_deref(), Some("oau_new"));
+    }
+
+    #[tokio::test]
+    async fn run_login_returns_err_on_cli_failure() {
+        let cli = MockCliRunner::with_err(1, "timeout waiting for browser");
+        assert!(run_login(&cli).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_login_returns_err_on_invalid_json() {
+        let cli = MockCliRunner::with_ok("Browser opened but no json returned");
+        let err = run_login(&cli).await.unwrap_err();
+        assert!(err.contains("Failed to parse"));
+    }
+
+    #[tokio::test]
+    async fn run_login_parse_error_does_not_echo_token() {
+        let cli = MockCliRunner::with_ok(
+            r#"{"status":"signed_in","access-token":"secret-token"} trailing"#,
+        );
+        let err = run_login(&cli).await.unwrap_err();
+        assert!(!err.contains("secret-token"));
+    }
+}

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -117,11 +117,15 @@ fn api_base_from_optional_url(
 }
 
 pub(crate) fn configured_credential() -> Option<AuthCredential> {
-    let access_token = std::env::var("CS_ACCESS_TOKEN")
-        .ok()
+    let vals = crate::config::try_read_env_multi(&["CS_ACCESS_TOKEN", "CS_ONPREM_URL"])?;
+    let access_token = vals[0]
+        .as_deref()
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())?;
-    let onprem_url = read_onprem_url();
+    let onprem_url = vals[1]
+        .as_deref()
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty());
     Some(AuthCredential::Configured {
         access_token,
         onprem_url,
@@ -164,11 +168,10 @@ pub(crate) fn resolve_web_root(credential: Option<&AuthCredential>) -> Option<St
         .or_else(default_web_root)
 }
 
-/// Read `CS_ONPREM_URL` from the environment, trimmed and normalized.
+/// Read `CS_ONPREM_URL` from the guarded config env, trimmed and normalized.
 /// Returns `None` if unset or empty.
 fn read_onprem_url() -> Option<String> {
-    std::env::var("CS_ONPREM_URL")
-        .ok()
+    crate::config::try_read_env("CS_ONPREM_URL")
         .map(|v| v.trim().trim_end_matches('/').to_string())
         .filter(|v| !v.is_empty())
 }
@@ -178,6 +181,35 @@ pub(crate) fn now_epoch_secs() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+fn sanitized_output_preview(output: &str) -> String {
+    let compact = output.split_whitespace().collect::<Vec<_>>().join(" ");
+    let preview = ["access-token", "refresh-token"]
+        .into_iter()
+        .fold(compact, |preview, key| redact_json_string_value(preview, key));
+    const MAX_PREVIEW_CHARS: usize = 200;
+    if preview.chars().count() <= MAX_PREVIEW_CHARS {
+        preview
+    } else {
+        let truncated = preview.chars().take(MAX_PREVIEW_CHARS).collect::<String>();
+        format!("{truncated}...")
+    }
+}
+
+fn redact_json_string_value(mut text: String, key: &str) -> String {
+    let pattern = format!("\"{key}\":\"");
+    let mut search_from = 0;
+    while let Some(relative_start) = text[search_from..].find(&pattern) {
+        let value_start = search_from + relative_start + pattern.len();
+        let Some(relative_end) = text[value_start..].find('"') else {
+            break;
+        };
+        let value_end = value_start + relative_end;
+        text.replace_range(value_start..value_end, "[redacted]");
+        search_from = value_start + "[redacted]".len();
+    }
+    text
 }
 
 /// Fetch the current OAuth token via `cs auth token --client mcp --output-format json`.
@@ -206,7 +238,12 @@ async fn run_and_parse_auth(
 ) -> Result<CliTokenResponse, String> {
     let output = run_auth_command(cli_runner, command).await?;
     serde_json::from_str(output.trim()).map_err(|e| {
-        tracing::debug!(error = %e, command, "failed to parse auth response");
+        tracing::warn!(
+            command,
+            error = %e,
+            output_preview = %sanitized_output_preview(&output),
+            "failed to parse auth response"
+        );
         format!("Failed to parse {command} response from CLI")
     })
 }
@@ -226,7 +263,7 @@ async fn run_auth_command(cli_runner: &dyn CliRunner, command: &str) -> Result<S
         )
         .await
         .map_err(|e| {
-            tracing::debug!(error = %e, command, "auth command failed");
+            tracing::warn!(error = %e, command, error_kind = e.kind(), "auth command failed");
             match &e {
                 crate::errors::CliError::NotFound(_) => {
                     "CodeScene CLI not found. Ensure it is installed.".to_string()
@@ -331,6 +368,19 @@ mod tests {
         );
         assert_eq!(resp.expires_at, Some(1784044090));
         assert_eq!(resp.refresh_token_expires_at, Some(1815576430));
+    }
+
+    #[test]
+    fn sanitized_output_preview_redacts_tokens_and_truncates() {
+        let raw = format!(
+            "{{\"access-token\":\"secret-access\",\"refresh-token\":\"secret-refresh\",\"message\":\"{}\"}}",
+            "x".repeat(300)
+        );
+        let preview = sanitized_output_preview(&raw);
+        assert!(!preview.contains("secret-access"), "preview: {preview}");
+        assert!(!preview.contains("secret-refresh"), "preview: {preview}");
+        assert!(preview.contains("[redacted]"), "preview: {preview}");
+        assert!(preview.ends_with("..."), "preview: {preview}");
     }
 
     #[test]

--- a/src/auth/state.rs
+++ b/src/auth/state.rs
@@ -1,0 +1,152 @@
+use super::{now_epoch_secs, AuthCredential, CliTokenResponse};
+
+/// Tokens are considered stale this many seconds before their actual `expires-at`.
+const TOKEN_EXPIRY_MARGIN_SECS: i64 = 60;
+
+/// Sentinel value for `CS_OAUTH_EXPIRES_AT` indicating the user is signed out.
+const SIGNED_OUT_SENTINEL: &str = "0";
+
+pub(super) fn fresh_credential() -> Option<AuthCredential> {
+    let vals = crate::config::try_read_env_multi(&[
+        "CS_OAUTH_TOKEN",
+        "CS_OAUTH_EXPIRES_AT",
+        "CS_ONPREM_URL",
+    ])?;
+    let token = vals[0].as_deref()?.trim().to_string();
+    if token.is_empty() {
+        let oauth_expires_at = vals[1].clone();
+        tracing::info!(oauth_expires_at, "cached OAuth state has no access token");
+        return None;
+    }
+    if let Some(expires_str) = vals[1].as_deref() {
+        if let Ok(expires_at) = expires_str.parse::<i64>() {
+            if expires_at <= now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS {
+                tracing::info!(
+                    oauth_expires_at = expires_at,
+                    "cached OAuth token is expired or within refresh margin"
+                );
+                return None;
+            }
+        }
+    }
+    let onprem_url = vals[2]
+        .as_deref()
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty());
+    Some(AuthCredential::OAuth {
+        access_token: token,
+        onprem_url,
+    })
+}
+
+pub(super) fn has_fresh_token() -> bool {
+    fresh_credential().is_some()
+}
+
+pub(super) fn guard_has_fresh_token(guard: &crate::config::ConfigEnvWriteGuard) -> bool {
+    let Some(token) = guard.read_env("CS_OAUTH_TOKEN") else {
+        return false;
+    };
+    if token.trim().is_empty() {
+        return false;
+    }
+    let Some(expires_str) = guard.read_env("CS_OAUTH_EXPIRES_AT") else {
+        return false;
+    };
+    let Ok(expires_at) = expires_str.parse::<i64>() else {
+        return false;
+    };
+    expires_at > now_epoch_secs() + TOKEN_EXPIRY_MARGIN_SECS
+}
+
+pub(super) fn is_signed_out() -> bool {
+    crate::config::try_read_env("CS_OAUTH_EXPIRES_AT").as_deref() == Some(SIGNED_OUT_SENTINEL)
+}
+
+pub(super) fn guard_is_signed_out(guard: &crate::config::ConfigEnvWriteGuard) -> bool {
+    guard.read_env("CS_OAUTH_EXPIRES_AT").as_deref() == Some(SIGNED_OUT_SENTINEL)
+}
+
+pub(super) fn response_from_env() -> Option<CliTokenResponse> {
+    let vals = crate::config::try_read_env_multi(&[
+        "CS_OAUTH_TOKEN",
+        "CS_OAUTH_EXPIRES_AT",
+        "CS_OAUTH_REFRESH_EXPIRES_AT",
+        "CS_ONPREM_URL",
+    ])?;
+    let token = vals[0].clone()?;
+    let expires_at = vals[1].as_deref().and_then(|s| s.parse::<i64>().ok());
+    let refresh_expires_at = vals[2].as_deref().and_then(|s| s.parse::<i64>().ok());
+    let api_url = vals[3]
+        .as_deref()
+        .map(|u| format!("{}/api", u.trim_end_matches('/')));
+    Some(CliTokenResponse {
+        status: "signed_in".into(),
+        access_token: Some(token),
+        api_url,
+        expires_at,
+        refresh_token_expires_at: refresh_expires_at,
+    })
+}
+
+pub(super) fn response_from_guard(guard: &crate::config::ConfigEnvWriteGuard) -> CliTokenResponse {
+    let token = guard.read_env("CS_OAUTH_TOKEN");
+    let expires_at = guard
+        .read_env("CS_OAUTH_EXPIRES_AT")
+        .and_then(|s| s.parse::<i64>().ok());
+    let refresh_expires_at = guard
+        .read_env("CS_OAUTH_REFRESH_EXPIRES_AT")
+        .and_then(|s| s.parse::<i64>().ok());
+    let api_url = guard
+        .read_env("CS_ONPREM_URL")
+        .map(|u| format!("{}/api", u.trim_end_matches('/')));
+    CliTokenResponse {
+        status: "signed_in".into(),
+        access_token: token,
+        api_url,
+        expires_at,
+        refresh_token_expires_at: refresh_expires_at,
+    }
+}
+
+pub(super) fn persist_response(
+    guard: &crate::config::ConfigEnvWriteGuard,
+    response: &CliTokenResponse,
+) {
+    let token = response.access_token.as_deref().unwrap_or("").trim();
+    let expires_at = response
+        .expires_at
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let refresh_expires_at = response
+        .refresh_token_expires_at
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+    let entries: &[(&str, &str)] = &[
+        ("oauth_token", token),
+        ("oauth_expires_at", &expires_at),
+        ("oauth_refresh_expires_at", &refresh_expires_at),
+    ];
+    if let Err(e) = guard.write_env_multi(entries) {
+        tracing::warn!(error = %e, "failed to persist OAuth state to config file");
+    }
+    let has_access_token = !token.is_empty();
+    tracing::info!(
+        has_access_token,
+        expires_at = %expires_at,
+        refresh_expires_at = %refresh_expires_at,
+        "persisted OAuth state to config-backed environment"
+    );
+}
+
+pub(super) fn persist_signed_out(guard: &crate::config::ConfigEnvWriteGuard) {
+    let entries: &[(&str, &str)] = &[
+        ("oauth_token", ""),
+        ("oauth_expires_at", SIGNED_OUT_SENTINEL),
+        ("oauth_refresh_expires_at", ""),
+    ];
+    if let Err(e) = guard.write_env_multi(entries) {
+        tracing::warn!(error = %e, "failed to persist signed-out state to config file");
+    }
+    tracing::info!("persisted signed-out sentinel to config-backed environment");
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,7 @@ fn resolve_from_docker() -> Option<Result<PathBuf, CliError>> {
 
 pub async fn run_cli(args: &[&str], working_dir: Option<&Path>) -> Result<String, CliError> {
     let cli_path = resolve_cli_path()?;
+    tracing::info!(path = %cli_path.display(), args = ?args, "using CodeScene CLI");
     run_cli_at_path(&cli_path, args, working_dir).await
 }
 
@@ -105,14 +106,6 @@ async fn run_cli_process(
     let mut cmd = tokio::process::Command::new(cli_path);
     let effective_args = with_ssl_cli_args_if_needed(cli_path, args);
 
-    // Scrub sensitive env vars (tokens) from the inherited environment so
-    // child processes that don't need them can't read them from /proc or
-    // inherit them to further subprocesses.  We then selectively add back
-    // only CS_ACCESS_TOKEN, which the CLI needs for on-prem authentication.
-    for var in crate::config::sensitive_env_vars() {
-        cmd.env_remove(var);
-    }
-
     cmd.args(&effective_args)
         .env("CS_CONTEXT", "mcp-server")
         .env("CS_DISABLE_VERSION_CHECK", "1");
@@ -121,22 +114,42 @@ async fn run_cli_process(
         cmd.env("CS_DISABLE_TRACKING", "1");
     }
 
-    if let Ok(token) = std::env::var("CS_ACCESS_TOKEN") {
-        let token = token.trim();
-        if !token.is_empty() {
-            cmd.env("CS_ACCESS_TOKEN", token);
-        }
-    }
-
-    if let Ok(url) = std::env::var("CS_ONPREM_URL") {
-        cmd.env("CS_ONPREM_URL", url);
-    }
+    remove_sensitive_env_vars(&mut cmd);
+    apply_optional_cli_env(&mut cmd, "CS_ACCESS_TOKEN", true);
+    apply_optional_cli_env(&mut cmd, "CS_ONPREM_URL", false);
+    apply_optional_cli_env(&mut cmd, "CS_OAUTH_CLIENT", true);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
     }
 
     cmd.output().await.map_err(CliError::from)
+}
+
+fn remove_sensitive_env_vars(cmd: &mut tokio::process::Command) {
+    // Scrub sensitive env vars (tokens) from the inherited environment so
+    // child processes that don't need them can't read them from /proc or
+    // inherit them to further subprocesses. We then selectively add back
+    // the specific values the CLI needs.
+    for var in crate::config::sensitive_env_vars() {
+        cmd.env_remove(var);
+    }
+}
+
+fn apply_optional_cli_env(cmd: &mut tokio::process::Command, key: &str, trim: bool) {
+    let Some(value) = crate::config::try_read_env(key) else {
+        return;
+    };
+
+    let value = if trim {
+        value.trim().to_string()
+    } else {
+        value
+    };
+
+    if !value.is_empty() {
+        cmd.env(key, value);
+    }
 }
 
 fn should_retry_after_telemetry_flush_error(stderr: &str) -> bool {
@@ -1296,19 +1309,22 @@ sC0Nc9QdNQt5Tos5Je5S7CWL0w==
         let _lock = config::lock_test_env();
         std::env::set_var("CS_ACCESS_TOKEN", "test-token-xyz");
         std::env::set_var("CS_ONPREM_URL", "https://onprem.example.com");
+        std::env::set_var("CS_OAUTH_CLIENT", "mcp");
 
         let output = run_cli_at_path(
             Path::new("/bin/sh"),
-            &["-c", "echo $CS_ACCESS_TOKEN $CS_ONPREM_URL"],
+            &["-c", "echo $CS_ACCESS_TOKEN $CS_ONPREM_URL $CS_OAUTH_CLIENT"],
             None,
         )
         .await
         .unwrap();
         assert!(output.contains("test-token-xyz"));
         assert!(output.contains("https://onprem.example.com"));
+        assert!(output.contains("mcp"));
 
         std::env::remove_var("CS_ACCESS_TOKEN");
         std::env::remove_var("CS_ONPREM_URL");
+        std::env::remove_var("CS_OAUTH_CLIENT");
     }
 
     #[cfg(unix)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,7 @@ use std::sync::OnceLock;
 use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 use uuid::Uuid;
 
 use crate::errors::ConfigError;
@@ -34,6 +35,114 @@ pub(crate) fn lock_test_env() -> std::sync::MutexGuard<'static, ()> {
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|e| e.into_inner())
+}
+
+// ---------------------------------------------------------------------------
+// RwLock-guarded access to config-backed environment variables.
+//
+// All reads and writes of config-backed env vars (the vars listed in OPTIONS)
+// should go through `read_env` / `write_env` / `write_env_multi` to ensure
+// consistent concurrent access and atomic persistence to the config file.
+// ---------------------------------------------------------------------------
+
+/// Global RwLock guarding all config-backed environment variable access.
+/// Readers can proceed concurrently; writers get exclusive access and
+/// persist changes to both process env and the config file atomically.
+/// Uses tokio::sync::RwLock so that the write guard can be held across
+/// await points (e.g. CLI subprocess calls).
+static CONFIG_ENV_LOCK: OnceLock<RwLock<()>> = OnceLock::new();
+
+fn config_env_lock() -> &'static RwLock<()> {
+    CONFIG_ENV_LOCK.get_or_init(|| RwLock::new(()))
+}
+
+/// Synchronous read of a config-backed env var. Uses `try_read` to avoid
+/// blocking; returns `None` if the lock is contended or the var is unset.
+pub fn try_read_env(env_var: &str) -> Option<String> {
+    let _guard = config_env_lock().try_read().ok()?;
+    std::env::var(env_var).ok().filter(|v| !v.is_empty())
+}
+
+/// Synchronous read of multiple config-backed env vars. Uses `try_read`.
+/// Returns `None` if the lock is contended.
+pub fn try_read_env_multi(env_vars: &[&str]) -> Option<Vec<Option<String>>> {
+    let _guard = config_env_lock().try_read().ok()?;
+    Some(
+        env_vars
+            .iter()
+            .map(|var| std::env::var(var).ok().filter(|v| !v.is_empty()))
+            .collect(),
+    )
+}
+
+/// Write a single config-backed env var under the exclusive write lock.
+/// Also persists the new value to the config file.
+/// Pass an empty value to remove the key.
+pub async fn write_env(key: &str, value: &str) -> Result<(), ConfigError> {
+    write_env_multi(&[(key, value)]).await
+}
+
+/// Write multiple config-backed env vars atomically under the exclusive write lock.
+/// Also persists all new values to the config file.
+/// Pass an empty value for a key to remove it.
+pub async fn write_env_multi(entries: &[(&str, &str)]) -> Result<(), ConfigError> {
+    let _guard = config_env_lock().write().await;
+    write_env_multi_inner(entries)
+}
+
+/// Acquire the exclusive config write lock. While held, no other thread can
+/// read or write config-backed env vars. Use this when you need to hold the
+/// lock across an external operation (e.g. a CLI call) and then write the
+/// result atomically.
+pub async fn acquire_write_lock() -> ConfigEnvWriteGuard {
+    let guard = config_env_lock().write().await;
+    ConfigEnvWriteGuard { _guard: guard }
+}
+
+/// RAII guard for the config env write lock. While held, provides methods
+/// to read and write env vars without re-acquiring the lock.
+pub struct ConfigEnvWriteGuard {
+    _guard: tokio::sync::RwLockWriteGuard<'static, ()>,
+}
+
+impl ConfigEnvWriteGuard {
+    /// Read an env var while holding the write lock (for double-check patterns).
+    pub fn read_env(&self, env_var: &str) -> Option<String> {
+        std::env::var(env_var).ok().filter(|v| !v.is_empty())
+    }
+
+    /// Write multiple entries to env + config file while holding the lock.
+    pub fn write_env_multi(&self, entries: &[(&str, &str)]) -> Result<(), ConfigError> {
+        write_env_multi_inner(entries)
+    }
+}
+
+/// Shared implementation for writing env vars + persisting to config.
+/// Caller must already hold the write lock.
+fn write_env_multi_inner(entries: &[(&str, &str)]) -> Result<(), ConfigError> {
+    let mut data = load().unwrap_or_default();
+
+    for &(key, value) in entries {
+        let option = match find_option(key) {
+            Some(o) => o,
+            None => continue,
+        };
+
+        if value.is_empty() {
+            data.values.remove(option.key);
+            if !is_client_env_var(option.env_var) {
+                std::env::remove_var(option.env_var);
+            }
+        } else {
+            data.values
+                .insert(option.key.to_string(), value.to_string());
+            if !is_client_env_var(option.env_var) {
+                std::env::set_var(option.env_var, value);
+            }
+        }
+    }
+
+    save(&data)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -501,15 +610,24 @@ mod tests {
         });
     }
 
+    fn apply_to_env_value(config_key: &str, value: &str) {
+        let mut data = ConfigData::default();
+        data.values.insert(config_key.to_string(), value.to_string());
+        apply_to_env(&data);
+    }
+
+    fn enabled_tools_from(value: &str) -> Option<HashSet<String>> {
+        let mut data = ConfigData::default();
+        data.values
+            .insert("enabled_tools".to_string(), value.to_string());
+        enabled_tools(&data)
+    }
+
     #[test]
     fn apply_to_env_skips_already_set_vars() {
         let _lock = lock_test_env();
         std::env::set_var("CS_ONPREM_URL", "already-set");
-        let mut data = ConfigData::default();
-        data.values
-            .insert("onprem_url".to_string(), "from-config".to_string());
-
-        apply_to_env(&data);
+        apply_to_env_value("onprem_url", "from-config");
 
         let val = std::env::var("CS_ONPREM_URL").unwrap();
         assert_eq!(val, "already-set");
@@ -520,12 +638,20 @@ mod tests {
     fn apply_to_env_skips_empty_values() {
         let _lock = lock_test_env();
         std::env::remove_var("CS_ONPREM_URL");
-        let mut data = ConfigData::default();
-        data.values.insert("onprem_url".to_string(), "".to_string());
-
-        apply_to_env(&data);
+        apply_to_env_value("onprem_url", "");
 
         assert!(std::env::var("CS_ONPREM_URL").is_err());
+    }
+
+    #[test]
+    fn apply_to_env_sets_oauth_client() {
+        let _lock = lock_test_env();
+        std::env::remove_var("CS_OAUTH_CLIENT");
+        apply_to_env_value("oauth_client", "mcp");
+
+        let val = std::env::var("CS_OAUTH_CLIENT").unwrap_or_default();
+        assert_eq!(val, "mcp");
+        std::env::remove_var("CS_OAUTH_CLIENT");
     }
 
     #[test]
@@ -572,40 +698,26 @@ mod tests {
 
     #[test]
     fn enabled_tools_returns_none_when_empty() {
-        let mut data = ConfigData::default();
-        data.values
-            .insert("enabled_tools".to_string(), "".to_string());
-        assert!(enabled_tools(&data).is_none());
+        assert!(enabled_tools_from("").is_none());
     }
 
     #[test]
     fn enabled_tools_returns_none_when_whitespace_only() {
-        let mut data = ConfigData::default();
-        data.values
-            .insert("enabled_tools".to_string(), "  ".to_string());
-        assert!(enabled_tools(&data).is_none());
+        assert!(enabled_tools_from("  ").is_none());
     }
 
     #[test]
     fn enabled_tools_parses_single_tool() {
-        let mut data = ConfigData::default();
-        data.values.insert(
-            "enabled_tools".to_string(),
-            "code_health_review".to_string(),
-        );
-        let result = enabled_tools(&data).unwrap();
+        let result = enabled_tools_from("code_health_review").unwrap();
         assert_eq!(result.len(), 1);
         assert!(result.contains("code_health_review"));
     }
 
     #[test]
     fn enabled_tools_parses_multiple_tools() {
-        let mut data = ConfigData::default();
-        data.values.insert(
-            "enabled_tools".to_string(),
-            "code_health_review,code_health_score,analyze_change_set".to_string(),
-        );
-        let result = enabled_tools(&data).unwrap();
+        let result =
+            enabled_tools_from("code_health_review,code_health_score,analyze_change_set")
+                .unwrap();
         assert_eq!(result.len(), 3);
         assert!(result.contains("code_health_review"));
         assert!(result.contains("code_health_score"));
@@ -614,12 +726,7 @@ mod tests {
 
     #[test]
     fn enabled_tools_trims_whitespace() {
-        let mut data = ConfigData::default();
-        data.values.insert(
-            "enabled_tools".to_string(),
-            " code_health_review , code_health_score ".to_string(),
-        );
-        let result = enabled_tools(&data).unwrap();
+        let result = enabled_tools_from(" code_health_review , code_health_score ").unwrap();
         assert_eq!(result.len(), 2);
         assert!(result.contains("code_health_review"));
         assert!(result.contains("code_health_score"));
@@ -627,12 +734,7 @@ mod tests {
 
     #[test]
     fn enabled_tools_ignores_empty_segments() {
-        let mut data = ConfigData::default();
-        data.values.insert(
-            "enabled_tools".to_string(),
-            "code_health_review,,code_health_score,".to_string(),
-        );
-        let result = enabled_tools(&data).unwrap();
+        let result = enabled_tools_from("code_health_review,,code_health_score,").unwrap();
         assert_eq!(result.len(), 2);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -612,7 +612,8 @@ mod tests {
 
     fn apply_to_env_value(config_key: &str, value: &str) {
         let mut data = ConfigData::default();
-        data.values.insert(config_key.to_string(), value.to_string());
+        data.values
+            .insert(config_key.to_string(), value.to_string());
         apply_to_env(&data);
     }
 
@@ -716,8 +717,7 @@ mod tests {
     #[test]
     fn enabled_tools_parses_multiple_tools() {
         let result =
-            enabled_tools_from("code_health_review,code_health_score,analyze_change_set")
-                .unwrap();
+            enabled_tools_from("code_health_review,code_health_score,analyze_change_set").unwrap();
         assert_eq!(result.len(), 3);
         assert!(result.contains("code_health_review"));
         assert!(result.contains("code_health_score"));
@@ -736,5 +736,29 @@ mod tests {
     fn enabled_tools_ignores_empty_segments() {
         let result = enabled_tools_from("code_health_review,,code_health_score,").unwrap();
         assert_eq!(result.len(), 2);
+    }
+
+    // ---- write_env_multi / write_env_multi_inner ----
+
+    #[tokio::test]
+    async fn write_env_multi_skips_unknown_keys_but_applies_known_ones() {
+        let _lock = lock_test_env();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("CS_CONFIG_DIR", dir.path().as_os_str());
+
+        let result = write_env_multi(&[
+            ("not_a_real_config_key", "whatever"),
+            ("ca_bundle", "/cert.pem"),
+        ])
+        .await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(
+            std::env::var("REQUESTS_CA_BUNDLE").ok().as_deref(),
+            Some("/cert.pem")
+        );
+
+        std::env::remove_var("CS_CONFIG_DIR");
+        std::env::remove_var("REQUESTS_CA_BUNDLE");
     }
 }

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -100,6 +100,46 @@ pub const OPTIONS: &[ConfigOption] = &[
         aliases: &["log_days"],
         docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
     },
+    ConfigOption {
+        key: "oauth_token",
+        env_var: "CS_OAUTH_TOKEN",
+        description: "OAuth access token (managed automatically by login flow)",
+        sensitive: true,
+        hidden: true,
+        api_only: false,
+        aliases: &[],
+        docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
+    },
+    ConfigOption {
+        key: "oauth_expires_at",
+        env_var: "CS_OAUTH_EXPIRES_AT",
+        description: "OAuth access token expiry as epoch seconds (managed automatically)",
+        sensitive: false,
+        hidden: true,
+        api_only: false,
+        aliases: &[],
+        docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
+    },
+    ConfigOption {
+        key: "oauth_refresh_expires_at",
+        env_var: "CS_OAUTH_REFRESH_EXPIRES_AT",
+        description: "OAuth refresh token expiry as epoch seconds (managed automatically)",
+        sensitive: false,
+        hidden: true,
+        api_only: false,
+        aliases: &[],
+        docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
+    },
+    ConfigOption {
+        key: "oauth_client",
+        env_var: "CS_OAUTH_CLIENT",
+        description: "OAuth client slot used by CLI subprocesses (managed automatically)",
+        sensitive: false,
+        hidden: true,
+        api_only: false,
+        aliases: &[],
+        docs_url: "https://codescene.io/docs/integrations/mcp.html#configuration",
+    },
 ];
 
 /// Tool names that can be enabled/disabled via the `enabled_tools` config.
@@ -226,5 +266,12 @@ mod tests {
         let opt = find_option("environment");
         assert!(opt.is_some());
         assert_eq!(opt.unwrap().key, "tracking_environment");
+    }
+
+    #[test]
+    fn find_option_oauth_client_by_env_var() {
+        let opt = find_option("CS_OAUTH_CLIENT");
+        assert!(opt.is_some());
+        assert_eq!(opt.unwrap().key, "oauth_client");
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -4,7 +4,11 @@ use super::options::{ConfigOption, OPTIONS};
 const URL_KEYS: &[&str] = &["onprem_url"];
 
 /// Localhost hosts that are exempt from the HTTPS requirement.
-const LOCALHOST_HOSTS: &[&str] = &["localhost", "127.0.0.1", "0.0.0.0"];
+/// `host.docker.internal` is included because it is the standard way for a
+/// process running inside a Docker container to reach services on its host
+/// machine (e.g. our e2e tests' fake servers) — it is not a publicly
+/// routable address, so it carries the same trust profile as `localhost`.
+const LOCALHOST_HOSTS: &[&str] = &["localhost", "127.0.0.1", "0.0.0.0", "host.docker.internal"];
 
 /// Check whether a URL (after stripping the scheme) points to a localhost address.
 fn is_localhost_url(url: &str) -> bool {
@@ -27,7 +31,7 @@ fn is_allowed_url(url: &str) -> bool {
 
 /// Validate that a URL value uses the HTTPS scheme.
 /// Returns `Ok(())` for valid HTTPS URLs, or `Err` with a user-facing message.
-/// Localhost addresses (localhost, 127.0.0.1, 0.0.0.0) are exempt.
+/// Localhost addresses (localhost, 127.0.0.1, 0.0.0.0, host.docker.internal) are exempt.
 pub fn validate_https_url(key: &str, url: &str) -> Result<(), String> {
     if !URL_KEYS.contains(&key) {
         return Ok(());
@@ -44,7 +48,7 @@ pub fn validate_https_url(key: &str, url: &str) -> Result<(), String> {
 
 /// Validate that a raw URL string uses HTTPS. Used for env vars not managed
 /// through the config system (e.g. CS_TRACKING_URL).
-/// Localhost addresses (localhost, 127.0.0.1, 0.0.0.0) are exempt.
+/// Localhost addresses (localhost, 127.0.0.1, 0.0.0.0, host.docker.internal) are exempt.
 pub fn require_https(env_var: &str, url: &str) -> Result<(), String> {
     let trimmed = url.trim();
     if is_allowed_url(trimmed) {
@@ -178,6 +182,18 @@ mod tests {
     fn require_https_accepts_http_0_0_0_0() {
         assert!(require_https("CS_TRACKING_URL", "http://0.0.0.0").is_ok());
         assert!(require_https("CS_TRACKING_URL", "http://0.0.0.0:9090").is_ok());
+    }
+
+    #[test]
+    fn validate_https_url_accepts_http_host_docker_internal() {
+        assert!(validate_https_url("onprem_url", "http://host.docker.internal").is_ok());
+        assert!(validate_https_url("onprem_url", "http://host.docker.internal:8080").is_ok());
+    }
+
+    #[test]
+    fn require_https_accepts_http_host_docker_internal() {
+        assert!(require_https("CS_TRACKING_URL", "http://host.docker.internal").is_ok());
+        assert!(require_https("CS_TRACKING_URL", "http://host.docker.internal:9090").is_ok());
     }
 
     #[test]

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -33,7 +33,7 @@ pub fn get_all(data: &ConfigData, is_standalone: bool) -> String {
     serde_json::to_string(&result).unwrap_or_default()
 }
 
-pub fn set_value(key: &str, value: &str) -> String {
+pub async fn set_value(key: &str, value: &str) -> String {
     let option = match config::find_option(key) {
         Some(o) => o,
         None => return unknown_key_error(key),
@@ -51,12 +51,44 @@ pub fn set_value(key: &str, value: &str) -> String {
         }
     }
 
-    let mut data = config::load().unwrap_or_default();
+    // Use the guarded write path: acquires write lock, updates env + config file.
+    if let Err(e) = config::write_env(option.key, value).await {
+        return format!("Error saving config: {e}");
+    }
 
+    serde_json::to_string(&set_value_response(option, value)).unwrap_or_default()
+}
+
+fn set_value_response(option: &config::ConfigOption, value: &str) -> serde_json::Value {
     if value.is_empty() {
-        delete_key(option, &mut data)
-    } else {
-        save_key(option, value, &mut data)
+        let mut result = json!({ "status": "removed", "key": option.key });
+        attach_docs_url(&mut result, option);
+        return result;
+    }
+
+    let mut result = json!({
+        "status": "saved",
+        "key": option.key,
+        "config_dir": config::config_dir().to_string_lossy(),
+    });
+    attach_set_value_warnings(&mut result, option, value);
+    attach_docs_url(&mut result, option);
+    result
+}
+
+fn attach_set_value_warnings(
+    result: &mut serde_json::Value,
+    option: &config::ConfigOption,
+    value: &str,
+) {
+    if let Some(warning) = env_override_warning(option) {
+        result["warning"] = json!(warning);
+    }
+    if let Some(restart) = restart_warning(option) {
+        result["restart_required"] = json!(restart);
+    }
+    if let Some(tool_warning) = unknown_tool_names_warning(option, value) {
+        result["tool_name_warning"] = json!(tool_warning);
     }
 }
 
@@ -102,47 +134,6 @@ fn api_only_error(key: &str, is_standalone: bool) -> String {
         "valid_keys": valid,
     }))
     .unwrap_or_default()
-}
-
-fn delete_key(option: &config::ConfigOption, data: &mut ConfigData) -> String {
-    data.values.remove(option.key);
-    if let Err(e) = config::save(data) {
-        return format!("Error saving config: {e}");
-    }
-    if !config::is_client_env_var(option.env_var) {
-        std::env::remove_var(option.env_var);
-    }
-    let mut result = json!({ "status": "removed", "key": option.key });
-    attach_docs_url(&mut result, option);
-    serde_json::to_string(&result).unwrap_or_default()
-}
-
-fn save_key(option: &config::ConfigOption, value: &str, data: &mut ConfigData) -> String {
-    data.values
-        .insert(option.key.to_string(), value.to_string());
-    if let Err(e) = config::save(data) {
-        return format!("Error saving config: {e}");
-    }
-    if !config::is_client_env_var(option.env_var) {
-        std::env::set_var(option.env_var, value);
-    }
-
-    let mut result = json!({
-        "status": "saved",
-        "key": option.key,
-        "config_dir": config::config_dir().to_string_lossy(),
-    });
-    if let Some(warning) = env_override_warning(option) {
-        result["warning"] = json!(warning);
-    }
-    if let Some(restart) = restart_warning(option) {
-        result["restart_required"] = json!(restart);
-    }
-    if let Some(tool_warning) = unknown_tool_names_warning(option, value) {
-        result["tool_name_warning"] = json!(tool_warning);
-    }
-    attach_docs_url(&mut result, option);
-    serde_json::to_string(&result).unwrap_or_default()
 }
 
 fn env_override_warning(option: &config::ConfigOption) -> Option<String> {
@@ -401,6 +392,20 @@ mod tests {
 
     // ---- set_value / delete_key / save_key via CS_CONFIG_DIR ----
 
+    /// Helper: run an async closure with CS_CONFIG_DIR pointing to a fresh temp dir,
+    /// holding the env lock to prevent parallel test interference.
+    async fn with_temp_config_dir_async<F, Fut>(f: F)
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let _lock = config::lock_test_env();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("CS_CONFIG_DIR", dir.path().as_os_str());
+        f().await;
+        std::env::remove_var("CS_CONFIG_DIR");
+    }
+
     /// Helper: run a closure with CS_CONFIG_DIR pointing to a fresh temp dir,
     /// holding the env lock to prevent parallel test interference.
     fn with_temp_config_dir<F, R>(f: F) -> R
@@ -415,92 +420,89 @@ mod tests {
         result
     }
 
-    #[test]
-    fn set_value_unknown_key_returns_error() {
-        let result = set_value("nonexistent", "val");
+    #[tokio::test]
+    async fn set_value_unknown_key_returns_error() {
+        let result = set_value("nonexistent", "val").await;
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.get("error").is_some());
     }
 
-    #[test]
-    fn set_value_saves_key_to_config() {
-        with_temp_config_dir(|| {
-            let result = set_value("ca_bundle", "/path/to/cert.pem");
+    #[tokio::test]
+    async fn set_value_saves_key_to_config() {
+        with_temp_config_dir_async(|| async {
+            let result = set_value("ca_bundle", "/path/to/cert.pem").await;
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert_eq!(parsed["key"], json!("ca_bundle"));
             assert!(parsed.get("config_dir").is_some());
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_access_token_includes_restart_warning() {
-        with_temp_config_dir(|| {
-            let result = set_value("access_token", "my-token");
+    #[tokio::test]
+    async fn set_value_access_token_includes_restart_warning() {
+        with_temp_config_dir_async(|| async {
+            let result = set_value("access_token", "my-token").await;
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("restart_required").is_some());
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_trims_access_token() {
-        with_temp_config_dir(|| {
-            let _ = set_value("access_token", "  my-token  ");
+    #[tokio::test]
+    async fn set_value_trims_access_token() {
+        with_temp_config_dir_async(|| async {
+            let _ = set_value("access_token", "  my-token  ").await;
             let data = config::load().unwrap();
             assert_eq!(
                 data.values.get("access_token").map(|s| s.as_str()),
                 Some("my-token")
             );
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_includes_docs_url() {
-        with_temp_config_dir(|| {
-            let result = set_value("ca_bundle", "/cert.pem");
+    #[tokio::test]
+    async fn set_value_includes_docs_url() {
+        with_temp_config_dir_async(|| async {
+            let result = set_value("ca_bundle", "/cert.pem").await;
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert!(parsed.get("docs_url").is_some());
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_empty_deletes_key() {
-        with_temp_config_dir(|| {
-            // First save a value
-            set_value("ca_bundle", "/cert.pem");
-            // Then delete by setting empty
-            let result = set_value("ca_bundle", "");
+    #[tokio::test]
+    async fn set_value_empty_deletes_key() {
+        with_temp_config_dir_async(|| async {
+            set_value("ca_bundle", "/cert.pem").await;
+            let result = set_value("ca_bundle", "").await;
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("removed"));
             assert_eq!(parsed["key"], json!("ca_bundle"));
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_delete_includes_docs_url() {
-        with_temp_config_dir(|| {
-            set_value("ca_bundle", "/cert.pem");
-            let result = set_value("ca_bundle", "");
+    #[tokio::test]
+    async fn set_value_delete_includes_docs_url() {
+        with_temp_config_dir_async(|| async {
+            set_value("ca_bundle", "/cert.pem").await;
+            let result = set_value("ca_bundle", "").await;
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert!(parsed.get("docs_url").is_some());
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_client_var_includes_env_override_warning() {
-        with_temp_config_dir(|| {
-            // Ensure snapshot captures CS_DISABLE_TRACKING as a client var.
+    #[tokio::test]
+    async fn set_value_client_var_includes_env_override_warning() {
+        with_temp_config_dir_async(|| async {
             std::env::set_var("CS_DISABLE_TRACKING", "1");
             config::snapshot_client_env_vars();
-            let result = set_value("disable_tracking", "true");
+            let result = set_value("disable_tracking", "true").await;
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("warning").is_some());
             let warning = parsed["warning"].as_str().unwrap();
             assert!(warning.contains("CS_DISABLE_TRACKING"));
             std::env::remove_var("CS_DISABLE_TRACKING");
-        });
+        }).await;
     }
 
     // ---- save failure paths ----
@@ -597,64 +599,74 @@ mod tests {
 
     // ---- set_value for enabled_tools ----
 
-    #[test]
-    fn set_value_enabled_tools_includes_restart_warning() {
-        with_temp_config_dir(|| {
-            let result = set_value("enabled_tools", "code_health_review,code_health_score");
+    #[tokio::test]
+    async fn set_value_enabled_tools_includes_restart_warning() {
+        with_temp_config_dir_async(|| async {
+            let result = set_value("enabled_tools", "code_health_review,code_health_score").await;
             std::env::remove_var("CS_ENABLED_TOOLS");
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("restart_required").is_some());
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_enabled_tools_with_unknown_name_includes_warning() {
-        with_temp_config_dir(|| {
-            let result = set_value("enabled_tools", "code_health_review,bogus_tool");
+    #[tokio::test]
+    async fn set_value_enabled_tools_with_unknown_name_includes_warning() {
+        with_temp_config_dir_async(|| async {
+            let result = set_value("enabled_tools", "code_health_review,bogus_tool").await;
             std::env::remove_var("CS_ENABLED_TOOLS");
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("tool_name_warning").is_some());
             let warning = parsed["tool_name_warning"].as_str().unwrap();
             assert!(warning.contains("bogus_tool"));
-        });
+        }).await;
     }
 
-    #[test]
-    fn set_value_enabled_tools_valid_names_no_tool_warning() {
-        with_temp_config_dir(|| {
-            let result = set_value("enabled_tools", "code_health_review,code_health_score");
+    #[tokio::test]
+    async fn set_value_enabled_tools_valid_names_no_tool_warning() {
+        with_temp_config_dir_async(|| async {
+            let result = set_value("enabled_tools", "code_health_review,code_health_score").await;
             std::env::remove_var("CS_ENABLED_TOOLS");
             let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
             assert_eq!(parsed["status"], json!("saved"));
             assert!(parsed.get("tool_name_warning").is_none());
-        });
+        }).await;
     }
 
     // ---- save failure paths ----
 
-    #[test]
-    fn save_key_returns_error_when_save_fails() {
-        with_unwritable_config_dir(|| {
-            let result = set_value("ca_bundle", "/cert.pem");
-            assert!(
-                result.contains("Error saving config"),
-                "expected save error, got: {result}"
-            );
-        });
+    #[tokio::test]
+    async fn save_key_returns_error_when_save_fails() {
+        let _lock = config::lock_test_env();
+        let impossible = if cfg!(windows) {
+            r"NUL\impossible"
+        } else {
+            "/dev/null/impossible"
+        };
+        std::env::set_var("CS_CONFIG_DIR", impossible);
+        let result = set_value("ca_bundle", "/cert.pem").await;
+        std::env::remove_var("CS_CONFIG_DIR");
+        assert!(
+            result.contains("Error saving config"),
+            "expected save error, got: {result}"
+        );
     }
 
-    #[test]
-    fn delete_key_returns_error_when_save_fails() {
-        with_unwritable_config_dir(|| {
-            // First, set a value in ConfigData (won't persist since save fails)
-            // Then try deleting — delete_key also calls save
-            let result = set_value("ca_bundle", "");
-            assert!(
-                result.contains("Error saving config"),
-                "expected save error, got: {result}"
-            );
-        });
+    #[tokio::test]
+    async fn delete_key_returns_error_when_save_fails() {
+        let _lock = config::lock_test_env();
+        let impossible = if cfg!(windows) {
+            r"NUL\impossible"
+        } else {
+            "/dev/null/impossible"
+        };
+        std::env::set_var("CS_CONFIG_DIR", impossible);
+        let result = set_value("ca_bundle", "").await;
+        std::env::remove_var("CS_CONFIG_DIR");
+        assert!(
+            result.contains("Error saving config"),
+            "expected save error, got: {result}"
+        );
     }
 }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -406,20 +406,6 @@ mod tests {
         std::env::remove_var("CS_CONFIG_DIR");
     }
 
-    /// Helper: run a closure with CS_CONFIG_DIR pointing to a fresh temp dir,
-    /// holding the env lock to prevent parallel test interference.
-    fn with_temp_config_dir<F, R>(f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        let _lock = config::lock_test_env();
-        let dir = tempfile::tempdir().unwrap();
-        std::env::set_var("CS_CONFIG_DIR", dir.path().as_os_str());
-        let result = f();
-        std::env::remove_var("CS_CONFIG_DIR");
-        result
-    }
-
     #[tokio::test]
     async fn set_value_unknown_key_returns_error() {
         let result = set_value("nonexistent", "val").await;
@@ -428,24 +414,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn set_value_saves_key_to_config() {
+    async fn set_value_returns_expected_response_metadata() {
         with_temp_config_dir_async(|| async {
-            let result = set_value("ca_bundle", "/path/to/cert.pem").await;
-            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-            assert_eq!(parsed["status"], json!("saved"));
-            assert_eq!(parsed["key"], json!("ca_bundle"));
-            assert!(parsed.get("config_dir").is_some());
-        }).await;
-    }
-
-    #[tokio::test]
-    async fn set_value_access_token_includes_restart_warning() {
-        with_temp_config_dir_async(|| async {
-            let result = set_value("access_token", "my-token").await;
-            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-            assert_eq!(parsed["status"], json!("saved"));
-            assert!(parsed.get("restart_required").is_some());
-        }).await;
+            for (key, value, status, metadata) in [
+                ("ca_bundle", "/path/to/cert.pem", "saved", "config_dir"),
+                ("access_token", "my-token", "saved", "restart_required"),
+                ("ca_bundle", "", "removed", "docs_url"),
+                (
+                    "enabled_tools",
+                    "code_health_review,code_health_score",
+                    "saved",
+                    "restart_required",
+                ),
+            ] {
+                if value.is_empty() {
+                    set_value(key, "/cert.pem").await;
+                }
+                let result = set_value(key, value).await;
+                let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+                assert_eq!(parsed["status"], json!(status), "key: {key}");
+                assert_eq!(parsed["key"], json!(key));
+                assert!(
+                    parsed.get(metadata).is_some(),
+                    "key: {key}, metadata: {metadata}"
+                );
+                assert!(parsed.get("tool_name_warning").is_none(), "key: {key}");
+            }
+            std::env::remove_var("CS_ENABLED_TOOLS");
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -457,37 +454,8 @@ mod tests {
                 data.values.get("access_token").map(|s| s.as_str()),
                 Some("my-token")
             );
-        }).await;
-    }
-
-    #[tokio::test]
-    async fn set_value_includes_docs_url() {
-        with_temp_config_dir_async(|| async {
-            let result = set_value("ca_bundle", "/cert.pem").await;
-            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-            assert!(parsed.get("docs_url").is_some());
-        }).await;
-    }
-
-    #[tokio::test]
-    async fn set_value_empty_deletes_key() {
-        with_temp_config_dir_async(|| async {
-            set_value("ca_bundle", "/cert.pem").await;
-            let result = set_value("ca_bundle", "").await;
-            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-            assert_eq!(parsed["status"], json!("removed"));
-            assert_eq!(parsed["key"], json!("ca_bundle"));
-        }).await;
-    }
-
-    #[tokio::test]
-    async fn set_value_delete_includes_docs_url() {
-        with_temp_config_dir_async(|| async {
-            set_value("ca_bundle", "/cert.pem").await;
-            let result = set_value("ca_bundle", "").await;
-            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-            assert!(parsed.get("docs_url").is_some());
-        }).await;
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -502,28 +470,31 @@ mod tests {
             let warning = parsed["warning"].as_str().unwrap();
             assert!(warning.contains("CS_DISABLE_TRACKING"));
             std::env::remove_var("CS_DISABLE_TRACKING");
-        }).await;
+        })
+        .await;
     }
 
     // ---- save failure paths ----
 
-    /// Helper: run a closure with CS_CONFIG_DIR pointing to an unwritable
-    /// location so that `config::save()` will fail.
-    fn with_unwritable_config_dir<F, R>(f: F) -> R
+    /// Path known to make `create_dir_all` fail so that `config::save()`
+    /// (and hence the guarded config write path) can't write:
+    ///   Unix:    /dev/null is a file, so /dev/null/impossible cannot be created.
+    ///   Windows: NUL is a reserved device name, so NUL\impossible cannot be created.
+    #[cfg(windows)]
+    const IMPOSSIBLE_CONFIG_DIR: &str = r"NUL\impossible";
+    #[cfg(not(windows))]
+    const IMPOSSIBLE_CONFIG_DIR: &str = "/dev/null/impossible";
+
+    /// Helper: run an async closure with CS_CONFIG_DIR pointing to an
+    /// unwritable location so that `config::save()` will fail.
+    async fn with_unwritable_config_dir<F, Fut, R>(f: F) -> R
     where
-        F: FnOnce() -> R,
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = R>,
     {
         let _lock = config::lock_test_env();
-        // Use a path where create_dir_all will fail:
-        //   Unix:    /dev/null is a file, so /dev/null/impossible cannot be created.
-        //   Windows: NUL is a reserved device name, so NUL\impossible cannot be created.
-        let impossible = if cfg!(windows) {
-            r"NUL\impossible"
-        } else {
-            "/dev/null/impossible"
-        };
-        std::env::set_var("CS_CONFIG_DIR", impossible);
-        let result = f();
+        std::env::set_var("CS_CONFIG_DIR", IMPOSSIBLE_CONFIG_DIR);
+        let result = f().await;
         std::env::remove_var("CS_CONFIG_DIR");
         result
     }
@@ -600,17 +571,6 @@ mod tests {
     // ---- set_value for enabled_tools ----
 
     #[tokio::test]
-    async fn set_value_enabled_tools_includes_restart_warning() {
-        with_temp_config_dir_async(|| async {
-            let result = set_value("enabled_tools", "code_health_review,code_health_score").await;
-            std::env::remove_var("CS_ENABLED_TOOLS");
-            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-            assert_eq!(parsed["status"], json!("saved"));
-            assert!(parsed.get("restart_required").is_some());
-        }).await;
-    }
-
-    #[tokio::test]
     async fn set_value_enabled_tools_with_unknown_name_includes_warning() {
         with_temp_config_dir_async(|| async {
             let result = set_value("enabled_tools", "code_health_review,bogus_tool").await;
@@ -620,33 +580,15 @@ mod tests {
             assert!(parsed.get("tool_name_warning").is_some());
             let warning = parsed["tool_name_warning"].as_str().unwrap();
             assert!(warning.contains("bogus_tool"));
-        }).await;
-    }
-
-    #[tokio::test]
-    async fn set_value_enabled_tools_valid_names_no_tool_warning() {
-        with_temp_config_dir_async(|| async {
-            let result = set_value("enabled_tools", "code_health_review,code_health_score").await;
-            std::env::remove_var("CS_ENABLED_TOOLS");
-            let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
-            assert_eq!(parsed["status"], json!("saved"));
-            assert!(parsed.get("tool_name_warning").is_none());
-        }).await;
+        })
+        .await;
     }
 
     // ---- save failure paths ----
 
     #[tokio::test]
     async fn save_key_returns_error_when_save_fails() {
-        let _lock = config::lock_test_env();
-        let impossible = if cfg!(windows) {
-            r"NUL\impossible"
-        } else {
-            "/dev/null/impossible"
-        };
-        std::env::set_var("CS_CONFIG_DIR", impossible);
-        let result = set_value("ca_bundle", "/cert.pem").await;
-        std::env::remove_var("CS_CONFIG_DIR");
+        let result = with_unwritable_config_dir(|| set_value("ca_bundle", "/cert.pem")).await;
         assert!(
             result.contains("Error saving config"),
             "expected save error, got: {result}"
@@ -655,15 +597,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_key_returns_error_when_save_fails() {
-        let _lock = config::lock_test_env();
-        let impossible = if cfg!(windows) {
-            r"NUL\impossible"
-        } else {
-            "/dev/null/impossible"
-        };
-        std::env::set_var("CS_CONFIG_DIR", impossible);
-        let result = set_value("ca_bundle", "").await;
-        std::env::remove_var("CS_CONFIG_DIR");
+        let result = with_unwritable_config_dir(|| set_value("ca_bundle", "")).await;
         assert!(
             result.contains("Error saving config"),
             "expected save error, got: {result}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,24 +174,11 @@ impl CodeSceneServer {
             .await
         {
             Ok(Some(credential)) => {
-                tracing::info!(
-                    source = credential_source(&credential),
-                    has_web_root = credential.web_root().is_some(),
-                    "token requirement satisfied"
-                );
+                self.log_credential_resolved(&credential, "token requirement satisfied");
                 None
             }
             Ok(None) => {
-                tracing::warn!(
-                    has_configured_token = crate::auth::configured_credential().is_some(),
-                    has_oauth_token = self.auth_manager.try_cached_access_token().is_some(),
-                    oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT"),
-                    signed_out_sentinel = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT")
-                        .as_deref()
-                        == Some("0"),
-                    oauth_client = crate::config::try_read_env("CS_OAUTH_CLIENT"),
-                    "token requirement failed: no usable credential resolved"
-                );
+                self.log_no_credential("token requirement failed: no usable credential resolved");
                 Some(CallToolResult::success(vec![Content::text(
                     TOKEN_MISSING_MSG,
                 )]))
@@ -212,24 +199,11 @@ impl CodeSceneServer {
             .await
         {
             Ok(Some(credential)) => {
-                tracing::info!(
-                    source = credential_source(&credential),
-                    has_web_root = credential.web_root().is_some(),
-                    "resolved auth credential for API tool"
-                );
+                self.log_credential_resolved(&credential, "resolved auth credential for API tool");
                 Ok(credential)
             }
             Ok(None) => {
-                tracing::warn!(
-                    has_configured_token = crate::auth::configured_credential().is_some(),
-                    has_oauth_token = self.auth_manager.try_cached_access_token().is_some(),
-                    oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT"),
-                    signed_out_sentinel = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT")
-                        .as_deref()
-                        == Some("0"),
-                    oauth_client = crate::config::try_read_env("CS_OAUTH_CLIENT"),
-                    "failed to resolve auth credential for API tool"
-                );
+                self.log_no_credential("failed to resolve auth credential for API tool");
                 Err(CallToolResult::success(vec![Content::text(
                     TOKEN_MISSING_MSG,
                 )]))
@@ -241,6 +215,29 @@ impl CodeSceneServer {
                 )]))
             }
         }
+    }
+
+    fn log_credential_resolved(&self, credential: &AuthCredential, message: &'static str) {
+        let source = credential_source(credential);
+        let has_web_root = credential.web_root().is_some();
+        tracing::info!(source, has_web_root, "{}", message);
+    }
+
+    fn log_no_credential(&self, message: &'static str) {
+        let has_configured_token = crate::auth::configured_credential().is_some();
+        let has_oauth_token = self.auth_manager.try_cached_access_token().is_some();
+        let oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT");
+        let signed_out_sentinel = oauth_expires_at.as_deref() == Some("0");
+        let oauth_client = crate::config::try_read_env("CS_OAUTH_CLIENT");
+        tracing::warn!(
+            has_configured_token,
+            has_oauth_token,
+            oauth_expires_at,
+            signed_out_sentinel,
+            oauth_client,
+            "{}",
+            message
+        );
     }
 
     pub(crate) async fn maybe_version_warning(&self, text: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod api_client;
+mod auth;
 mod business_case;
 mod cli;
 mod config;
@@ -38,12 +39,13 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 
+use crate::auth::{AuthCredential, AuthManager};
 use crate::cli::CliRunner;
 use crate::config::ConfigData;
 use crate::http::HttpClient;
 use crate::tools::validation::{ValidationError, Validator};
 use crate::tools::{
-    ChangeSetParam, DownloadSkillParam, FilePathParam, GetConfigParam, GitRepoParam,
+    ChangeSetParam, DownloadSkillParam, FilePathParam, GetConfigParam, GitRepoParam, LoginParam,
     OptionalContext, OwnershipParam, ProjectFileParam, ProjectParam,
     RulesConfigListThresholdsParam, RulesConfigSetRuleParam, RulesConfigSetThresholdParam,
     RulesConfigValidateParam, SetConfigParam, SkillNameParam, SyncSkillsParam,
@@ -52,10 +54,11 @@ use crate::version_checker::VersionChecker;
 
 const TOKEN_MISSING_MSG: &str = "\
 No access token configured.\n\n\
-To use this tool, set your access token using one of these methods:\n\
+To sign in with OAuth, use the `login` tool.\n\n\
+Alternatively, set your access token directly:\n\
 1. Use the `set_config` tool: set_config(key=\"access_token\", value=\"your-token\")\n\
 2. Set the CS_ACCESS_TOKEN environment variable in your MCP client configuration\n\n\
-To get an Access Token, see:\n\
+To get a Personal Access Token, see:\n\
 https://github.com/codescene-oss/codescene-mcp-server/blob/main/docs/getting-a-personal-access-token.md";
 
 const _VERSION_NOTICE_SUFFIX: &str = "\n\
@@ -73,7 +76,7 @@ pub(crate) const API_ONLY_TOOLS: &[&str] = &[
 ];
 
 /// Tools that cannot be disabled via `enabled_tools` config.
-pub(crate) const ALWAYS_ENABLED_TOOLS: &[&str] = &["get_config", "set_config"];
+pub(crate) const ALWAYS_ENABLED_TOOLS: &[&str] = &["get_config", "set_config", "login"];
 
 #[derive(Debug)]
 pub(crate) enum CliAction {
@@ -133,6 +136,7 @@ pub(crate) struct ServerDeps {
     pub(crate) instance_id: String,
     pub(crate) is_standalone: bool,
     pub(crate) version_checker: VersionChecker,
+    pub(crate) auth_manager: AuthManager,
     pub(crate) cli_runner: Arc<dyn CliRunner>,
     pub(crate) http_client: Arc<dyn HttpClient>,
     pub(crate) validator: Arc<dyn Validator>,
@@ -142,6 +146,7 @@ pub(crate) struct ServerDeps {
 pub(crate) struct CodeSceneServer {
     pub(crate) tool_router: ToolRouter<Self>,
     pub(crate) version_checker: VersionChecker,
+    pub(crate) auth_manager: AuthManager,
     pub(crate) config_data: Arc<ConfigData>,
     pub(crate) instance_id: String,
     pub(crate) is_standalone: bool,
@@ -151,16 +156,42 @@ pub(crate) struct CodeSceneServer {
 }
 
 impl CodeSceneServer {
-    pub(crate) fn require_token(&self) -> Option<CallToolResult> {
-        if std::env::var("CS_ACCESS_TOKEN")
-            .map(|v| v.trim().is_empty())
-            .unwrap_or(true)
+    pub(crate) async fn require_token(&self) -> Option<CallToolResult> {
+        match self
+            .auth_manager
+            .resolve_credential(&*self.cli_runner)
+            .await
         {
-            return Some(CallToolResult::success(vec![Content::text(
+            Ok(Some(_)) => None,
+            Ok(None) => Some(CallToolResult::success(vec![Content::text(
                 TOKEN_MISSING_MSG,
-            )]));
+            )])),
+            Err(e) => {
+                tracing::warn!(error = %e, "auth token check failed");
+                Some(CallToolResult::success(vec![Content::text(
+                    TOKEN_MISSING_MSG,
+                )]))
+            }
         }
-        None
+    }
+
+    pub(crate) async fn resolve_auth_credential(&self) -> Result<AuthCredential, CallToolResult> {
+        match self
+            .auth_manager
+            .resolve_credential(&*self.cli_runner)
+            .await
+        {
+            Ok(Some(credential)) => Ok(credential),
+            Ok(None) => Err(CallToolResult::success(vec![Content::text(
+                TOKEN_MISSING_MSG,
+            )])),
+            Err(e) => {
+                tracing::warn!(error = %e, "auth token check failed");
+                Err(CallToolResult::success(vec![Content::text(
+                    TOKEN_MISSING_MSG,
+                )]))
+            }
+        }
     }
 
     pub(crate) async fn maybe_version_warning(&self, text: &str) -> String {
@@ -174,47 +205,56 @@ impl CodeSceneServer {
     }
 
     pub(crate) fn track(&self, event: &str, props: serde_json::Value) {
-        tracking::track_event(event, props, &self.instance_id);
+        tracking::track_event(event, props, &self.instance_id, &self.tracking_auth());
     }
 
     pub(crate) fn track_err(&self, tool: &str, err: &errors::CliError) {
         tracing::warn!(tool, error = %err, "tool error");
-        tracking::track_error(&tracking::ErrorEvent {
-            error_kind: err.kind(),
-            tool_name: tool,
-            instance_id: &self.instance_id,
-            detail: None,
-        });
+        self.track_error_event(err.kind(), tool, None);
     }
 
     pub(crate) fn track_api_err(&self, tool: &str, err: &errors::ApiError) {
         tracing::warn!(tool, error = %err, "API error");
-        tracking::track_error(&tracking::ErrorEvent {
-            error_kind: err.kind(),
-            tool_name: tool,
-            instance_id: &self.instance_id,
-            detail: None,
-        });
+        self.track_error_event(err.kind(), tool, None);
     }
 
     pub(crate) fn track_validation_err(&self, tool: &str, err: &ValidationError) {
         tracing::warn!(tool, error = %err, "tool error");
-        tracking::track_error(&tracking::ErrorEvent {
-            error_kind: err.kind,
-            tool_name: tool,
-            instance_id: &self.instance_id,
-            detail: err.detail.as_deref(),
-        });
+        self.track_error_event(err.kind, tool, err.detail.as_deref());
     }
 
     pub(crate) fn track_err_msg(&self, tool: &str, error_kind: &str, err: &str) {
         tracing::warn!(tool, error = err, "tool error");
+        self.track_error_event(error_kind, tool, None);
+    }
+
+    fn track_error_event(&self, error_kind: &str, tool: &str, detail: Option<&str>) {
+        let auth = self.tracking_auth();
         tracking::track_error(&tracking::ErrorEvent {
             error_kind,
             tool_name: tool,
             instance_id: &self.instance_id,
-            detail: None,
+            detail,
+            auth: &auth,
         });
+    }
+
+    /// Resolve the best available token and API root for tracking.
+    /// Prefers configured PAT, falls back to cached OAuth token.
+    fn tracking_auth(&self) -> tracking::TrackingAuth {
+        if let Some(cred) = auth::configured_credential() {
+            return tracking::TrackingAuth {
+                access_token: cred.access_token().to_string(),
+                api_root: cred.api_root().ok(),
+            };
+        }
+        tracking::TrackingAuth {
+            access_token: self
+                .auth_manager
+                .try_cached_access_token()
+                .unwrap_or_default(),
+            api_root: self.auth_manager.try_cached_api_root(),
+        }
     }
 }
 
@@ -253,6 +293,7 @@ impl CodeSceneServer {
         Self {
             tool_router: router,
             version_checker: deps.version_checker,
+            auth_manager: deps.auth_manager,
             config_data: Arc::new(deps.config_data),
             instance_id: deps.instance_id,
             is_standalone: deps.is_standalone,
@@ -468,6 +509,17 @@ impl CodeSceneServer {
     }
 
     #[tool(
+        description = "Sign in to CodeScene using OAuth.\n\nWhen to use:\n    Use this tool when no access token is configured and the user needs\n    to authenticate. The tool opens the user's browser to complete the\n    OAuth flow. If the browser cannot be opened automatically, the URL\n    is printed so the user can open it manually.\n\nLimitations:\n    - Not needed when CS_ACCESS_TOKEN is already set.\n    - Requires the embedded CLI to be available.\n    - Waits up to 2 minutes for the user to complete the browser flow.\n    - For on-prem instances, configure CS_ONPREM_URL before calling this tool.\n\nReturns:\n    A success message when signed in, or an error describing the failure.\n\nExample:\n    Call without arguments to sign in to CodeScene cloud.",
+        input_schema = inlined_schema_for::<LoginParam>()
+    )]
+    async fn login(
+        &self,
+        Parameters(params): Parameters<LoginParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        tools::login::handle(self, params).await
+    }
+
+    #[tool(
         description = "List all available skills embedded in this MCP server.\n\nWhen to use:\n    Use this tool to discover what skills are available for\n    download or inspection.\n\nLimitations:\n    - Returns only skills embedded at compile time.\n    - Does not scan external skill directories.\n\nReturns:\n    A formatted list of skill names with their descriptions.\n\nExample:\n    Call this tool to see all available skills, then use\n    download_skill or sync_skills to install them locally."
     )]
     async fn list_skills(&self) -> Result<CallToolResult, ErrorData> {
@@ -609,6 +661,7 @@ async fn main() -> anyhow::Result<()> {
         instance_id,
         is_standalone,
         version_checker,
+        auth_manager: AuthManager::new(),
         cli_runner: Arc::new(cli::ProductionCliRunner),
         http_client: Arc::new(http::ReqwestClient),
         validator: Arc::new(tools::validation::ProductionCliValidator),

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,8 +54,9 @@ use crate::version_checker::VersionChecker;
 
 const TOKEN_MISSING_MSG: &str = "\
 No access token configured.\n\n\
-To sign in with OAuth, use the `login` tool.\n\n\
-Alternatively, set your access token directly:\n\
+Call the `login` tool now to sign in with OAuth. Do not ask the user for a token first.\n\n\
+Use a Personal Access Token only when OAuth is not suitable, such as CI/CD or other headless environments.\n\
+If a token must be configured manually:\n\
 1. Use the `set_config` tool: set_config(key=\"access_token\", value=\"your-token\")\n\
 2. Set the CS_ACCESS_TOKEN environment variable in your MCP client configuration\n\n\
 To get a Personal Access Token, see:\n\
@@ -92,6 +93,16 @@ pub(crate) fn display_version(raw_version: &str) -> &str {
 
 pub(crate) fn help_text() -> &'static str {
     "CodeScene MCP Server\n\nUsage: cs-mcp [OPTIONS]\n\nOptions:\n  -h, --help       Show this help message and exit\n  -v, --version    Show version and exit\n  --cli-version    Show embedded CLI version and exit"
+}
+
+async fn ensure_oauth_client_configured() {
+    if crate::config::try_read_env("CS_OAUTH_CLIENT").is_some() {
+        return;
+    }
+
+    if let Err(e) = crate::config::write_env("oauth_client", "mcp").await {
+        tracing::warn!(error = %e, "failed to persist default OAuth client");
+    }
 }
 
 pub(crate) fn parse_cli_args(args: &[String], raw_version: &str) -> Result<CliAction, String> {
@@ -162,10 +173,29 @@ impl CodeSceneServer {
             .resolve_credential(&*self.cli_runner)
             .await
         {
-            Ok(Some(_)) => None,
-            Ok(None) => Some(CallToolResult::success(vec![Content::text(
-                TOKEN_MISSING_MSG,
-            )])),
+            Ok(Some(credential)) => {
+                tracing::info!(
+                    source = credential_source(&credential),
+                    has_web_root = credential.web_root().is_some(),
+                    "token requirement satisfied"
+                );
+                None
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    has_configured_token = crate::auth::configured_credential().is_some(),
+                    has_oauth_token = self.auth_manager.try_cached_access_token().is_some(),
+                    oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT"),
+                    signed_out_sentinel = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT")
+                        .as_deref()
+                        == Some("0"),
+                    oauth_client = crate::config::try_read_env("CS_OAUTH_CLIENT"),
+                    "token requirement failed: no usable credential resolved"
+                );
+                Some(CallToolResult::success(vec![Content::text(
+                    TOKEN_MISSING_MSG,
+                )]))
+            }
             Err(e) => {
                 tracing::warn!(error = %e, "auth token check failed");
                 Some(CallToolResult::success(vec![Content::text(
@@ -181,10 +211,29 @@ impl CodeSceneServer {
             .resolve_credential(&*self.cli_runner)
             .await
         {
-            Ok(Some(credential)) => Ok(credential),
-            Ok(None) => Err(CallToolResult::success(vec![Content::text(
-                TOKEN_MISSING_MSG,
-            )])),
+            Ok(Some(credential)) => {
+                tracing::info!(
+                    source = credential_source(&credential),
+                    has_web_root = credential.web_root().is_some(),
+                    "resolved auth credential for API tool"
+                );
+                Ok(credential)
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    has_configured_token = crate::auth::configured_credential().is_some(),
+                    has_oauth_token = self.auth_manager.try_cached_access_token().is_some(),
+                    oauth_expires_at = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT"),
+                    signed_out_sentinel = crate::config::try_read_env("CS_OAUTH_EXPIRES_AT")
+                        .as_deref()
+                        == Some("0"),
+                    oauth_client = crate::config::try_read_env("CS_OAUTH_CLIENT"),
+                    "failed to resolve auth credential for API tool"
+                );
+                Err(CallToolResult::success(vec![Content::text(
+                    TOKEN_MISSING_MSG,
+                )]))
+            }
             Err(e) => {
                 tracing::warn!(error = %e, "auth token check failed");
                 Err(CallToolResult::success(vec![Content::text(
@@ -255,6 +304,13 @@ impl CodeSceneServer {
                 .unwrap_or_default(),
             api_root: self.auth_manager.try_cached_api_root(),
         }
+    }
+}
+
+fn credential_source(credential: &AuthCredential) -> &'static str {
+    match credential {
+        AuthCredential::Configured { .. } => "configured",
+        AuthCredential::OAuth { .. } => "oauth",
     }
 }
 
@@ -509,7 +565,7 @@ impl CodeSceneServer {
     }
 
     #[tool(
-        description = "Sign in to CodeScene using OAuth.\n\nWhen to use:\n    Use this tool when no access token is configured and the user needs\n    to authenticate. The tool opens the user's browser to complete the\n    OAuth flow. If the browser cannot be opened automatically, the URL\n    is printed so the user can open it manually.\n\nLimitations:\n    - Not needed when CS_ACCESS_TOKEN is already set.\n    - Requires the embedded CLI to be available.\n    - Waits up to 2 minutes for the user to complete the browser flow.\n    - For on-prem instances, configure CS_ONPREM_URL before calling this tool.\n\nReturns:\n    A success message when signed in, or an error describing the failure.\n\nExample:\n    Call without arguments to sign in to CodeScene cloud.",
+        description = "Sign in to CodeScene using OAuth.\n\nWhen to use:\n    Use this tool when no CS_ACCESS_TOKEN env to authenticate. Can be used during read-only mode. If the browser cannot be opened automatically, the URL\n    is printed so the user can open it manually.\n\nLimitations:\n    - Not needed when CS_ACCESS_TOKEN is already set.\n    - Requires the embedded CLI to be available.\n    - Waits up to 2 minutes for the user to complete the browser flow.\n    - For on-prem instances, configure CS_ONPREM_URL before calling this tool.\n\nReturns:\n    A success message when signed in, or an error describing the failure.",
         input_schema = inlined_schema_for::<LoginParam>()
     )]
     async fn login(
@@ -639,6 +695,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     config::snapshot_client_env_vars();
+    ensure_oauth_client_configured().await;
     let config_data = config::load().unwrap_or_default();
     config::apply_to_env(&config_data);
 

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -191,6 +191,7 @@ pub(crate) fn build_instructions(is_standalone: bool, tools_filtered: bool) -> S
     let mut text = String::from(
         "CodeScene MCP Server - Code Health analysis tools for AI-assisted development.\n\n\
          TOOLS (always available):\n\
+         - login: Sign in to CodeScene with OAuth. When authentication is missing, call this tool first.\n\
          - explain_code_health: Learn about the Code Health metric.\n\
          - explain_code_health_productivity: Business case for Code Health.\n\
          - code_health_review: Detailed review of a single file.\n\

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -127,6 +127,10 @@ pub(crate) struct TokenGuard<'a> {
 impl Drop for TokenGuard<'_> {
     fn drop(&mut self) {
         std::env::remove_var("CS_ACCESS_TOKEN");
+        std::env::remove_var("CS_OAUTH_TOKEN");
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+        std::env::remove_var("CS_OAUTH_REFRESH_EXPIRES_AT");
+        std::env::remove_var("CS_OAUTH_CLIENT");
     }
 }
 
@@ -139,6 +143,10 @@ pub(crate) fn set_token(value: &str) -> TokenGuard<'static> {
 pub(crate) fn clear_token() -> TokenGuard<'static> {
     let lock = crate::config::lock_test_env();
     std::env::remove_var("CS_ACCESS_TOKEN");
+    std::env::remove_var("CS_OAUTH_TOKEN");
+    std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+    std::env::remove_var("CS_OAUTH_REFRESH_EXPIRES_AT");
+    std::env::remove_var("CS_OAUTH_CLIENT");
     TokenGuard { _lock: lock }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use rmcp::model::CallToolResult;
 
+use crate::auth::AuthManager;
 use crate::cli::{self, CliRunner};
 use crate::config::ConfigData;
 use crate::errors::CliError;
@@ -64,6 +65,7 @@ pub(crate) fn test_deps(id: &str, is_standalone: bool, mocks: TestMocks) -> Serv
         instance_id: id.to_string(),
         is_standalone,
         version_checker: VersionChecker::new("dev"),
+        auth_manager: AuthManager::new(),
         cli_runner: mocks.cli,
         http_client: mocks.http,
         validator: mocks.validator,
@@ -111,6 +113,7 @@ pub(crate) async fn make_server_with_version(
         instance_id: "test".to_string(),
         is_standalone: false,
         version_checker: vc,
+        auth_manager: AuthManager::new(),
         cli_runner: Arc::new(cli::ProductionCliRunner),
         http_client: Arc::new(http::ReqwestClient),
         validator: Arc::new(MockValidator::passing()),
@@ -141,12 +144,14 @@ pub(crate) fn clear_token() -> TokenGuard<'static> {
 
 pub(crate) struct MockCliRunner {
     responses: Mutex<Vec<Result<String, CliError>>>,
+    calls: Arc<Mutex<Vec<Vec<String>>>>,
 }
 
 impl MockCliRunner {
     pub(crate) fn with_responses(responses: Vec<Result<String, CliError>>) -> Self {
         Self {
             responses: Mutex::new(responses),
+            calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -160,11 +165,23 @@ impl MockCliRunner {
             stderr: stderr.to_string(),
         })])
     }
+
+    pub(crate) fn calls(&self) -> Arc<Mutex<Vec<Vec<String>>>> {
+        self.calls.clone()
+    }
+
+    pub(crate) fn call_count(&self) -> usize {
+        self.calls.lock().unwrap().len()
+    }
 }
 
 #[async_trait]
 impl CliRunner for MockCliRunner {
-    async fn run(&self, _args: &[&str], _working_dir: Option<&Path>) -> Result<String, CliError> {
+    async fn run(&self, args: &[&str], _working_dir: Option<&Path>) -> Result<String, CliError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(args.iter().map(|arg| arg.to_string()).collect());
         self.responses.lock().unwrap().remove(0)
     }
 }
@@ -469,19 +486,19 @@ mod tests {
     #[tokio::test]
     async fn require_token_returns_error_when_missing() {
         let _g = clear_token();
-        assert!(make_server(false).require_token().is_some());
+        assert!(make_server(false).require_token().await.is_some());
     }
 
     #[tokio::test]
     async fn require_token_returns_none_when_set() {
         let _g = set_token("token");
-        assert!(make_server(false).require_token().is_none());
+        assert!(make_server(false).require_token().await.is_none());
     }
 
     #[tokio::test]
     async fn require_token_treats_whitespace_as_missing() {
         let _g = set_token("   ");
-        assert!(make_server(false).require_token().is_some());
+        assert!(make_server(false).require_token().await.is_some());
     }
 
     #[tokio::test]
@@ -564,6 +581,7 @@ mod tests {
             instance_id: "test-filter".to_string(),
             is_standalone,
             version_checker: VersionChecker::new("dev"),
+            auth_manager: AuthManager::new(),
             cli_runner: Arc::new(cli::ProductionCliRunner),
             http_client: Arc::new(http::ReqwestClient),
             validator: Arc::new(MockValidator::passing()),
@@ -579,6 +597,7 @@ mod tests {
             names.contains(&"set_config".to_string()),
             "missing set_config"
         );
+        assert!(names.contains(&"login".to_string()), "missing login");
     }
 
     fn assert_tool_count_and_config(names: &[String], expected: usize) {
@@ -596,7 +615,7 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server(false);
         let names = tool_names(&server);
-        assert_tool_count_and_config(&names, 24);
+        assert_tool_count_and_config(&names, 25);
         assert!(names.contains(&"code_health_review".to_string()));
     }
 
@@ -606,8 +625,8 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server_with_enabled_tools(false, "code_health_review,code_health_score");
         let names = tool_names(&server);
-        // Should have the 2 enabled tools + 2 always-on = 4
-        assert_tool_count_and_config(&names, 4);
+        // Should have the 2 enabled tools + 3 always-on = 5
+        assert_tool_count_and_config(&names, 5);
         assert!(names.contains(&"code_health_review".to_string()));
         assert!(names.contains(&"code_health_score".to_string()));
     }
@@ -642,7 +661,7 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server_with_enabled_tools(false, "analyze_change_set");
         let names = tool_names(&server);
-        assert_tool_count_and_config(&names, 3);
+        assert_tool_count_and_config(&names, 4);
         assert!(names.contains(&"analyze_change_set".to_string()));
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -510,6 +510,180 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn require_token_returns_missing_message_when_no_credential_resolved() {
+        let _g = clear_token();
+        std::env::set_var("CS_OAUTH_EXPIRES_AT", "0"); // signed-out sentinel avoids a CLI call
+        let server = make_server_with_mocks(
+            false,
+            MockCliRunner::with_responses(vec![]),
+            MockHttpClient::new(vec![]),
+        );
+        let result = server.require_token().await.unwrap();
+        assert!(
+            result_text(&result).contains("access token"),
+            "got: {}",
+            result_text(&result)
+        );
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+    }
+
+    #[tokio::test]
+    async fn require_token_returns_missing_message_when_cli_errors() {
+        let _g = clear_token();
+        let cli = MockCliRunner::with_responses(vec![Err(crate::errors::CliError::NotFound(
+            "cs".to_string(),
+        ))]);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = server.require_token().await.unwrap();
+        assert!(
+            result_text(&result).contains("access token"),
+            "got: {}",
+            result_text(&result)
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_auth_credential_returns_error_result_when_no_credential_resolved() {
+        let _g = clear_token();
+        std::env::set_var("CS_OAUTH_EXPIRES_AT", "0"); // signed-out sentinel avoids a CLI call
+        let server = make_server_with_mocks(
+            false,
+            MockCliRunner::with_responses(vec![]),
+            MockHttpClient::new(vec![]),
+        );
+        let err = server.resolve_auth_credential().await.unwrap_err();
+        assert!(
+            result_text(&err).contains("access token"),
+            "got: {}",
+            result_text(&err)
+        );
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+    }
+
+    #[tokio::test]
+    async fn resolve_auth_credential_returns_ok_when_configured() {
+        let _g = set_token("pat-token");
+        let server = make_server_with_mocks(
+            false,
+            MockCliRunner::with_responses(vec![]),
+            MockHttpClient::new(vec![]),
+        );
+        let credential = server.resolve_auth_credential().await.unwrap();
+        assert_eq!(credential.access_token(), "pat-token");
+    }
+
+    #[test]
+    fn credential_source_reports_configured_and_oauth() {
+        let configured = crate::auth::AuthCredential::Configured {
+            access_token: "tok".to_string(),
+            onprem_url: None,
+        };
+        let oauth = crate::auth::AuthCredential::OAuth {
+            access_token: "tok".to_string(),
+            onprem_url: None,
+        };
+        assert_eq!(crate::credential_source(&configured), "configured");
+        assert_eq!(crate::credential_source(&oauth), "oauth");
+    }
+
+    #[tokio::test]
+    async fn ensure_oauth_client_configured_sets_default_when_unset() {
+        let _lock = config::lock_test_env();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("CS_CONFIG_DIR", dir.path().as_os_str());
+        std::env::remove_var("CS_OAUTH_CLIENT");
+
+        crate::ensure_oauth_client_configured().await;
+
+        assert_eq!(
+            std::env::var("CS_OAUTH_CLIENT").ok().as_deref(),
+            Some("mcp")
+        );
+
+        std::env::remove_var("CS_OAUTH_CLIENT");
+        std::env::remove_var("CS_CONFIG_DIR");
+    }
+
+    #[tokio::test]
+    async fn ensure_oauth_client_configured_leaves_existing_value_untouched() {
+        let _lock = config::lock_test_env();
+        std::env::set_var("CS_OAUTH_CLIENT", "custom-client");
+
+        crate::ensure_oauth_client_configured().await;
+
+        assert_eq!(
+            std::env::var("CS_OAUTH_CLIENT").ok().as_deref(),
+            Some("custom-client")
+        );
+        std::env::remove_var("CS_OAUTH_CLIENT");
+    }
+
+    #[tokio::test]
+    async fn ensure_oauth_client_configured_tolerates_persistence_failure() {
+        let _lock = config::lock_test_env();
+        let impossible = if cfg!(windows) {
+            r"NUL\impossible"
+        } else {
+            "/dev/null/impossible"
+        };
+        std::env::set_var("CS_CONFIG_DIR", impossible);
+        std::env::remove_var("CS_OAUTH_CLIENT");
+
+        crate::ensure_oauth_client_configured().await;
+
+        assert_eq!(
+            std::env::var("CS_OAUTH_CLIENT").ok().as_deref(),
+            Some("mcp")
+        );
+        std::env::remove_var("CS_OAUTH_CLIENT");
+        std::env::remove_var("CS_CONFIG_DIR");
+    }
+
+    #[tokio::test]
+    async fn login_dispatch_method_delegates_to_login_handler() {
+        use rmcp::handler::server::wrapper::Parameters;
+
+        let _g = set_token("existing-token");
+        let server = make_server_with_mocks(
+            false,
+            MockCliRunner::with_responses(vec![]),
+            MockHttpClient::new(vec![]),
+        );
+        let result = server
+            .login(Parameters(crate::tools::LoginParam {}))
+            .await
+            .unwrap();
+        assert!(
+            result_text(&result).contains("CS_ACCESS_TOKEN is already configured"),
+            "got: {}",
+            result_text(&result)
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_installation_dispatch_method_delegates_to_handler() {
+        use rmcp::handler::server::wrapper::Parameters;
+
+        let _g = set_token("existing-token");
+        let server = make_server_with_mocks(
+            false,
+            MockCliRunner::with_responses(vec![Ok("{}".to_string()), Ok("{}".to_string())]),
+            MockHttpClient::always(crate::http::HttpResponse::ok(r#"[{"id":1}]"#)),
+        );
+        let result = server
+            .verify_installation(Parameters(crate::tools::GitRepoParam {
+                git_repository_path: "/tmp/project".to_string(),
+            }))
+            .await
+            .unwrap();
+        assert!(
+            result_text(&result).contains("CLI Connectivity"),
+            "got: {}",
+            result_text(&result)
+        );
+    }
+
+    #[tokio::test]
     async fn maybe_version_warning_returns_text_when_no_cache() {
         assert_eq!(
             make_server(false).maybe_version_warning("hello").await,

--- a/src/tools/analyze_change_set.rs
+++ b/src/tools/analyze_change_set.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ChangeSetParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.require_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/code_health_refactoring_business_case.rs
+++ b/src/tools/code_health_refactoring_business_case.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: FilePathParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.require_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/code_health_review.rs
+++ b/src/tools/code_health_review.rs
@@ -14,7 +14,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: FilePathParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.require_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();
@@ -87,6 +87,39 @@ mod tests {
         };
         let result = server.code_health_review(Parameters(params)).await.unwrap();
         assert_success_contains(&result, "9.5");
+    }
+
+    #[tokio::test]
+    async fn uses_stored_oauth_session_when_env_token_missing() {
+        let _g = clear_token();
+        let auth_token = r#"{"status":"signed_in","access-token":"oau_test","api-url":"https://api.codescene.io/api","expires-at":9999999999}"#;
+        let cli = MockCliRunner::with_responses(vec![
+            Ok(auth_token.to_string()),
+            Ok(r#"{"score":9.5,"review":[]}"#.to_string()),
+        ]);
+        let calls = cli.calls();
+        let server = make_cli_mock_server(cli);
+        let params = FilePathParam {
+            file_path: "/tmp/test.rs".to_string(),
+        };
+
+        let result = server.code_health_review(Parameters(params)).await.unwrap();
+
+        assert_success_contains(&result, "9.5");
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(
+            calls[0],
+            [
+                "auth",
+                "token",
+                "--client",
+                "mcp",
+                "--output-format",
+                "json"
+            ]
+        );
+        assert_eq!(calls[1][0], "review");
     }
 
     #[tokio::test]

--- a/src/tools/code_health_score.rs
+++ b/src/tools/code_health_score.rs
@@ -14,7 +14,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: FilePathParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.require_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/code_ownership_for_path.rs
+++ b/src/tools/code_ownership_for_path.rs
@@ -14,9 +14,10 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: OwnershipParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
-        return Ok(r);
-    }
+    let credential = match server.resolve_auth_credential().await {
+        Ok(credential) => credential,
+        Err(r) => return Ok(r),
+    };
     if server.is_standalone {
         return Ok(tool_error(
             "This tool requires a CodeScene API token (not a standalone license).",
@@ -30,11 +31,12 @@ pub(crate) async fn handle(
         ("filter".to_string(), format!("path~{}", relative)),
         ("fields".to_string(), "owner,path".to_string()),
     ];
-    let result = api_client::query_api_keyed_list_with_client(
+    let result = api_client::query_api_keyed_list_with_auth(
         &endpoint,
         &query_params,
         "files",
         &*server.http_client,
+        Some(&credential),
     )
     .await;
     match result {

--- a/src/tools/codescene_links.rs
+++ b/src/tools/codescene_links.rs
@@ -1,37 +1,26 @@
 /// Constructs user-facing CodeScene URLs for technical debt pages.
 ///
 /// On-prem and cloud use different path structures:
-///   On-prem: {CS_ONPREM_URL}/{project_id}/analyses/{analysis_id}/...
+///   On-prem: {web_root}/{project_id}/analyses/{analysis_id}/...
 ///   Cloud:   https://codescene.io/projects/{project_id}/jobs/{analysis_id}/results/...
-
-/// Returns the on-prem base URL if `CS_ONPREM_URL` is set and non-empty.
-fn onprem_url() -> Option<String> {
-    std::env::var("CS_ONPREM_URL")
-        .ok()
-        .filter(|u| !u.is_empty())
-        .and_then(|u| {
-            if let Err(e) = crate::config::require_https("CS_ONPREM_URL", &u) {
-                tracing::warn!("{e}");
-                return None;
-            }
-            Some(u.trim_end_matches('/').to_string())
-        })
-}
+///
+/// The `web_root` parameter is `None` for cloud, or `Some("https://host")` for on-prem.
+/// Callers obtain it from `auth::resolve_web_root(credential)`.
 
 /// Returns the base path for an analysis page (without trailing slash).
 ///
-/// On-prem: `{CS_ONPREM_URL}/{project_id}/analyses/{analysis_id}`
+/// On-prem: `{web_root}/{project_id}/analyses/{analysis_id}`
 /// Cloud:   `https://codescene.io/projects/{project_id}/jobs/{analysis_id}/results`
-fn analysis_base(project_id: i64, analysis_id: i64) -> String {
-    match onprem_url() {
+fn analysis_base(project_id: i64, analysis_id: i64, web_root: Option<&str>) -> String {
+    match web_root.map(|base| base.trim_end_matches('/').to_string()) {
         Some(base) => format!("{base}/{project_id}/analyses/{analysis_id}"),
         None => format!("https://codescene.io/projects/{project_id}/jobs/{analysis_id}/results"),
     }
 }
 
 /// Builds a link to the technical debt hotspots system map page.
-pub fn hotspots_link(project_id: i64, analysis_id: i64) -> String {
-    let base = analysis_base(project_id, analysis_id);
+pub fn hotspots_link(project_id: i64, analysis_id: i64, web_root: Option<&str>) -> String {
+    let base = analysis_base(project_id, analysis_id, web_root);
     format!(
         "{base}/code/technical-debt/system-map\
          ?max-code-health=10.00\
@@ -47,8 +36,13 @@ pub fn hotspots_link(project_id: i64, analysis_id: i64) -> String {
 ///
 /// When `file_name` is provided the link includes a `?name=` query parameter
 /// with the file name percent-encoded.
-pub fn biomarkers_link(project_id: i64, analysis_id: i64, file_name: Option<&str>) -> String {
-    let base = analysis_base(project_id, analysis_id);
+pub fn biomarkers_link(
+    project_id: i64,
+    analysis_id: i64,
+    file_name: Option<&str>,
+    web_root: Option<&str>,
+) -> String {
+    let base = analysis_base(project_id, analysis_id, web_root);
     let path = format!("{base}/code/biomarkers");
     match file_name {
         Some(name) => {
@@ -81,68 +75,30 @@ fn percent_encode_path(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config;
-
-    // ── helpers ──────────────────────────────────────────────
-
-    fn with_cloud() -> std::sync::MutexGuard<'static, ()> {
-        let guard = config::lock_test_env();
-        std::env::remove_var("CS_ONPREM_URL");
-        guard
-    }
-
-    fn with_onprem(url: &str) -> std::sync::MutexGuard<'static, ()> {
-        let guard = config::lock_test_env();
-        std::env::set_var("CS_ONPREM_URL", url);
-        guard
-    }
-
-    // ── onprem_url ──────────────────────────────────────────
-
-    #[test]
-    fn onprem_url_returns_none_when_unset() {
-        let _g = with_cloud();
-        assert!(onprem_url().is_none());
-    }
-
-    #[test]
-    fn onprem_url_returns_none_when_empty() {
-        let _g = config::lock_test_env();
-        std::env::set_var("CS_ONPREM_URL", "");
-        assert!(onprem_url().is_none());
-    }
-
-    #[test]
-    fn onprem_url_trims_trailing_slash() {
-        let _g = with_onprem("https://my-instance.com/");
-        assert_eq!(onprem_url().unwrap(), "https://my-instance.com");
-    }
-
-    #[test]
-    fn onprem_url_blocks_http() {
-        let _g = config::lock_test_env();
-        std::env::set_var("CS_ONPREM_URL", "http://my-instance.com");
-        assert!(onprem_url().is_none(), "HTTP URLs should be blocked");
-        std::env::remove_var("CS_ONPREM_URL");
-    }
 
     // ── analysis_base ───────────────────────────────────────
 
     #[test]
     fn analysis_base_cloud() {
-        let _g = with_cloud();
         assert_eq!(
-            analysis_base(72308, 6006312),
+            analysis_base(72308, 6006312, None),
             "https://codescene.io/projects/72308/jobs/6006312/results"
         );
     }
 
     #[test]
     fn analysis_base_onprem() {
-        let _g = with_onprem("https://test-env.enterprise.codescene.io");
         assert_eq!(
-            analysis_base(147, 37888),
+            analysis_base(147, 37888, Some("https://test-env.enterprise.codescene.io")),
             "https://test-env.enterprise.codescene.io/147/analyses/37888"
+        );
+    }
+
+    #[test]
+    fn analysis_base_trims_trailing_slash() {
+        assert_eq!(
+            analysis_base(147, 37888, Some("https://my-instance.com/")),
+            "https://my-instance.com/147/analyses/37888"
         );
     }
 
@@ -150,8 +106,7 @@ mod tests {
 
     #[test]
     fn hotspots_link_cloud() {
-        let _g = with_cloud();
-        let link = hotspots_link(72308, 6006312);
+        let link = hotspots_link(72308, 6006312, None);
         assert!(link.starts_with(
             "https://codescene.io/projects/72308/jobs/6006312/results/code/technical-debt/system-map?"
         ));
@@ -162,8 +117,7 @@ mod tests {
 
     #[test]
     fn hotspots_link_onprem() {
-        let _g = with_onprem("https://test-env.enterprise.codescene.io");
-        let link = hotspots_link(147, 37888);
+        let link = hotspots_link(147, 37888, Some("https://test-env.enterprise.codescene.io"));
         assert!(link.starts_with(
             "https://test-env.enterprise.codescene.io/147/analyses/37888/code/technical-debt/system-map?"
         ));
@@ -174,8 +128,7 @@ mod tests {
 
     #[test]
     fn biomarkers_link_cloud_no_file() {
-        let _g = with_cloud();
-        let link = biomarkers_link(72308, 6006312, None);
+        let link = biomarkers_link(72308, 6006312, None, None);
         assert_eq!(
             link,
             "https://codescene.io/projects/72308/jobs/6006312/results/code/biomarkers"
@@ -184,11 +137,11 @@ mod tests {
 
     #[test]
     fn biomarkers_link_cloud_with_file() {
-        let _g = with_cloud();
         let link = biomarkers_link(
             72308,
             6006312,
             Some("code-coverage-examples-single-component/src/main/java/com/codescene/ConditionalExample.java"),
+            None,
         );
         assert_eq!(
             link,
@@ -198,21 +151,18 @@ mod tests {
     }
 
     #[test]
-    fn biomarkers_link_onprem_no_file() {
-        let _g = with_onprem("https://test-env.enterprise.codescene.io");
-        let link = biomarkers_link(147, 37888, None);
+    fn biomarkers_link_onprem() {
+        let base = Some("https://test-env.enterprise.codescene.io");
+
+        // Without file name
         assert_eq!(
-            link,
+            biomarkers_link(147, 37888, None, base),
             "https://test-env.enterprise.codescene.io/147/analyses/37888/code/biomarkers"
         );
-    }
 
-    #[test]
-    fn biomarkers_link_onprem_with_file() {
-        let _g = with_onprem("https://test-env.enterprise.codescene.io");
-        let link = biomarkers_link(147, 37888, Some("seata/mmil-test.java"));
+        // With file name
         assert_eq!(
-            link,
+            biomarkers_link(147, 37888, Some("seata/mmil-test.java"), base),
             "https://test-env.enterprise.codescene.io/147/analyses/37888/code/biomarkers\
              ?name=seata/mmil-test.java"
         );

--- a/src/tools/explain_code_health.rs
+++ b/src/tools/explain_code_health.rs
@@ -6,7 +6,7 @@ use crate::resources;
 use crate::CodeSceneServer;
 
 pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.require_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/explain_code_health_productivity.rs
+++ b/src/tools/explain_code_health_productivity.rs
@@ -6,7 +6,7 @@ use crate::resources;
 use crate::CodeSceneServer;
 
 pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.require_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/list_technical_debt_goals_for_project.rs
+++ b/src/tools/list_technical_debt_goals_for_project.rs
@@ -13,9 +13,10 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
-        return Ok(r);
-    }
+    let credential = match server.resolve_auth_credential().await {
+        Ok(credential) => credential,
+        Err(r) => return Ok(r),
+    };
     if server.is_standalone {
         return Ok(tool_error(
             "This tool requires a CodeScene API token (not a standalone license).",
@@ -23,9 +24,13 @@ pub(crate) async fn handle(
     }
     server.version_checker.check_in_background();
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
-        .await
-        .map_err(|e| format!("Error fetching latest analysis: {e}"));
+    let analysis_id = api_client::get_latest_analysis_id_with_auth(
+        params.project_id,
+        &*server.http_client,
+        Some(&credential),
+    )
+    .await
+    .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
@@ -40,18 +45,24 @@ pub(crate) async fn handle(
         ("filter".to_string(), "goals^not-empty".to_string()),
         ("fields".to_string(), "path,goals".to_string()),
     ];
-    let result = api_client::query_api_keyed_list_with_client(
+    let result = api_client::query_api_keyed_list_with_auth(
         &endpoint,
         &query_params,
         "files",
         &*server.http_client,
+        Some(&credential),
     )
     .await;
     match result {
         Ok(data) => {
             let props = event_properties::goals_properties(params.project_id, data.len());
             server.track("list-technical-debt-goals", props);
-            let link = codescene_links::biomarkers_link(params.project_id, analysis_id, None);
+            let link = codescene_links::biomarkers_link(
+                params.project_id,
+                analysis_id,
+                None,
+                credential.web_root().as_deref(),
+            );
             let response = json!({ "data": data, "link": link });
             let text = serde_json::to_string(&response).unwrap_or_default();
             let text = server.maybe_version_warning(&text).await;

--- a/src/tools/list_technical_debt_goals_for_project_file.rs
+++ b/src/tools/list_technical_debt_goals_for_project_file.rs
@@ -16,9 +16,10 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectFileParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
-        return Ok(r);
-    }
+    let credential = match server.resolve_auth_credential().await {
+        Ok(credential) => credential,
+        Err(r) => return Ok(r),
+    };
     if server.is_standalone {
         return Ok(tool_error(
             "This tool requires a CodeScene API token (not a standalone license).",
@@ -26,9 +27,13 @@ pub(crate) async fn handle(
     }
     server.version_checker.check_in_background();
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
-        .await
-        .map_err(|e| format!("Error fetching latest analysis: {e}"));
+    let analysis_id = api_client::get_latest_analysis_id_with_auth(
+        params.project_id,
+        &*server.http_client,
+        Some(&credential),
+    )
+    .await
+    .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
@@ -44,19 +49,24 @@ pub(crate) async fn handle(
         ("filter".to_string(), format!("path~{}", relative)),
         ("fields".to_string(), "goals".to_string()),
     ];
-    let result = api_client::query_api_keyed_list_with_client(
+    let result = api_client::query_api_keyed_list_with_auth(
         &endpoint,
         &query_params,
         "files",
         &*server.http_client,
+        Some(&credential),
     )
     .await;
     match result {
         Ok(data) => {
             let props = event_properties::goals_file_properties(Path::new(&params.file_path));
             server.track("list-technical-debt-goals-file", props);
-            let link =
-                codescene_links::biomarkers_link(params.project_id, analysis_id, Some(&relative));
+            let link = codescene_links::biomarkers_link(
+                params.project_id,
+                analysis_id,
+                Some(&relative),
+                credential.web_root().as_deref(),
+            );
             let response = json!({ "data": data, "link": link });
             let text = serde_json::to_string(&response).unwrap_or_default();
             let text = server.maybe_version_warning(&text).await;

--- a/src/tools/list_technical_debt_hotspots_for_project.rs
+++ b/src/tools/list_technical_debt_hotspots_for_project.rs
@@ -13,9 +13,10 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
-        return Ok(r);
-    }
+    let credential = match server.resolve_auth_credential().await {
+        Ok(credential) => credential,
+        Err(r) => return Ok(r),
+    };
     if server.is_standalone {
         return Ok(tool_error(
             "This tool requires a CodeScene API token (not a standalone license).",
@@ -23,9 +24,13 @@ pub(crate) async fn handle(
     }
     server.version_checker.check_in_background();
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
-        .await
-        .map_err(|e| format!("Error fetching latest analysis: {e}"));
+    let analysis_id = api_client::get_latest_analysis_id_with_auth(
+        params.project_id,
+        &*server.http_client,
+        Some(&credential),
+    )
+    .await
+    .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
@@ -42,18 +47,23 @@ pub(crate) async fn handle(
         ("page_size".to_string(), "200".to_string()),
         ("refactoring_targets".to_string(), "true".to_string()),
     ];
-    let result = api_client::query_api_keyed_list_with_client(
+    let result = api_client::query_api_keyed_list_with_auth(
         &endpoint,
         &query_params,
         "result",
         &*server.http_client,
+        Some(&credential),
     )
     .await;
     match result {
         Ok(data) => {
             let props = event_properties::hotspots_properties(params.project_id, data.len());
             server.track("list-technical-debt-hotspots", props);
-            let link = codescene_links::hotspots_link(params.project_id, analysis_id);
+            let link = codescene_links::hotspots_link(
+                params.project_id,
+                analysis_id,
+                credential.web_root().as_deref(),
+            );
             let response = json!({ "data": data, "link": link });
             let text = serde_json::to_string(&response).unwrap_or_default();
             let text = server.maybe_version_warning(&text).await;

--- a/src/tools/list_technical_debt_hotspots_for_project_file.rs
+++ b/src/tools/list_technical_debt_hotspots_for_project_file.rs
@@ -16,9 +16,10 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: ProjectFileParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
-        return Ok(r);
-    }
+    let credential = match server.resolve_auth_credential().await {
+        Ok(credential) => credential,
+        Err(r) => return Ok(r),
+    };
     if server.is_standalone {
         return Ok(tool_error(
             "This tool requires a CodeScene API token (not a standalone license).",
@@ -26,9 +27,13 @@ pub(crate) async fn handle(
     }
     server.version_checker.check_in_background();
 
-    let analysis_id = api_client::get_latest_analysis_id(params.project_id, &*server.http_client)
-        .await
-        .map_err(|e| format!("Error fetching latest analysis: {e}"));
+    let analysis_id = api_client::get_latest_analysis_id_with_auth(
+        params.project_id,
+        &*server.http_client,
+        Some(&credential),
+    )
+    .await
+    .map_err(|e| format!("Error fetching latest analysis: {e}"));
     let analysis_id = match analysis_id {
         Ok(id) => id,
         Err(e) => {
@@ -47,18 +52,23 @@ pub(crate) async fn handle(
         ("filter".to_string(), format!("file_name~{}", relative)),
         ("refactoring_targets".to_string(), "true".to_string()),
     ];
-    let result = api_client::query_api_keyed_list_with_client(
+    let result = api_client::query_api_keyed_list_with_auth(
         &endpoint,
         &query_params,
         "result",
         &*server.http_client,
+        Some(&credential),
     )
     .await;
     match result {
         Ok(data) => {
             let props = event_properties::hotspots_file_properties(Path::new(&params.file_path));
             server.track("list-technical-debt-hotspots-file", props);
-            let link = codescene_links::hotspots_link(params.project_id, analysis_id);
+            let link = codescene_links::hotspots_link(
+                params.project_id,
+                analysis_id,
+                credential.web_root().as_deref(),
+            );
             let response = json!({ "data": data, "link": link });
             let text = serde_json::to_string(&response).unwrap_or_default();
             let text = server.maybe_version_warning(&text).await;

--- a/src/tools/login.rs
+++ b/src/tools/login.rs
@@ -14,6 +14,7 @@ async fn try_existing_session(server: &CodeSceneServer) -> Option<CallToolResult
         .current_token(&*server.cli_runner)
         .await
         .ok()??;
+    tracing::info!("reusing existing CodeScene login session");
     server.track("auth-login", json!({"result": "already_signed_in"}));
     Some(CallToolResult::success(vec![Content::text(
         "Already signed in to CodeScene.",
@@ -22,12 +23,15 @@ async fn try_existing_session(server: &CodeSceneServer) -> Option<CallToolResult
 
 /// Run the interactive login flow (opens browser) and apply the result.
 async fn run_and_apply_login(server: &CodeSceneServer) -> CallToolResult {
+    tracing::info!("starting interactive CodeScene login");
     match server.auth_manager.login(&*server.cli_runner).await {
         Ok(resp) if resp.is_signed_in() => {
+            tracing::info!("interactive CodeScene login succeeded");
             server.track("auth-login", json!({"result": "success"}));
             CallToolResult::success(vec![Content::text("Successfully signed in to CodeScene.")])
         }
         Ok(resp) => {
+            tracing::info!(status = %resp.status, "interactive CodeScene login did not sign in");
             server.track("auth-login", json!({"result": "failed"}));
             CallToolResult::success(vec![Content::text(format!(
                 "Login did not complete. Status: {}",
@@ -35,6 +39,7 @@ async fn run_and_apply_login(server: &CodeSceneServer) -> CallToolResult {
             ))])
         }
         Err(e) => {
+            tracing::warn!(error = %e, "interactive CodeScene login failed");
             server.track("auth-login", json!({"result": "error"}));
             CallToolResult::success(vec![Content::text(format!(
                 "Login failed: {e}\n\n\
@@ -50,6 +55,7 @@ pub(crate) async fn handle(
     _params: LoginParam,
 ) -> Result<CallToolResult, ErrorData> {
     if auth::configured_credential().is_some() {
+        tracing::info!("skipping OAuth login because CS_ACCESS_TOKEN is already configured");
         server.track("auth-login", json!({"result": "already_configured"}));
         return Ok(CallToolResult::success(vec![Content::text(
             "CS_ACCESS_TOKEN is already configured. OAuth login is not needed.\n\
@@ -118,6 +124,11 @@ mod tests {
         let text = result_text(&result);
         assert!(text.contains("Successfully signed in"), "got: {text}");
         assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
+
+        // Clear OAuth state from Case 1 before Case 2
+        std::env::remove_var("CS_OAUTH_TOKEN");
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+        std::env::remove_var("CS_OAUTH_REFRESH_EXPIRES_AT");
 
         // Case 2: token check errors → falls through to login
         let cli = MockCliRunner::with_responses(vec![

--- a/src/tools/login.rs
+++ b/src/tools/login.rs
@@ -1,0 +1,166 @@
+use rmcp::model::{CallToolResult, Content};
+use rmcp::ErrorData;
+use serde_json::json;
+
+use crate::auth;
+use crate::tools::LoginParam;
+use crate::CodeSceneServer;
+
+/// Attempt to reuse an existing session (token already stored by the CLI).
+/// Returns `Some(result)` if the user is already signed in, `None` otherwise.
+async fn try_existing_session(server: &CodeSceneServer) -> Option<CallToolResult> {
+    server
+        .auth_manager
+        .current_token(&*server.cli_runner)
+        .await
+        .ok()??;
+    server.track("auth-login", json!({"result": "already_signed_in"}));
+    Some(CallToolResult::success(vec![Content::text(
+        "Already signed in to CodeScene.",
+    )]))
+}
+
+/// Run the interactive login flow (opens browser) and apply the result.
+async fn run_and_apply_login(server: &CodeSceneServer) -> CallToolResult {
+    match server.auth_manager.login(&*server.cli_runner).await {
+        Ok(resp) if resp.is_signed_in() => {
+            server.track("auth-login", json!({"result": "success"}));
+            CallToolResult::success(vec![Content::text("Successfully signed in to CodeScene.")])
+        }
+        Ok(resp) => {
+            server.track("auth-login", json!({"result": "failed"}));
+            CallToolResult::success(vec![Content::text(format!(
+                "Login did not complete. Status: {}",
+                resp.status
+            ))])
+        }
+        Err(e) => {
+            server.track("auth-login", json!({"result": "error"}));
+            CallToolResult::success(vec![Content::text(format!(
+                "Login failed: {e}\n\n\
+                 If your browser did not open automatically, you can sign in manually \
+                 using the CodeScene CLI:\n  cs auth login"
+            ))])
+        }
+    }
+}
+
+pub(crate) async fn handle(
+    server: &CodeSceneServer,
+    _params: LoginParam,
+) -> Result<CallToolResult, ErrorData> {
+    if auth::configured_credential().is_some() {
+        server.track("auth-login", json!({"result": "already_configured"}));
+        return Ok(CallToolResult::success(vec![Content::text(
+            "CS_ACCESS_TOKEN is already configured. OAuth login is not needed.\n\
+             To use OAuth instead, remove CS_ACCESS_TOKEN from your MCP client configuration.",
+        )]));
+    }
+
+    if let Some(result) = try_existing_session(server).await {
+        return Ok(result);
+    }
+
+    Ok(run_and_apply_login(server).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::tests::MockHttpClient;
+    use crate::test_utils::MockCliRunner;
+    use crate::tests::{clear_token, make_server_with_mocks, result_text, set_token};
+
+    fn params() -> LoginParam {
+        LoginParam {}
+    }
+
+    const SIGNED_IN_JSON: &str = r#"{"status":"signed_in","access-token":"oau_test","api-url":"https://api.codescene.io/api"}"#;
+    const SIGNED_OUT_JSON: &str = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+
+    #[tokio::test]
+    async fn returns_early_when_token_already_set() {
+        let _g = set_token("existing-token");
+        let server = make_server_with_mocks(
+            false,
+            MockCliRunner::with_ok(""),
+            MockHttpClient::new(vec![]),
+        );
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(
+            text.contains("CS_ACCESS_TOKEN is already configured"),
+            "got: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_already_signed_in_when_token_fresh() {
+        let _g = clear_token();
+        let cli = MockCliRunner::with_responses(vec![Ok(SIGNED_IN_JSON.into())]);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("Already signed in"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn runs_login_flow_when_no_existing_session() {
+        let _g = clear_token();
+
+        // Case 1: token check returns signed_out → proceeds to login
+        let cli = MockCliRunner::with_responses(vec![
+            Ok(SIGNED_OUT_JSON.into()),
+            Ok(SIGNED_IN_JSON.into()),
+        ]);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("Successfully signed in"), "got: {text}");
+        assert!(std::env::var("CS_ACCESS_TOKEN").is_err());
+
+        // Case 2: token check errors → falls through to login
+        let cli = MockCliRunner::with_responses(vec![
+            Err(crate::errors::CliError::NonZeroExit {
+                code: 1,
+                stderr: "no credentials file".into(),
+            }),
+            Ok(SIGNED_IN_JSON.into()),
+        ]);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("Successfully signed in"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn shows_error_message_when_login_fails() {
+        let _g = clear_token();
+        let cli = MockCliRunner::with_responses(vec![
+            Ok(SIGNED_OUT_JSON.into()),
+            Err(crate::errors::CliError::NonZeroExit {
+                code: 1,
+                stderr: "timeout".into(),
+            }),
+        ]);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("Login failed"), "got: {text}");
+        assert!(text.contains("cs auth login"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn login_response_not_signed_in_reports_status() {
+        let _g = clear_token();
+        let incomplete_json = r#"{"status":"expired","access-token":null,"api-url":null}"#;
+        let cli = MockCliRunner::with_responses(vec![
+            Ok(SIGNED_OUT_JSON.into()),
+            Ok(incomplete_json.into()),
+        ]);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("expired"), "got: {text}");
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -18,6 +18,7 @@ pub mod list_technical_debt_goals_for_project;
 pub mod list_technical_debt_goals_for_project_file;
 pub mod list_technical_debt_hotspots_for_project;
 pub mod list_technical_debt_hotspots_for_project_file;
+pub mod login;
 pub mod pre_commit_code_health_safeguard;
 pub mod rules_config;
 pub mod rules_config_list_thresholds;
@@ -29,6 +30,10 @@ pub mod set_config;
 pub mod sync_skills;
 pub mod validation;
 pub mod verify_installation;
+
+/// Parameters for the `login` tool (currently accepts no arguments).
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct LoginParam {}
 
 /// Optional context parameter used by explain tools.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/src/tools/pre_commit_code_health_safeguard.rs
+++ b/src/tools/pre_commit_code_health_safeguard.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle(
     server: &CodeSceneServer,
     params: GitRepoParam,
 ) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
+    if let Some(r) = server.require_token().await {
         return Ok(r);
     }
     server.version_checker.check_in_background();

--- a/src/tools/select_project.rs
+++ b/src/tools/select_project.rs
@@ -8,16 +8,17 @@ use crate::tools::common::tool_error;
 use crate::CodeSceneServer;
 
 pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, ErrorData> {
-    if let Some(r) = server.require_token() {
-        return Ok(r);
-    }
+    let credential = match server.resolve_auth_credential().await {
+        Ok(credential) => credential,
+        Err(r) => return Ok(r),
+    };
     if server.is_standalone {
         return Ok(tool_error(
             "This tool requires a CodeScene API token (not a standalone license).",
         ));
     }
     server.version_checker.check_in_background();
-    let result = run_select_project(&*server.http_client).await;
+    let result = run_select_project(&*server.http_client, Some(&credential)).await;
     match &result {
         Ok(output) => {
             let props = event_properties::select_project_properties();
@@ -37,10 +38,9 @@ pub(crate) async fn handle(server: &CodeSceneServer) -> Result<CallToolResult, E
 
 pub(crate) async fn run_select_project(
     http_client: &dyn crate::http::HttpClient,
+    credential: Option<&crate::auth::AuthCredential>,
 ) -> Result<serde_json::Value, String> {
-    let link = std::env::var("CS_ONPREM_URL")
-        .ok()
-        .filter(|u| !u.is_empty())
+    let link = crate::auth::resolve_web_root(credential)
         .unwrap_or_else(|| "https://codescene.io/projects".to_string());
 
     if let Ok(id_str) = std::env::var("CS_DEFAULT_PROJECT_ID") {
@@ -55,7 +55,7 @@ pub(crate) async fn run_select_project(
         }
     }
 
-    let data = api_client::query_api_list_with_client("v2/projects", http_client)
+    let data = api_client::query_api_list_with_auth("v2/projects", http_client, credential)
         .await
         .map_err(|e| format!("Error: {e}"))?;
 
@@ -97,7 +97,7 @@ mod tests {
     async fn run_with_default_project_id() {
         let _g = set_token("test-token");
         std::env::set_var("CS_DEFAULT_PROJECT_ID", "42");
-        let result = run_select_project(&crate::http::ReqwestClient).await;
+        let result = run_select_project(&crate::http::ReqwestClient, None).await;
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         let value = result.unwrap();
         assert_eq!(value["id"], 42);
@@ -108,7 +108,7 @@ mod tests {
     async fn run_default_id_empty_falls_through() {
         let _g = set_token("test-token");
         std::env::set_var("CS_DEFAULT_PROJECT_ID", "");
-        let result = run_select_project(&crate::http::ReqwestClient).await;
+        let result = run_select_project(&crate::http::ReqwestClient, None).await;
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         match result {
             Ok(val) => assert!(val.get("projects").is_some()),
@@ -141,7 +141,7 @@ mod tests {
         let _g = set_token("tok");
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         let http = make_api_mock(HttpResponse::ok(r#"[{"id":99,"name":"TestProject"}]"#));
-        let result = run_select_project(&http).await.unwrap();
+        let result = run_select_project(&http, None).await.unwrap();
         assert!(result["projects"].as_array().unwrap().len() > 0);
         assert_eq!(result["projects"][0]["name"], "TestProject");
     }
@@ -151,7 +151,7 @@ mod tests {
         let _g = set_token("tok");
         std::env::remove_var("CS_DEFAULT_PROJECT_ID");
         let http = MockHttpClient::new(vec![HttpResponse::error(500, "fail")]);
-        let result = run_select_project(&http).await;
+        let result = run_select_project(&http, None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Error"));
     }

--- a/src/tools/set_config.rs
+++ b/src/tools/set_config.rs
@@ -15,7 +15,7 @@ pub(crate) async fn handle(
         event_properties::config_properties(event_properties::ConfigAction::Set, &params.key);
     server.track("set-config", props);
 
-    let result = configure::set_value(&params.key, &params.value);
+    let result = configure::set_value(&params.key, &params.value).await;
     let text = server.maybe_version_warning(&result).await;
     Ok(CallToolResult::success(vec![Content::text(text)]))
 }

--- a/src/tools/verify_installation.rs
+++ b/src/tools/verify_installation.rs
@@ -5,6 +5,7 @@ use rmcp::ErrorData;
 use serde_json::json;
 
 use crate::api_client;
+use crate::auth::AuthCredential;
 use crate::cli;
 use crate::cli::CliRunner;
 use crate::docker;
@@ -20,13 +21,21 @@ pub(crate) async fn handle(
 ) -> Result<CallToolResult, ErrorData> {
     server.version_checker.check_in_background();
     let project_root = docker::adapt_path_for_docker(Path::new(&params.git_repository_path));
-    let checks = run_all_checks(
-        &project_root,
-        &*server.cli_runner,
-        &*server.http_client,
-        server.is_standalone,
-    )
-    .await;
+    let credential = server
+        .auth_manager
+        .resolve_credential(&*server.cli_runner)
+        .await
+        .ok()
+        .flatten();
+    let ctx = CheckContext {
+        cli_runner: &*server.cli_runner,
+        http_client: &*server.http_client,
+        is_standalone: server.is_standalone,
+        credential: credential.as_ref(),
+        target_label: api_url_label(credential.as_ref()),
+        cli_timeout: TOKEN_CHECK_TIMEOUT,
+    };
+    let checks = run_all_checks(&project_root, &ctx).await;
     let text = format_results(&checks);
     server.track("verify-installation", json!({}));
     let text = server.maybe_version_warning(&text).await;
@@ -41,20 +50,27 @@ struct CheckResult {
 
 const TOKEN_CHECK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-async fn run_all_checks(
-    project_root: &str,
-    cli_runner: &dyn CliRunner,
-    http_client: &dyn HttpClient,
+/// Context for running all installation checks.
+struct CheckContext<'a> {
+    cli_runner: &'a dyn CliRunner,
+    http_client: &'a dyn HttpClient,
     is_standalone: bool,
-) -> Vec<CheckResult> {
+    credential: Option<&'a AuthCredential>,
+    /// Pre-computed user-friendly label for the API target.
+    target_label: String,
+    /// Timeout for CLI-based checks (token validation, connectivity).
+    cli_timeout: std::time::Duration,
+}
+
+async fn run_all_checks(project_root: &str, ctx: &CheckContext<'_>) -> Vec<CheckResult> {
     let path = Path::new(project_root);
     let mut checks = vec![
         check_git_repository(path),
-        check_token_via_cli(path, cli_runner, TOKEN_CHECK_TIMEOUT).await,
-        check_cli_connectivity(path, cli_runner, TOKEN_CHECK_TIMEOUT).await,
+        check_token_via_cli(path, ctx).await,
+        check_cli_connectivity(path, ctx).await,
     ];
-    if !is_standalone {
-        checks.push(check_api_connectivity(http_client).await);
+    if !ctx.is_standalone {
+        checks.push(check_api_connectivity(ctx).await);
     }
     checks.push(check_environment());
     checks
@@ -81,11 +97,15 @@ fn is_connectivity_error(stderr: &str) -> bool {
     KEYWORDS.iter().any(|kw| lower.contains(kw))
 }
 
-async fn check_token_via_cli(
-    repo_path: &Path,
-    cli_runner: &dyn CliRunner,
-    timeout: std::time::Duration,
-) -> CheckResult {
+async fn check_token_via_cli(repo_path: &Path, ctx: &CheckContext<'_>) -> CheckResult {
+    if matches!(ctx.credential, Some(AuthCredential::OAuth { .. })) {
+        return CheckResult {
+            name: "Access Token",
+            passed: true,
+            detail: "Authenticated via OAuth session.".to_string(),
+        };
+    }
+
     let token = std::env::var("CS_ACCESS_TOKEN")
         .map(|v| v.trim().to_string())
         .unwrap_or_default();
@@ -96,14 +116,10 @@ async fn check_token_via_cli(
             detail: "CS_ACCESS_TOKEN is not set or empty.".to_string(),
         };
     }
-    // Use `review` on a known source file instead of `delta` because
-    // `delta` performs heavyweight git operations that can hang on
-    // Windows.  The license check runs before any analysis, so any
-    // analysable file works.
     let probe = find_probe_file(repo_path);
     let args: Vec<&str> = vec!["review", "--output-format=json", &probe];
-    let cli_future = cli_runner.run(&args, Some(repo_path));
-    match tokio::time::timeout(timeout, cli_future).await {
+    let cli_future = ctx.cli_runner.run(&args, Some(repo_path));
+    match tokio::time::timeout(ctx.cli_timeout, cli_future).await {
         Err(_) => CheckResult {
             name: "Access Token",
             passed: false,
@@ -116,7 +132,7 @@ async fn check_token_via_cli(
                 passed: false,
                 detail: format!(
                     "CLI could not connect to {} — possible TLS/network issue: {stderr}",
-                    api_url_label()
+                    ctx.target_label
                 ),
             }
         }
@@ -131,7 +147,7 @@ async fn check_token_via_cli(
                 passed: false,
                 detail: format!(
                     "CLI could not connect to {} — possible TLS/network issue: {stderr}",
-                    api_url_label()
+                    ctx.target_label
                 ),
             }
         }
@@ -145,15 +161,11 @@ async fn check_token_via_cli(
 /// Used for standalone users who don't have API access. The CLI still
 /// connects to CodeScene to validate the license, so a broken CA cert
 /// or network issue will surface here.
-async fn check_cli_connectivity(
-    repo_path: &Path,
-    cli_runner: &dyn CliRunner,
-    timeout: std::time::Duration,
-) -> CheckResult {
+async fn check_cli_connectivity(repo_path: &Path, ctx: &CheckContext<'_>) -> CheckResult {
     let probe = find_probe_file(repo_path);
     let args: Vec<&str> = vec!["review", "--output-format=json", &probe];
-    let cli_future = cli_runner.run(&args, Some(repo_path));
-    match tokio::time::timeout(timeout, cli_future).await {
+    let cli_future = ctx.cli_runner.run(&args, Some(repo_path));
+    match tokio::time::timeout(ctx.cli_timeout, cli_future).await {
         Err(_) => CheckResult {
             name: "CLI Connectivity",
             passed: false,
@@ -168,7 +180,7 @@ async fn check_cli_connectivity(
                 passed: false,
                 detail: format!(
                     "CLI could not connect to {} — possible TLS/network issue: {stderr}",
-                    api_url_label()
+                    ctx.target_label
                 ),
             }
         }
@@ -177,7 +189,7 @@ async fn check_cli_connectivity(
         Ok(_) => CheckResult {
             name: "CLI Connectivity",
             passed: true,
-            detail: format!("CLI connected to {} successfully.", api_url_label()),
+            detail: format!("CLI connected to {} successfully.", ctx.target_label),
         },
     }
 }
@@ -188,37 +200,31 @@ async fn check_cli_connectivity(
 /// certificate misconfiguration that the CLI check alone might miss
 /// (since the CLI and the MCP server build their TLS stacks
 /// independently).
-async fn check_api_connectivity(http_client: &dyn HttpClient) -> CheckResult {
-    let token = std::env::var("CS_ACCESS_TOKEN")
-        .map(|v| v.trim().to_string())
-        .unwrap_or_default();
-    if token.is_empty() {
+async fn check_api_connectivity(ctx: &CheckContext<'_>) -> CheckResult {
+    let Some(credential) = ctx.credential else {
         return CheckResult {
             name: "API Connectivity",
             passed: false,
-            detail: "Skipped — CS_ACCESS_TOKEN is not set.".to_string(),
+            detail: "Skipped — no access token configured and not signed in via OAuth.".to_string(),
         };
-    }
-    match api_client::query_api_with_client("v2/projects", http_client).await {
+    };
+    match api_client::query_api_with_auth("v2/projects", ctx.http_client, Some(credential)).await {
         Ok(_) => CheckResult {
             name: "API Connectivity",
             passed: true,
-            detail: format!("Connected to {} successfully.", api_url_label()),
+            detail: format!("Connected to {} successfully.", ctx.target_label),
         },
         Err(e) => CheckResult {
             name: "API Connectivity",
             passed: false,
-            detail: format!("Could not reach {}: {e}", api_url_label()),
+            detail: format!("Could not reach {}: {e}", ctx.target_label),
         },
     }
 }
 
 /// User-friendly label for the API target (on-prem URL or "CodeScene Cloud").
-fn api_url_label() -> String {
-    std::env::var("CS_ONPREM_URL")
-        .ok()
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| "CodeScene Cloud".to_string())
+fn api_url_label(credential: Option<&AuthCredential>) -> String {
+    crate::auth::resolve_web_root(credential).unwrap_or_else(|| "CodeScene Cloud".to_string())
 }
 
 /// Find a source file in the repo to use as a probe for the license
@@ -289,6 +295,37 @@ mod tests {
 
     use super::*;
 
+    /// Test helper: build a CheckContext for check_token_via_cli / check_cli_connectivity tests.
+    fn test_ctx_cli<'a>(
+        cli_runner: &'a dyn CliRunner,
+        credential: Option<&'a AuthCredential>,
+    ) -> CheckContext<'a> {
+        CheckContext {
+            cli_runner,
+            http_client: &crate::http::ReqwestClient,
+            is_standalone: false,
+            credential,
+            target_label: "CodeScene Cloud".to_string(),
+            cli_timeout: std::time::Duration::from_millis(100),
+        }
+    }
+
+    /// Test helper: build a CheckContext for check_api_connectivity tests.
+    fn test_ctx_http<'a>(
+        http_client: &'a dyn HttpClient,
+        cli_runner: &'a dyn CliRunner,
+        credential: Option<&'a AuthCredential>,
+    ) -> CheckContext<'a> {
+        CheckContext {
+            cli_runner,
+            http_client,
+            is_standalone: false,
+            credential,
+            target_label: "CodeScene Cloud".to_string(),
+            cli_timeout: std::time::Duration::from_millis(100),
+        }
+    }
+
     fn repo_param(path: &str) -> GitRepoParam {
         GitRepoParam {
             git_repository_path: path.to_string(),
@@ -329,7 +366,7 @@ mod tests {
     async fn token_missing_reports_fail() {
         let _g = clear_token();
         let cli = MockCliRunner::with_ok("");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert!(!result.passed);
         assert!(result.detail.contains("not set"));
     }
@@ -338,7 +375,7 @@ mod tests {
     async fn token_valid_reports_pass() {
         let _g = set_token("tok");
         let cli = MockCliRunner::with_ok("{}");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert!(result.passed);
         assert!(result.detail.contains("authenticated"));
     }
@@ -347,7 +384,7 @@ mod tests {
     async fn token_invalid_reports_fail() {
         let _g = set_token("bad");
         let cli = mock_license_failure("License check failed: [401]");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert!(!result.passed);
         assert!(result.detail.contains("invalid or expired"));
     }
@@ -356,7 +393,7 @@ mod tests {
     async fn non_license_error_still_passes_auth() {
         let _g = set_token("tok");
         let cli = MockCliRunner::with_err(1, "no changes found");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert!(result.passed);
     }
 
@@ -367,7 +404,7 @@ mod tests {
             1,
             "SSL certificate problem: unable to get local issuer certificate",
         );
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert_check(&result, false, "TLS/network");
     }
 
@@ -375,7 +412,7 @@ mod tests {
     async fn connection_refused_from_cli_reports_connectivity_failure() {
         let _g = set_token("tok");
         let cli = MockCliRunner::with_err(1, "connection refused");
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert_check(&result, false, "TLS/network");
     }
 
@@ -383,7 +420,7 @@ mod tests {
     async fn license_check_with_ssl_handshake_reports_connectivity_failure() {
         let _g = set_token("tok");
         let cli = mock_license_failure(SSL_HANDSHAKE_STDERR);
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert_check(&result, false, "TLS/network");
         assert!(
             result.detail.contains("SSLHandshakeException"),
@@ -398,7 +435,7 @@ mod tests {
         let cli = mock_license_failure(
             "License check failed, could not reach CodeScene servers (https://wrong.ee/api/v2/tool-license/cli)"
         );
-        let result = check_token_via_cli(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert_check(&result, false, "TLS/network");
         assert!(
             result.detail.contains("could not reach"),
@@ -426,19 +463,41 @@ mod tests {
         }
 
         let _g = set_token("tok");
-        let short = std::time::Duration::from_millis(50);
-        let result = check_token_via_cli(Path::new("/tmp"), &HangingCli, short).await;
+        let result = check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&HangingCli, None)).await;
         assert!(!result.passed);
         assert!(result.detail.contains("timed out"));
     }
 
+    #[tokio::test]
+    async fn oauth_credential_reports_token_pass_without_env() {
+        let _g = clear_token();
+        let cli = MockCliRunner::with_responses(vec![]);
+        let credential = AuthCredential::OAuth {
+            access_token: "oau-token".to_string(),
+            onprem_url: None,
+        };
+        let result =
+            check_token_via_cli(Path::new("/tmp"), &test_ctx_cli(&cli, Some(&credential))).await;
+        assert_check(&result, true, "OAuth");
+        assert!(cli.calls().lock().unwrap().is_empty());
+    }
+
     // -- check_api_connectivity ----------------------------------------------
+
+    fn test_credential() -> AuthCredential {
+        AuthCredential::Configured {
+            access_token: "tok".to_string(),
+            onprem_url: None,
+        }
+    }
 
     #[tokio::test]
     async fn api_connectivity_succeeds() {
         let _g = set_token("tok");
         let http = MockHttpClient::always(HttpResponse::ok(r#"[{"id":1}]"#));
-        let result = check_api_connectivity(&http).await;
+        let cli = MockCliRunner::with_ok("");
+        let cred = test_credential();
+        let result = check_api_connectivity(&test_ctx_http(&http, &cli, Some(&cred))).await;
         assert_check(&result, true, "successfully");
     }
 
@@ -446,7 +505,9 @@ mod tests {
     async fn api_connectivity_fails_on_transport_error() {
         let _g = set_token("tok");
         let http = MockHttpClient::new(vec![]);
-        let result = check_api_connectivity(&http).await;
+        let cli = MockCliRunner::with_ok("");
+        let cred = test_credential();
+        let result = check_api_connectivity(&test_ctx_http(&http, &cli, Some(&cred))).await;
         assert_check(&result, false, "Could not reach");
     }
 
@@ -454,7 +515,8 @@ mod tests {
     async fn api_connectivity_skipped_without_token() {
         let _g = clear_token();
         let http = MockHttpClient::new(vec![]);
-        let result = check_api_connectivity(&http).await;
+        let cli = MockCliRunner::with_ok("");
+        let result = check_api_connectivity(&test_ctx_http(&http, &cli, None)).await;
         assert_check(&result, false, "Skipped");
     }
 
@@ -462,7 +524,12 @@ mod tests {
     async fn api_connectivity_fails_on_auth_error() {
         let _g = set_token("bad-token");
         let http = MockHttpClient::always(HttpResponse::error(401, "Unauthorized"));
-        let result = check_api_connectivity(&http).await;
+        let cli = MockCliRunner::with_ok("");
+        let cred = AuthCredential::Configured {
+            access_token: "bad-token".to_string(),
+            onprem_url: None,
+        };
+        let result = check_api_connectivity(&test_ctx_http(&http, &cli, Some(&cred))).await;
         assert!(!result.passed);
         assert!(result.detail.contains("401"), "detail: {}", result.detail);
     }
@@ -474,7 +541,7 @@ mod tests {
     #[tokio::test]
     async fn cli_connectivity_succeeds_on_ok() {
         let cli = MockCliRunner::with_ok("{}");
-        let result = check_cli_connectivity(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_cli_connectivity(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert!(result.passed, "detail: {}", result.detail);
         assert!(
             result.detail.contains("successfully"),
@@ -486,7 +553,7 @@ mod tests {
     #[tokio::test]
     async fn cli_connectivity_succeeds_on_non_tls_error() {
         let cli = MockCliRunner::with_err(1, "unsupported file type");
-        let result = check_cli_connectivity(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_cli_connectivity(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert!(
             result.passed,
             "non-TLS error should still pass: {}",
@@ -500,14 +567,14 @@ mod tests {
             1,
             "SSL certificate problem: unable to get local issuer certificate",
         );
-        let result = check_cli_connectivity(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_cli_connectivity(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert_check(&result, false, "TLS/network");
     }
 
     #[tokio::test]
     async fn cli_connectivity_fails_on_license_check_ssl_error() {
         let cli = mock_license_failure(SSL_HANDSHAKE_STDERR);
-        let result = check_cli_connectivity(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_cli_connectivity(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert_check(&result, false, "TLS/network");
     }
 
@@ -516,14 +583,14 @@ mod tests {
         let cli = mock_license_failure(
             "License check failed, could not reach CodeScene servers (https://wrong.ee/api/v2/tool-license/cli)"
         );
-        let result = check_cli_connectivity(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_cli_connectivity(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert_check(&result, false, "TLS/network");
     }
 
     #[tokio::test]
     async fn cli_connectivity_passes_on_plain_license_failure() {
         let cli = mock_license_failure("License check failed: [401] Unauthorized");
-        let result = check_cli_connectivity(Path::new("/tmp"), &cli, TEST_TIMEOUT).await;
+        let result = check_cli_connectivity(Path::new("/tmp"), &test_ctx_cli(&cli, None)).await;
         assert!(
             result.passed,
             "plain license failure (no TLS) should pass connectivity: {}",
@@ -545,8 +612,8 @@ mod tests {
                 Ok(String::new())
             }
         }
-        let short = std::time::Duration::from_millis(50);
-        let result = check_cli_connectivity(Path::new("/tmp"), &HangingCli, short).await;
+        let result =
+            check_cli_connectivity(Path::new("/tmp"), &test_ctx_cli(&HangingCli, None)).await;
         assert!(!result.passed, "timeout should fail: {}", result.detail);
         assert!(
             result.detail.contains("timed out"),
@@ -653,18 +720,17 @@ mod tests {
     // -- api_url_label -------------------------------------------------------
 
     #[test]
-    fn api_url_label_returns_cloud_when_no_onprem() {
-        let _lock = crate::config::lock_test_env();
-        std::env::remove_var("CS_ONPREM_URL");
-        assert_eq!(api_url_label(), "CodeScene Cloud");
+    fn api_url_label_returns_cloud_when_no_credential() {
+        assert_eq!(api_url_label(None), "CodeScene Cloud");
     }
 
     #[test]
-    fn api_url_label_returns_onprem_url() {
-        let _lock = crate::config::lock_test_env();
-        std::env::set_var("CS_ONPREM_URL", "https://my-instance.com");
-        assert_eq!(api_url_label(), "https://my-instance.com");
-        std::env::remove_var("CS_ONPREM_URL");
+    fn api_url_label_returns_onprem_from_credential() {
+        let cred = AuthCredential::Configured {
+            access_token: "tok".to_string(),
+            onprem_url: Some("https://my-instance.com".to_string()),
+        };
+        assert_eq!(api_url_label(Some(&cred)), "https://my-instance.com");
     }
 
     // -- handle (integration) ------------------------------------------------

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -4,8 +4,6 @@ use serde_json::{json, Value};
 
 use crate::http::{HttpClient, HttpRequest, Method, ReqwestClient};
 
-const DEFAULT_API_URL: &str = "https://api.codescene.io";
-
 struct TrackingEvent {
     url: String,
     event: String,
@@ -13,16 +11,23 @@ struct TrackingEvent {
     environment: String,
     version: &'static str,
     properties: Value,
+    access_token: String,
+}
+
+/// Auth context for tracking events — pre-resolved token and API root.
+pub(crate) struct TrackingAuth {
+    pub(crate) access_token: String,
+    pub(crate) api_root: Option<String>,
 }
 
 /// Send a tracking event in the background (fire-and-forget).
-pub fn track_event(event: &str, properties: Value, instance_id: &str) {
+pub fn track_event(event: &str, properties: Value, instance_id: &str, auth: &TrackingAuth) {
     if is_disabled() {
         return;
     }
 
     let te = TrackingEvent {
-        url: match tracking_url() {
+        url: match resolve_tracking_url(auth.api_root.as_deref()) {
             Some(url) => url,
             None => return,
         },
@@ -31,6 +36,7 @@ pub fn track_event(event: &str, properties: Value, instance_id: &str) {
         environment: tracking_environment(),
         version: env!("CS_MCP_VERSION"),
         properties,
+        access_token: auth.access_token.clone(),
     };
 
     tokio::spawn(async move {
@@ -44,6 +50,7 @@ pub struct ErrorEvent<'a> {
     pub tool_name: &'a str,
     pub instance_id: &'a str,
     pub detail: Option<&'a str>,
+    pub auth: &'a TrackingAuth,
 }
 
 pub fn track_error(evt: &ErrorEvent<'_>) {
@@ -54,7 +61,7 @@ pub fn track_error(evt: &ErrorEvent<'_>) {
     if let Some(d) = evt.detail {
         properties["detail"] = json!(d);
     }
-    track_event("error", properties, evt.instance_id);
+    track_event("error", properties, evt.instance_id, evt.auth);
 }
 
 fn build_tracking_body(te: &mut TrackingEvent) -> Value {
@@ -71,7 +78,6 @@ fn build_tracking_body(te: &mut TrackingEvent) -> Value {
 
 async fn send_event(mut te: TrackingEvent, client: &dyn HttpClient) -> Result<(), String> {
     let body = build_tracking_body(&mut te);
-    let token = std::env::var("CS_ACCESS_TOKEN").unwrap_or_default();
     let mut headers = HashMap::from([
         ("Content-Type".to_string(), "application/json".to_string()),
         ("Accept".to_string(), "application/json".to_string()),
@@ -81,8 +87,11 @@ async fn send_event(mut te: TrackingEvent, client: &dyn HttpClient) -> Result<()
         ),
         ("X-CS-Source".to_string(), "mcp".to_string()),
     ]);
-    if !token.is_empty() {
-        headers.insert("Authorization".to_string(), format!("Bearer {token}"));
+    if !te.access_token.is_empty() {
+        headers.insert(
+            "Authorization".to_string(),
+            format!("Bearer {}", te.access_token),
+        );
     }
 
     let request = HttpRequest {
@@ -97,7 +106,13 @@ async fn send_event(mut te: TrackingEvent, client: &dyn HttpClient) -> Result<()
     Ok(())
 }
 
-fn tracking_url() -> Option<String> {
+/// Resolve the tracking endpoint URL.
+///
+/// Priority:
+/// 1. `CS_TRACKING_URL` env var (explicit override).
+/// 2. `api_root` parameter (from OAuth credential).
+/// 3. `default_api_root()` (from `CS_ONPREM_URL` or cloud fallback).
+fn resolve_tracking_url(api_root: Option<&str>) -> Option<String> {
     if let Ok(url) = std::env::var("CS_TRACKING_URL") {
         if let Err(e) = crate::config::require_https("CS_TRACKING_URL", &url) {
             tracing::warn!("{e}");
@@ -106,19 +121,11 @@ fn tracking_url() -> Option<String> {
         return Some(normalize_tracking_override(&url));
     }
 
-    let api_url = std::env::var("CS_ONPREM_URL")
-        .map(|u| {
-            if let Err(e) = crate::config::require_https("CS_ONPREM_URL", &u) {
-                tracing::warn!("{e}");
-                return Err(e);
-            }
-            Ok(format!("{u}/api"))
-        })
-        .unwrap_or_else(|_| Ok(DEFAULT_API_URL.to_string()));
-
-    api_url
-        .ok()
-        .map(|base| format!("{base}/v2/analytics/track"))
+    let base = match api_root {
+        Some(root) => root.trim_end_matches('/').to_string(),
+        None => crate::auth::default_api_root().ok()?,
+    };
+    Some(format!("{}/v2/analytics/track", base.trim_end_matches('/')))
 }
 
 fn tracking_environment() -> String {
@@ -204,63 +211,63 @@ mod tests {
         std::env::remove_var("CS_TRACKING_URL");
         std::env::remove_var("CS_ONPREM_URL");
         assert_eq!(
-            tracking_url(),
+            resolve_tracking_url(None),
             Some("https://api.codescene.io/v2/analytics/track".to_string())
         );
     }
 
     #[test]
-    fn tracking_url_override() {
+    fn tracking_url_resolution_cases() {
         let _lock = config::lock_test_env();
-        std::env::set_var("CS_TRACKING_URL", "http://custom-tracking");
-        assert_eq!(tracking_url(), None, "HTTP URLs should be blocked");
-        std::env::remove_var("CS_TRACKING_URL");
-    }
 
-    #[test]
-    fn tracking_url_override_https() {
-        let _lock = config::lock_test_env();
+        // CS_TRACKING_URL override: HTTP blocked
+        std::env::set_var("CS_TRACKING_URL", "http://custom-tracking");
+        assert_eq!(resolve_tracking_url(None), None);
+
+        // CS_TRACKING_URL override: HTTPS without full path appends path
         std::env::set_var("CS_TRACKING_URL", "https://custom-tracking");
         assert_eq!(
-            tracking_url(),
+            resolve_tracking_url(None),
             Some("https://custom-tracking/v2/analytics/track".to_string())
         );
-        std::env::remove_var("CS_TRACKING_URL");
-    }
 
-    #[test]
-    fn tracking_url_override_with_full_path_keeps_path() {
-        let _lock = config::lock_test_env();
+        // CS_TRACKING_URL override: full path preserved as-is
         std::env::set_var(
             "CS_TRACKING_URL",
             "https://custom-tracking/v2/analytics/track",
         );
         assert_eq!(
-            tracking_url(),
+            resolve_tracking_url(None),
             Some("https://custom-tracking/v2/analytics/track".to_string())
         );
         std::env::remove_var("CS_TRACKING_URL");
-    }
 
-    #[test]
-    fn tracking_url_from_onprem() {
-        let _lock = config::lock_test_env();
-        std::env::remove_var("CS_TRACKING_URL");
+        // CS_ONPREM_URL fallback: derives from onprem + /api
         std::env::set_var("CS_ONPREM_URL", "https://my-instance.example.com");
         assert_eq!(
-            tracking_url(),
+            resolve_tracking_url(None),
             Some("https://my-instance.example.com/api/v2/analytics/track".to_string())
         );
+
+        // CS_ONPREM_URL: HTTP blocked
+        std::env::set_var("CS_ONPREM_URL", "http://my-instance.example.com");
+        assert_eq!(resolve_tracking_url(None), None);
         std::env::remove_var("CS_ONPREM_URL");
     }
 
     #[test]
-    fn tracking_url_from_onprem_http_blocked() {
+    fn tracking_url_from_oauth_api_root() {
         let _lock = config::lock_test_env();
         std::env::remove_var("CS_TRACKING_URL");
-        std::env::set_var("CS_ONPREM_URL", "http://my-instance.example.com");
-        assert_eq!(tracking_url(), None, "HTTP on-prem URL should be blocked");
         std::env::remove_var("CS_ONPREM_URL");
+        assert_eq!(
+            resolve_tracking_url(Some("https://oauth-host.example.com/api")),
+            Some("https://oauth-host.example.com/api/v2/analytics/track".to_string())
+        );
+        assert_eq!(
+            resolve_tracking_url(Some("https://api.codescene.io")),
+            Some("https://api.codescene.io/v2/analytics/track".to_string())
+        );
     }
 
     #[test]
@@ -301,6 +308,7 @@ mod tests {
             environment: "test-env".to_string(),
             version: "1.0.0",
             properties: json!({"tool": "review"}),
+            access_token: String::new(),
         };
         let body = build_tracking_body(&mut te);
         assert_eq!(body["event-type"], "mcp-test");
@@ -321,6 +329,7 @@ mod tests {
             environment: "env".to_string(),
             version: "1.0.0",
             properties: json!("not-an-object"),
+            access_token: String::new(),
         };
         let body = build_tracking_body(&mut te);
         // Properties stay as-is when not an object
@@ -328,14 +337,9 @@ mod tests {
     }
 
     async fn send_event_and_capture_request(
-        token: Option<&str>,
+        _token: Option<&str>,
         te: TrackingEvent,
     ) -> crate::http::HttpRequest {
-        match token {
-            Some(value) => std::env::set_var("CS_ACCESS_TOKEN", value),
-            None => std::env::remove_var("CS_ACCESS_TOKEN"),
-        }
-
         let mock = MockHttpClient::always(HttpResponse::ok(""));
         let captured = mock.captured_requests.clone();
 
@@ -365,6 +369,7 @@ mod tests {
             environment: "test".to_string(),
             version: "1.0.0",
             properties: json!({"key": "val"}),
+            access_token: "test-tok".to_string(),
         };
         let req = send_event_and_capture_request(Some("test-tok"), te).await;
 
@@ -372,8 +377,6 @@ mod tests {
         assert_eq!(req.method, Method::Post);
         assert_eq!(req.headers.get("Authorization").unwrap(), "Bearer test-tok");
         assert_standard_headers(&req);
-
-        std::env::remove_var("CS_ACCESS_TOKEN");
     }
 
     #[tokio::test]
@@ -386,6 +389,7 @@ mod tests {
             environment: "e".to_string(),
             version: "1.0.0",
             properties: json!({}),
+            access_token: String::new(),
         };
         let req = send_event_and_capture_request(None, te).await;
 
@@ -397,7 +401,6 @@ mod tests {
     #[tokio::test]
     async fn send_event_serializes_body_with_event_type() {
         let _lock = config::lock_test_env();
-        std::env::remove_var("CS_ACCESS_TOKEN");
 
         let mock = MockHttpClient::always(HttpResponse::ok(""));
         let captured = mock.captured_requests.clone();
@@ -409,6 +412,7 @@ mod tests {
             environment: "env".to_string(),
             version: "2.0.0",
             properties: json!({"tool": "score"}),
+            access_token: String::new(),
         };
         let _ = send_event(te, &mock).await;
 
@@ -422,7 +426,6 @@ mod tests {
     #[tokio::test]
     async fn send_event_returns_error_on_transport_failure() {
         let _lock = config::lock_test_env();
-        std::env::remove_var("CS_ACCESS_TOKEN");
 
         let mock = MockHttpClient::new(vec![]);
 
@@ -433,6 +436,7 @@ mod tests {
             environment: "e".to_string(),
             version: "1.0.0",
             properties: json!({}),
+            access_token: String::new(),
         };
         let result = send_event(te, &mock).await;
         assert!(result.is_err());
@@ -442,7 +446,16 @@ mod tests {
     async fn track_event_disabled_does_not_panic() {
         let _lock = config::lock_test_env();
         std::env::set_var("CS_DISABLE_TRACKING", "1");
-        track_event("test-event", json!({"key": "value"}), "test-instance");
+        let auth = TrackingAuth {
+            access_token: String::new(),
+            api_root: None,
+        };
+        track_event(
+            "test-event",
+            json!({"key": "value"}),
+            "test-instance",
+            &auth,
+        );
         std::env::remove_var("CS_DISABLE_TRACKING");
     }
 
@@ -450,11 +463,16 @@ mod tests {
     async fn track_error_disabled_does_not_panic() {
         let _lock = config::lock_test_env();
         std::env::set_var("CS_DISABLE_TRACKING", "1");
+        let auth = TrackingAuth {
+            access_token: String::new(),
+            api_root: None,
+        };
         track_error(&ErrorEvent {
             error_kind: "some error",
             tool_name: "some-tool",
             instance_id: "test-instance",
             detail: None,
+            auth: &auth,
         });
         std::env::remove_var("CS_DISABLE_TRACKING");
     }
@@ -471,7 +489,11 @@ mod tests {
     #[tokio::test]
     async fn track_event_enabled_spawns_without_panic() {
         run_with_tracking_enabled(|| {
-            track_event("test-enabled", json!({"key": "val"}), "test-id");
+            let auth = TrackingAuth {
+                access_token: String::new(),
+                api_root: None,
+            };
+            track_event("test-enabled", json!({"key": "val"}), "test-id", &auth);
         })
         .await;
     }
@@ -479,11 +501,16 @@ mod tests {
     #[tokio::test]
     async fn track_error_enabled_spawns_without_panic() {
         run_with_tracking_enabled(|| {
+            let auth = TrackingAuth {
+                access_token: String::new(),
+                api_root: None,
+            };
             track_error(&ErrorEvent {
                 error_kind: "err msg",
                 tool_name: "tool-name",
                 instance_id: "test-id",
                 detail: Some(".txt"),
+                auth: &auth,
             });
         })
         .await;

--- a/src/tracking.rs
+++ b/src/tracking.rs
@@ -271,6 +271,21 @@ mod tests {
     }
 
     #[test]
+    fn tracking_url_resolution_allows_host_docker_internal() {
+        // Regression test: e2e tests running under the Docker backend point
+        // CS_TRACKING_URL at `http://host.docker.internal:<port>` so the
+        // container can reach the fake tracking server on the host. This
+        // must not be blocked by the HTTPS requirement.
+        let _lock = config::lock_test_env();
+        std::env::set_var("CS_TRACKING_URL", "http://host.docker.internal:12345");
+        assert_eq!(
+            resolve_tracking_url(None),
+            Some("http://host.docker.internal:12345/v2/analytics/track".to_string())
+        );
+        std::env::remove_var("CS_TRACKING_URL");
+    }
+
+    #[test]
     fn tracking_environment_uses_detected_environment_when_unset() {
         let _lock = config::lock_test_env();
         std::env::remove_var("CS_ENVIRONMENT");

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1052,6 +1052,47 @@ fn test_ssl_path_set_config_ca_bundle_applies_immediately() {
     tests::ssl_ca_bundle_path_formats::test_set_config_ca_bundle_applies_immediately();
 }
 
+// --- OAuth Login ---
+#[test]
+fn test_login_skips_when_pat_configured() {
+    tests::oauth_login::test_login_skips_when_pat_configured();
+}
+
+#[test]
+fn test_login_reuses_existing_session() {
+    tests::oauth_login::test_login_reuses_existing_session();
+}
+
+#[test]
+fn test_login_interactive_flow_persists_token() {
+    tests::oauth_login::test_login_interactive_flow_persists_token();
+}
+
+#[test]
+fn test_login_fetches_token_when_login_omits_access_token() {
+    tests::oauth_login::test_login_fetches_token_when_login_omits_access_token();
+}
+
+#[test]
+fn test_failed_login_persists_signed_out_state() {
+    tests::oauth_login::test_failed_login_persists_signed_out_state();
+}
+
+#[test]
+fn test_persisted_oauth_reused_by_second_process() {
+    tests::oauth_login::test_persisted_oauth_reused_by_second_process();
+}
+
+#[test]
+fn test_expiry_without_token_triggers_refresh() {
+    tests::oauth_login::test_expiry_without_token_triggers_refresh();
+}
+
+#[test]
+fn test_pat_takes_precedence_over_oauth() {
+    tests::oauth_login::test_pat_takes_precedence_over_oauth();
+}
+
 // --- Stress Test ---
 #[test]
 #[ignore] // Long-running; run with --ignored

--- a/tests/e2e/tests/analytics_environment_override.rs
+++ b/tests/e2e/tests/analytics_environment_override.rs
@@ -4,20 +4,18 @@
 //! - Default environment (binary/docker) is sent when `CS_ENVIRONMENT` is unset
 //! - Custom environment value is sent when `CS_ENVIRONMENT` is set
 
-use super::fake_https_server::FakeHttpsServer;
+use super::fake_http_server::FakeHttpServer;
 use super::*;
 
 const TIMEOUT: Duration = Duration::from_secs(60);
 
 fn score_event_environment(extra_env: &[(&str, &str)]) -> Option<String> {
-    let cert_dir = create_temp_dir("cs_mcp_certs_env_").expect("cert dir");
-    let server = FakeHttpsServer::always_ok(cert_dir.path());
+    let server = FakeHttpServer::always_ok();
     let (command, mut env, repo_dir, _tmp) = setup();
 
+    use_isolated_config_dir(&mut env, &repo_dir, ".cs_config_analytics_env");
     env.retain(|(k, _)| k != "CS_DISABLE_TRACKING");
     env.push(("CS_TRACKING_URL".to_string(), server.url()));
-    let ca_path = super::docker_ca_bundle(&server.certs.ca_cert_path, &repo_dir);
-    env.push(("REQUESTS_CA_BUNDLE".to_string(), ca_path));
     for (key, val) in extra_env {
         env.push((key.to_string(), val.to_string()));
     }

--- a/tests/e2e/tests/analytics_tracking.rs
+++ b/tests/e2e/tests/analytics_tracking.rs
@@ -6,7 +6,7 @@
 //! - Tracking can be disabled via `CS_DISABLE_TRACKING`
 //! - Enriched events contain required common and tool-specific properties
 
-use super::fake_https_server::FakeHttpsServer;
+use super::fake_http_server::FakeHttpServer;
 use super::*;
 
 use sha2::{Digest, Sha256};
@@ -61,32 +61,30 @@ fn analytics_setup_with_env(
     extra: &[(&str, &str)],
 ) -> (Vec<String>, Vec<(String, String)>, PathBuf, TempDir) {
     let (command, mut env, repo_dir, tmp) = setup();
+    use_isolated_config_dir(&mut env, &repo_dir, ".cs_config_analytics");
     for (key, val) in extra {
         env.push((key.to_string(), val.to_string()));
     }
     (command, env, repo_dir, tmp)
 }
 
-fn analytics_setup_with_https_server(
+fn analytics_setup_with_tracking_server(
     extra: &[(&str, &str)],
 ) -> (
     Vec<String>,
     Vec<(String, String)>,
     PathBuf,
-    FakeHttpsServer,
-    TempDir,
+    FakeHttpServer,
     TempDir,
 ) {
-    let cert_dir = create_temp_dir("cs_mcp_certs_").expect("cert dir");
-    let server = FakeHttpsServer::always_ok(cert_dir.path());
+    let server = FakeHttpServer::always_ok();
     let (command, mut env, repo_dir, tmp) = setup();
+    use_isolated_config_dir(&mut env, &repo_dir, ".cs_config_analytics");
     env.push(("CS_TRACKING_URL".to_string(), server.url()));
-    let ca_path = super::docker_ca_bundle(&server.certs.ca_cert_path, &repo_dir);
-    env.push(("REQUESTS_CA_BUNDLE".to_string(), ca_path));
     for (key, val) in extra {
         env.push((key.to_string(), val.to_string()));
     }
-    (command, env, repo_dir, server, tmp, cert_dir)
+    (command, env, repo_dir, server, tmp)
 }
 
 fn call_code_health_score(client: &mut MCPClient, repo_dir: &Path) -> String {
@@ -145,18 +143,18 @@ fn assert_properties_are_nonempty(props: &serde_json::Value, keys: &[&str]) {
     }
 }
 
-fn wait_for_analytics(server: &FakeHttpsServer) {
+fn wait_for_analytics(server: &FakeHttpServer) {
     let deadline = Instant::now() + Duration::from_secs(15);
     while server.request_count() == 0 && Instant::now() < deadline {
         std::thread::sleep(Duration::from_millis(200));
     }
 }
 
-fn score_with_https_server(extra: &[(&str, &str)]) -> (String, FakeHttpsServer, TempDir, TempDir) {
-    let (command, env, repo_dir, server, tmp, cert_dir) = analytics_setup_with_https_server(extra);
+fn score_with_tracking_server(extra: &[(&str, &str)]) -> (String, FakeHttpServer, TempDir) {
+    let (command, env, repo_dir, server, tmp) = analytics_setup_with_tracking_server(extra);
     let (result, _client) = start_client_and_score(&command, &env, &repo_dir);
     wait_for_analytics(&server);
-    (result, server, tmp, cert_dir)
+    (result, server, tmp)
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +162,7 @@ fn score_with_https_server(extra: &[(&str, &str)]) -> (String, FakeHttpsServer, 
 // ---------------------------------------------------------------------------
 
 pub fn test_analytics_events_are_sent() {
-    let (_result, server, _tmp, _cert_dir) = score_with_https_server(&[]);
+    let (_result, server, _tmp) = score_with_tracking_server(&[]);
     assert!(
         server.request_count() > 0,
         "Analytics server should have received at least one request"
@@ -172,8 +170,7 @@ pub fn test_analytics_events_are_sent() {
 }
 
 pub fn test_disabled_tracking_sends_no_events() {
-    let (_result, server, _tmp, _cert_dir) =
-        score_with_https_server(&[("CS_DISABLE_TRACKING", "1")]);
+    let (_result, server, _tmp) = score_with_tracking_server(&[("CS_DISABLE_TRACKING", "1")]);
     assert_eq!(
         server.request_count(),
         0,
@@ -209,7 +206,7 @@ pub fn test_disabled_tracking_returns_valid_results() {
 }
 
 pub fn test_enriched_event_contains_common_properties() {
-    let (_result, server, _tmp, _cert_dir) = score_with_https_server(&[]);
+    let (_result, server, _tmp) = score_with_tracking_server(&[]);
 
     let payloads = server.get_payloads();
     let props = find_event_properties(&payloads, "mcp-code-health-score");
@@ -228,7 +225,7 @@ pub fn test_enriched_event_contains_common_properties() {
 }
 
 pub fn test_enriched_event_contains_tool_specific_properties() {
-    let (result, server, _tmp, _cert_dir) = score_with_https_server(&[]);
+    let (result, server, _tmp) = score_with_tracking_server(&[]);
 
     let payloads = server.get_payloads();
     let props = find_event_properties(&payloads, "mcp-code-health-score");
@@ -301,17 +298,15 @@ fn run_tool_with_fake_server<F>(
 where
     F: FnOnce(&mut MCPClient, &Path) -> String,
 {
-    let cert_dir = create_temp_dir("cs_mcp_certs_run_").expect("cert dir");
-    let server = FakeHttpsServer::always_ok(cert_dir.path());
+    let server = FakeHttpServer::always_ok();
     let executable = find_or_build_executable();
     let backend = create_backend(executable);
 
     let base = base_env();
     let env_map = backend.get_env(&base, repo_dir);
     let mut env_vec: Vec<(String, String)> = env_map.into_iter().collect();
+    use_isolated_config_dir(&mut env_vec, repo_dir, ".cs_config_analytics");
     env_vec.push(("CS_TRACKING_URL".to_string(), server.url()));
-    let ca_path = super::docker_ca_bundle(&server.certs.ca_cert_path, repo_dir);
-    env_vec.push(("REQUESTS_CA_BUNDLE".to_string(), ca_path));
     for (k, v) in extra_env {
         env_vec.push((k.to_string(), v.to_string()));
     }

--- a/tests/e2e/tests/enabled_tools.rs
+++ b/tests/e2e/tests/enabled_tools.rs
@@ -137,14 +137,15 @@ pub fn test_filter_restricts_tools() {
     );
     assert!(names.contains("get_config"), "get_config always listed");
     assert!(names.contains("set_config"), "set_config always listed");
+    assert!(names.contains("login"), "login always listed");
     assert!(
         !names.contains("explain_code_health"),
         "explain_code_health should NOT be listed"
     );
     assert_eq!(
         names.len(),
-        4,
-        "Expected exactly 4 tools, found {}: {:?}",
+        5,
+        "Expected exactly 5 tools, found {}: {:?}",
         names.len(),
         names
     );

--- a/tests/e2e/tests/mod.rs
+++ b/tests/e2e/tests/mod.rs
@@ -13,6 +13,20 @@ pub use serde_json::json;
 pub use std::path::Path;
 pub use std::time::Duration;
 
+pub fn use_isolated_config_dir(
+    env: &mut Vec<(String, String)>,
+    repo_dir: &Path,
+    dir_name: &str,
+) {
+    let config_dir = repo_dir.join(dir_name);
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+    env.retain(|(k, _)| k != "CS_CONFIG_DIR");
+    env.push((
+        "CS_CONFIG_DIR".to_string(),
+        docker_config_dir(&config_dir, repo_dir),
+    ));
+}
+
 #[allow(dead_code)]
 pub mod fake_http_server;
 pub mod fake_https_server;
@@ -29,6 +43,7 @@ pub mod enabled_tools;
 pub mod error_logging;
 pub mod git_subtree;
 pub mod git_worktree;
+pub mod oauth_login;
 pub mod platform_specific;
 pub mod relative_paths;
 pub mod require_access_token;

--- a/tests/e2e/tests/oauth_login.rs
+++ b/tests/e2e/tests/oauth_login.rs
@@ -240,6 +240,14 @@ fn seed_config(config_dir: &Path, values: serde_json::Value) {
         .expect("seed config file");
 }
 
+/// Start the MCP server and complete the JSON-RPC handshake.
+fn start_client(t: &OAuthTestEnv) -> MCPClient {
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+    client
+}
+
 fn call_login(client: &mut MCPClient) -> String {
     let response = client
         .call_tool("login", json!({}), Duration::from_secs(30))
@@ -270,9 +278,7 @@ pub fn test_login_skips_when_pat_configured() {
         return skip_if_docker("fake CLI binary not available in container");
     }
     let t = oauth_setup(&[("CS_ACCESS_TOKEN", "pat-token")]);
-    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client.start(), "Server should start");
-    client.initialize().expect("Initialize should succeed");
+    let mut client = start_client(&t);
 
     let result = call_login(&mut client);
     assert!(
@@ -303,9 +309,7 @@ pub fn test_login_reuses_existing_session() {
     }
     let token_resp = signed_in_json("session-token", 3600);
     let t = oauth_setup(&[("FAKE_AUTH_TOKEN_RESPONSE", token_resp.as_str())]);
-    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client.start(), "Server should start");
-    client.initialize().expect("Initialize should succeed");
+    let mut client = start_client(&t);
 
     let result = call_login(&mut client);
     assert!(result.contains("Already signed in"), "got: {result}");
@@ -326,9 +330,7 @@ pub fn test_login_interactive_flow_persists_token() {
         ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
         ("FAKE_AUTH_LOGIN_RESPONSE", login_resp.as_str()),
     ]);
-    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client.start(), "Server should start");
-    client.initialize().expect("Initialize should succeed");
+    let mut client = start_client(&t);
 
     let result = call_login(&mut client);
     assert!(result.contains("Successfully signed in"), "got: {result}");
@@ -356,9 +358,7 @@ pub fn test_login_fetches_token_when_login_omits_access_token() {
         ("FAKE_AUTH_TOKEN_RESPONSE_2", fetched_resp.as_str()),
         ("FAKE_AUTH_LOGIN_RESPONSE", login_without_token.as_str()),
     ]);
-    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client.start(), "Server should start");
-    client.initialize().expect("Initialize should succeed");
+    let mut client = start_client(&t);
 
     let result = call_login(&mut client);
     assert!(result.contains("Successfully signed in"), "got: {result}");
@@ -377,9 +377,7 @@ pub fn test_failed_login_persists_signed_out_state() {
         ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
         ("FAKE_AUTH_LOGIN_RESPONSE", SIGNED_OUT_JSON),
     ]);
-    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client.start(), "Server should start");
-    client.initialize().expect("Initialize should succeed");
+    let mut client = start_client(&t);
 
     let result = call_login(&mut client);
     assert!(result.contains("Login did not complete"), "got: {result}");
@@ -407,9 +405,7 @@ pub fn test_persisted_oauth_reused_by_second_process() {
     ]);
 
     {
-        let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-        assert!(client.start(), "First server should start");
-        client.initialize().expect("Initialize should succeed");
+        let mut client = start_client(&t);
         let result = call_login(&mut client);
         assert!(result.contains("Successfully signed in"), "got: {result}");
         client.stop();
@@ -420,9 +416,7 @@ pub fn test_persisted_oauth_reused_by_second_process() {
 
     let log_after_login = std::fs::read_to_string(&t.call_log_path).unwrap_or_default();
 
-    let mut client2 = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client2.start(), "Second server should start");
-    client2.initialize().expect("Initialize should succeed");
+    let mut client2 = start_client(&t);
 
     let score = call_score(&mut client2, &t.repo_dir);
     assert!(
@@ -454,9 +448,7 @@ pub fn test_expiry_without_token_triggers_refresh() {
         }),
     );
 
-    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client.start(), "Server should start");
-    client.initialize().expect("Initialize should succeed");
+    let mut client = start_client(&t);
 
     let score = call_score(&mut client, &t.repo_dir);
     assert!(
@@ -489,9 +481,7 @@ pub fn test_pat_takes_precedence_over_oauth() {
         }),
     );
 
-    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
-    assert!(client.start(), "Server should start");
-    client.initialize().expect("Initialize should succeed");
+    let mut client = start_client(&t);
 
     let score = call_score(&mut client, &t.repo_dir);
     assert!(

--- a/tests/e2e/tests/oauth_login.rs
+++ b/tests/e2e/tests/oauth_login.rs
@@ -319,30 +319,73 @@ pub fn test_login_reuses_existing_session() {
     assert!(config.get("oauth_expires_at").is_some());
 }
 
-/// When no session exists, `login` should run the interactive flow and
-/// persist the resulting token, which a subsequent guarded tool call can use.
-pub fn test_login_interactive_flow_persists_token() {
+/// Expectations for a login-flow scenario that exercises the full
+/// `login` -> persisted config -> guarded tool call path. Shared by the
+/// interactive-success and failed-login regression tests below, which
+/// otherwise differ only in these values.
+struct LoginFlowExpectation<'a> {
+    /// Response the fake CLI returns for `auth login`.
+    login_response: &'a str,
+    /// Substring expected in the `login` tool result text.
+    result_contains: &'a str,
+    /// Expected `oauth_token` value in the persisted config, if any.
+    oauth_token: Option<&'a str>,
+    /// Expected `oauth_expires_at` value in the persisted config, if any.
+    oauth_expires_at: Option<&'a str>,
+    /// Whether a subsequent guarded tool call should succeed using the
+    /// resulting auth state (`true`) or keep reporting a missing token
+    /// (`false`).
+    score_has_token: bool,
+}
+
+/// Runs `login` against a fresh session, then asserts on the tool result,
+/// the persisted config file, and a subsequent guarded tool call.
+fn assert_login_flow(expect: &LoginFlowExpectation) {
     if is_docker() {
         return skip_if_docker("fake CLI binary not available in container");
     }
-    let login_resp = signed_in_json("interactive-token", 3600);
     let t = oauth_setup(&[
         ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
-        ("FAKE_AUTH_LOGIN_RESPONSE", login_resp.as_str()),
+        ("FAKE_AUTH_LOGIN_RESPONSE", expect.login_response),
     ]);
     let mut client = start_client(&t);
 
     let result = call_login(&mut client);
-    assert!(result.contains("Successfully signed in"), "got: {result}");
+    assert!(result.contains(expect.result_contains), "got: {result}");
 
     let config = read_config(&t.config_dir);
-    assert_eq!(config["oauth_token"].as_str(), Some("interactive-token"));
+    if let Some(token) = expect.oauth_token {
+        assert_eq!(config["oauth_token"].as_str(), Some(token));
+    }
+    if let Some(expires_at) = expect.oauth_expires_at {
+        assert_eq!(config["oauth_expires_at"].as_str(), Some(expires_at));
+    }
 
     let score = call_score(&mut client, &t.repo_dir);
-    assert!(
-        !score.contains("No access token configured"),
-        "Guarded tool should work using the freshly persisted OAuth token, got: {score}"
-    );
+    if expect.score_has_token {
+        assert!(
+            !score.contains("No access token configured"),
+            "Guarded tool should work using the freshly persisted OAuth token, got: {score}"
+        );
+    } else {
+        assert!(
+            score.contains("No access token configured"),
+            "Should keep reporting missing token, got: {score}"
+        );
+    }
+}
+
+/// When no session exists, `login` should run the interactive flow and
+/// persist the resulting token, which a subsequent guarded tool call can use.
+pub fn test_login_interactive_flow_persists_token() {
+    let login_resp = signed_in_json("interactive-token", 3600);
+    assert_login_flow(&LoginFlowExpectation {
+        login_response: login_resp.as_str(),
+        result_contains: "Successfully signed in",
+        oauth_token: Some("interactive-token"),
+        oauth_expires_at: None,
+        score_has_token: true,
+    });
 }
 
 /// Regression test: when the login response omits `access-token`, MCP must
@@ -370,26 +413,13 @@ pub fn test_login_fetches_token_when_login_omits_access_token() {
 /// A login that never completes must persist the signed-out sentinel, and
 /// guarded tools must keep reporting "no token" rather than crashing.
 pub fn test_failed_login_persists_signed_out_state() {
-    if is_docker() {
-        return skip_if_docker("fake CLI binary not available in container");
-    }
-    let t = oauth_setup(&[
-        ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
-        ("FAKE_AUTH_LOGIN_RESPONSE", SIGNED_OUT_JSON),
-    ]);
-    let mut client = start_client(&t);
-
-    let result = call_login(&mut client);
-    assert!(result.contains("Login did not complete"), "got: {result}");
-
-    let config = read_config(&t.config_dir);
-    assert_eq!(config["oauth_expires_at"].as_str(), Some("0"));
-
-    let score = call_score(&mut client, &t.repo_dir);
-    assert!(
-        score.contains("No access token configured"),
-        "Should keep reporting missing token, got: {score}"
-    );
+    assert_login_flow(&LoginFlowExpectation {
+        login_response: SIGNED_OUT_JSON,
+        result_contains: "Login did not complete",
+        oauth_token: None,
+        oauth_expires_at: Some("0"),
+        score_has_token: false,
+    });
 }
 
 /// OAuth state persisted by one MCP process must be reusable by a second,

--- a/tests/e2e/tests/oauth_login.rs
+++ b/tests/e2e/tests/oauth_login.rs
@@ -1,0 +1,507 @@
+//! OAuth login end-to-end tests.
+//!
+//! The real OAuth authorization-code flow (browser redirect + provider
+//! token issuance) cannot be faked in an e2e test. Instead, these tests
+//! fake the embedded CLI (via `CS_CLI_PATH`), which is the actual contract
+//! the MCP server depends on: `cs auth token --client mcp --output-format
+//! json` and `cs auth login --client mcp --output-format json`.
+//!
+//! This lets us verify MCP-side behavior that previously regressed:
+//! - OAuth token persistence into the config-backed environment/config file
+//! - Falling back to `auth token` when a login response omits `access-token`
+//! - Reuse of persisted OAuth state across a fresh MCP server process
+//! - Refresh behavior when expiry exists but the token itself is missing
+//! - Correct precedence between a configured PAT and OAuth state
+//!
+//! Every test gets its own temp `CS_CONFIG_DIR` (never the real user config
+//! dir) and its own temp marker/log files for the fake CLI, so there is no
+//! shared state between tests or processes.
+
+use super::*;
+use std::process::Command;
+
+const SIGNED_OUT_JSON: &str =
+    r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+
+fn now_epoch() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+fn signed_in_json(token: &str, expires_in_secs: i64) -> String {
+    let expires_at = now_epoch() + expires_in_secs;
+    format!(
+        r#"{{"status":"signed_in","access-token":"{token}","api-url":"https://api.codescene.io/api","expires-at":{expires_at},"refresh-token-expires-at":{}}}"#,
+        expires_at + 3600
+    )
+}
+
+fn signed_in_without_access_token(expires_in_secs: i64) -> String {
+    let expires_at = now_epoch() + expires_in_secs;
+    format!(
+        r#"{{"status":"signed_in","access-token":null,"api-url":"https://api.codescene.io/api","expires-at":{expires_at},"refresh-token-expires-at":{}}}"#,
+        expires_at + 3600
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Fake CLI
+// ---------------------------------------------------------------------------
+
+/// Fake `cs` CLI that answers `auth token`, `auth login`, and `review`.
+///
+/// Responses are controlled entirely via env vars so a single compiled
+/// binary can be reused across every test in this file:
+/// - `FAKE_AUTH_TOKEN_RESPONSE` — response for the first `auth token` call
+/// - `FAKE_AUTH_TOKEN_RESPONSE_2` — response for subsequent `auth token`
+///   calls (falls back to `FAKE_AUTH_TOKEN_RESPONSE` if unset)
+/// - `FAKE_AUTH_LOGIN_RESPONSE` — response for `auth login` calls
+/// - `FAKE_CALL_MARKER` — path to a marker file used to distinguish the
+///   first vs. later `auth token` call
+/// - `FAKE_CALL_LOG` — path to an append-only log of every `auth ...`
+///   invocation, used to assert the CLI auth endpoints were/weren't called
+const FAKE_CLI_RS: &str = r##"use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process;
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).filter(|a| !a.starts_with("-D")).collect();
+
+    if args.first().map(|s| s.as_str()) == Some("auth") {
+        if let Ok(log_path) = env::var("FAKE_CALL_LOG") {
+            if let Ok(mut f) = fs::OpenOptions::new().create(true).append(true).open(&log_path) {
+                let _ = writeln!(f, "{}", args.join(" "));
+            }
+        }
+    }
+
+    match (args.first().map(|s| s.as_str()), args.get(1).map(|s| s.as_str())) {
+        (Some("auth"), Some("token")) => {
+            let marker = env::var("FAKE_CALL_MARKER").ok();
+            let already_called = marker
+                .as_deref()
+                .map(|p| Path::new(p).is_file())
+                .unwrap_or(false);
+            if let Some(p) = &marker {
+                let _ = fs::write(p, "1");
+            }
+            let resp = if already_called {
+                env::var("FAKE_AUTH_TOKEN_RESPONSE_2")
+                    .or_else(|_| env::var("FAKE_AUTH_TOKEN_RESPONSE"))
+            } else {
+                env::var("FAKE_AUTH_TOKEN_RESPONSE")
+            }
+            .unwrap_or_else(|_| {
+                r#"{"status":"signed_out","access-token":null,"api-url":null}"#.to_string()
+            });
+            println!("{resp}");
+            process::exit(0);
+        }
+        (Some("auth"), Some("login")) => {
+            let resp = env::var("FAKE_AUTH_LOGIN_RESPONSE").unwrap_or_else(|_| {
+                r#"{"status":"signed_out","access-token":null,"api-url":null}"#.to_string()
+            });
+            println!("{resp}");
+            process::exit(0);
+        }
+        (Some("review"), _) => {
+            println!(r#"{{"score":9.5,"review":[]}}"#);
+            process::exit(0);
+        }
+        (Some("version"), _) => {
+            println!("fake-cli-version");
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("fake-cli: unsupported command: {}", args.join(" "));
+            process::exit(1);
+        }
+    }
+}
+"##;
+
+/// Compile the fake CLI from embedded Rust source and return its path.
+fn make_fake_cli(dir: &Path) -> std::path::PathBuf {
+    let source = dir.join("fake_cs_oauth.rs");
+    std::fs::write(&source, FAKE_CLI_RS).expect("write fake CLI source");
+
+    let binary_name = if cfg!(windows) { "cs.exe" } else { "cs" };
+    let output_path = dir.join(binary_name);
+
+    let result = Command::new("rustc")
+        .args([
+            source.to_str().expect("source path"),
+            "-O",
+            "-o",
+            output_path.to_str().expect("output path"),
+        ])
+        .output()
+        .expect("rustc should execute");
+
+    assert!(
+        result.status.success(),
+        "Failed to compile fake CLI: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    output_path
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+struct OAuthTestEnv {
+    command: Vec<String>,
+    env: Vec<(String, String)>,
+    repo_dir: std::path::PathBuf,
+    config_dir: std::path::PathBuf,
+    call_log_path: std::path::PathBuf,
+    _tmp: tempfile::TempDir,
+}
+
+/// Build a fresh MCP environment with a fake CLI, a temp `CS_CONFIG_DIR`,
+/// and no `CS_ACCESS_TOKEN` (unless `extra_env` sets one). Every call gets
+/// its own temp dir, so marker/log files never leak across tests.
+fn oauth_setup(extra_env: &[(&str, &str)]) -> OAuthTestEnv {
+    let executable = find_or_build_executable();
+    let backend = create_backend(executable);
+
+    let temp_dir = create_temp_dir("cs_mcp_oauth_").expect("create temp dir");
+    let sample_files = get_sample_files();
+    let repo_dir = create_git_repo(temp_dir.path(), &sample_files).expect("create git repo");
+
+    let fake_cli = make_fake_cli(temp_dir.path());
+    let config_dir = temp_dir.path().join(".cs_config_oauth");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+
+    let call_marker = temp_dir.path().join(".auth_token_marker");
+    let call_log = temp_dir.path().join(".auth_calls.log");
+
+    let base = base_env();
+    let env_map = backend.get_env(&base, &repo_dir);
+    let env: Vec<(String, String)> = env_map
+        .into_iter()
+        .filter(|(k, _)| k != "CS_ACCESS_TOKEN")
+        .chain(
+            [
+                ("CS_CLI_PATH", fake_cli.to_string_lossy().into_owned()),
+                (
+                    "CS_CONFIG_DIR",
+                    config_dir.to_string_lossy().into_owned(),
+                ),
+                ("CS_DISABLE_VERSION_CHECK", "1".to_string()),
+                ("CS_DISABLE_TRACKING", "1".to_string()),
+                (
+                    "FAKE_CALL_MARKER",
+                    call_marker.to_string_lossy().into_owned(),
+                ),
+                ("FAKE_CALL_LOG", call_log.to_string_lossy().into_owned()),
+            ]
+            .into_iter()
+            .map(|(k, v): (&str, String)| (k.to_string(), v)),
+        )
+        .chain(
+            extra_env
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string())),
+        )
+        .collect();
+
+    let command = backend.get_command(&repo_dir);
+    OAuthTestEnv {
+        command,
+        env,
+        repo_dir,
+        config_dir,
+        call_log_path: call_log,
+        _tmp: temp_dir,
+    }
+}
+
+fn read_config(config_dir: &Path) -> serde_json::Value {
+    let path = config_dir.join("config.json");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read config file {}: {e}", path.display()));
+    serde_json::from_str(&content).expect("parse config.json")
+}
+
+fn config_file_exists(config_dir: &Path) -> bool {
+    config_dir.join("config.json").is_file()
+}
+
+fn seed_config(config_dir: &Path, values: serde_json::Value) {
+    let path = config_dir.join("config.json");
+    std::fs::write(&path, serde_json::to_string_pretty(&values).unwrap())
+        .expect("seed config file");
+}
+
+fn call_login(client: &mut MCPClient) -> String {
+    let response = client
+        .call_tool("login", json!({}), Duration::from_secs(30))
+        .expect("login call should succeed");
+    extract_result_text(&response)
+}
+
+fn call_score(client: &mut MCPClient, repo_dir: &Path) -> String {
+    let file = repo_dir.join("src/utils/calculator.py");
+    let response = client
+        .call_tool(
+            "code_health_score",
+            json!({"file_path": file.to_string_lossy()}),
+            Duration::from_secs(30),
+        )
+        .expect("code_health_score call should succeed");
+    extract_result_text(&response)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// A configured PAT must short-circuit OAuth entirely: `login` should not
+/// call the CLI auth endpoints, and no OAuth state should be persisted.
+pub fn test_login_skips_when_pat_configured() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let t = oauth_setup(&[("CS_ACCESS_TOKEN", "pat-token")]);
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let result = call_login(&mut client);
+    assert!(
+        result.contains("CS_ACCESS_TOKEN is already configured"),
+        "got: {result}"
+    );
+
+    if config_file_exists(&t.config_dir) {
+        let config = read_config(&t.config_dir);
+        assert!(
+            config.get("oauth_token").is_none(),
+            "should not persist oauth_token when PAT is configured, got: {config}"
+        );
+    }
+
+    let log = std::fs::read_to_string(&t.call_log_path).unwrap_or_default();
+    assert!(
+        log.is_empty(),
+        "CLI auth endpoints should not be called when PAT is configured, got log: {log}"
+    );
+}
+
+/// When the CLI already reports a fresh signed-in session, `login` should
+/// reuse it and persist the OAuth token into the config file.
+pub fn test_login_reuses_existing_session() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let token_resp = signed_in_json("session-token", 3600);
+    let t = oauth_setup(&[("FAKE_AUTH_TOKEN_RESPONSE", token_resp.as_str())]);
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let result = call_login(&mut client);
+    assert!(result.contains("Already signed in"), "got: {result}");
+
+    let config = read_config(&t.config_dir);
+    assert_eq!(config["oauth_token"].as_str(), Some("session-token"));
+    assert!(config.get("oauth_expires_at").is_some());
+}
+
+/// When no session exists, `login` should run the interactive flow and
+/// persist the resulting token, which a subsequent guarded tool call can use.
+pub fn test_login_interactive_flow_persists_token() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let login_resp = signed_in_json("interactive-token", 3600);
+    let t = oauth_setup(&[
+        ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
+        ("FAKE_AUTH_LOGIN_RESPONSE", login_resp.as_str()),
+    ]);
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let result = call_login(&mut client);
+    assert!(result.contains("Successfully signed in"), "got: {result}");
+
+    let config = read_config(&t.config_dir);
+    assert_eq!(config["oauth_token"].as_str(), Some("interactive-token"));
+
+    let score = call_score(&mut client, &t.repo_dir);
+    assert!(
+        !score.contains("No access token configured"),
+        "Guarded tool should work using the freshly persisted OAuth token, got: {score}"
+    );
+}
+
+/// Regression test: when the login response omits `access-token`, MCP must
+/// immediately fetch it via `auth token` and persist the real token, not null.
+pub fn test_login_fetches_token_when_login_omits_access_token() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let fetched_resp = signed_in_json("fetched-token", 3600);
+    let login_without_token = signed_in_without_access_token(3600);
+    let t = oauth_setup(&[
+        ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
+        ("FAKE_AUTH_TOKEN_RESPONSE_2", fetched_resp.as_str()),
+        ("FAKE_AUTH_LOGIN_RESPONSE", login_without_token.as_str()),
+    ]);
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let result = call_login(&mut client);
+    assert!(result.contains("Successfully signed in"), "got: {result}");
+
+    let config = read_config(&t.config_dir);
+    assert_eq!(config["oauth_token"].as_str(), Some("fetched-token"));
+}
+
+/// A login that never completes must persist the signed-out sentinel, and
+/// guarded tools must keep reporting "no token" rather than crashing.
+pub fn test_failed_login_persists_signed_out_state() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let t = oauth_setup(&[
+        ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
+        ("FAKE_AUTH_LOGIN_RESPONSE", SIGNED_OUT_JSON),
+    ]);
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let result = call_login(&mut client);
+    assert!(result.contains("Login did not complete"), "got: {result}");
+
+    let config = read_config(&t.config_dir);
+    assert_eq!(config["oauth_expires_at"].as_str(), Some("0"));
+
+    let score = call_score(&mut client, &t.repo_dir);
+    assert!(
+        score.contains("No access token configured"),
+        "Should keep reporting missing token, got: {score}"
+    );
+}
+
+/// OAuth state persisted by one MCP process must be reusable by a second,
+/// independently started MCP process without any further CLI auth calls.
+pub fn test_persisted_oauth_reused_by_second_process() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let login_resp = signed_in_json("persisted-token", 3600);
+    let t = oauth_setup(&[
+        ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
+        ("FAKE_AUTH_LOGIN_RESPONSE", login_resp.as_str()),
+    ]);
+
+    {
+        let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+        assert!(client.start(), "First server should start");
+        client.initialize().expect("Initialize should succeed");
+        let result = call_login(&mut client);
+        assert!(result.contains("Successfully signed in"), "got: {result}");
+        client.stop();
+    }
+
+    let config = read_config(&t.config_dir);
+    assert_eq!(config["oauth_token"].as_str(), Some("persisted-token"));
+
+    let log_after_login = std::fs::read_to_string(&t.call_log_path).unwrap_or_default();
+
+    let mut client2 = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client2.start(), "Second server should start");
+    client2.initialize().expect("Initialize should succeed");
+
+    let score = call_score(&mut client2, &t.repo_dir);
+    assert!(
+        !score.contains("No access token configured"),
+        "Second process should reuse persisted OAuth token, got: {score}"
+    );
+
+    let log_after_score = std::fs::read_to_string(&t.call_log_path).unwrap_or_default();
+    assert_eq!(
+        log_after_login, log_after_score,
+        "Second process should not need to call CLI auth endpoints again"
+    );
+}
+
+/// Regression test: cached state with an expiry but no token must not be
+/// treated as authenticated — MCP must refresh via the CLI and repair state.
+pub fn test_expiry_without_token_triggers_refresh() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let recovered_resp = signed_in_json("recovered-token", 3600);
+    let t = oauth_setup(&[("FAKE_AUTH_TOKEN_RESPONSE", recovered_resp.as_str())]);
+
+    seed_config(
+        &t.config_dir,
+        json!({
+            "instance_id": "test-instance-id",
+            "oauth_expires_at": (now_epoch() + 3600).to_string(),
+        }),
+    );
+
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let score = call_score(&mut client, &t.repo_dir);
+    assert!(
+        !score.contains("No access token configured"),
+        "Should refresh via CLI when expiry exists but token is missing, got: {score}"
+    );
+
+    let config = read_config(&t.config_dir);
+    assert_eq!(config["oauth_token"].as_str(), Some("recovered-token"));
+}
+
+/// A configured PAT must take precedence over any cached OAuth state, and
+/// resolving it must never invoke the CLI auth endpoints.
+pub fn test_pat_takes_precedence_over_oauth() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let should_not_be_used = signed_in_json("should-not-be-used", 3600);
+    let t = oauth_setup(&[
+        ("CS_ACCESS_TOKEN", "pat-token"),
+        ("FAKE_AUTH_TOKEN_RESPONSE", should_not_be_used.as_str()),
+    ]);
+
+    seed_config(
+        &t.config_dir,
+        json!({
+            "instance_id": "test-instance-id",
+            "oauth_token": "stale-oauth-token",
+            "oauth_expires_at": (now_epoch() + 3600).to_string(),
+        }),
+    );
+
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+
+    let score = call_score(&mut client, &t.repo_dir);
+    assert!(
+        !score.contains("No access token configured"),
+        "Should succeed using the configured PAT, got: {score}"
+    );
+
+    let log = std::fs::read_to_string(&t.call_log_path).unwrap_or_default();
+    assert!(
+        log.is_empty(),
+        "CLI auth endpoints should not be called when PAT is configured, got log: {log}"
+    );
+}


### PR DESCRIPTION
## Summary
- add an OAuth login tool and reuse OAuth tokens across MCP requests
- persist OAuth login state in config-backed environment variables so login and token refresh survive beyond a single call
- tighten CLI/config integration around OAuth client selection and token export handling

## Commit Details
### `860bdd6` Add OAuth login and token reuse
- adds the `login` MCP tool and wires it into tool registration
- introduces OAuth credential handling in `src/auth/mod.rs` and `src/auth/manager.rs`
- updates API client and tracking paths to use resolved OAuth credentials in addition to PATs
- updates docs and e2e coverage for the new login flow and configurable tool enablement

### `110715c` Fix OAuth login token persistence
- persists OAuth access token, expiry, and refresh expiry via the config-backed env lock instead of process-local in-memory cache
- treats login responses without `access-token` as incomplete and immediately fetches `auth token` from the CLI before persisting
- only reuses cached OAuth state when both token and expiry are present and fresh; signed-out state is stored via a sentinel to avoid unnecessary refreshes
- refactors CLI env wiring and config response construction to keep Code Health green

## Verification
- `cargo test login_fetches_token_when_login_response_omits_access_token`
- `cargo test current_token_refreshes_when_expiry_exists_but_token_missing`
- `cargo test login_persists_and_returns_token`
- `CS_ENV=staging cs delta`