### PR TITLE
Add host-only OAuth Authorization Code e2e with mock IdP

### DIFF
--- a/.agents/skills/run-e2e-tests/SKILL.md
+++ b/.agents/skills/run-e2e-tests/SKILL.md
@@ -79,6 +79,8 @@ CS_MCP_EXECUTABLE=target/release/cs-mcp cargo test --test e2e
 | `error_logging` | Error telemetry redaction and file logging |
 | `git_subtree` | Git subtree repository support |
 | `git_worktree` | Git worktree repository support |
+| `oauth_login` | MCP OAuth contract via fake CLI (`CS_CLI_PATH`) |
+| `oauth_login_flow` | Real CLI Authorization Code flow against mock OAuth server (host-only; skips Docker) |
 | `platform_specific` | Path handling (absolute, relative, symlinks, spaces, unicode) |
 | `relative_paths` | Relative path resolution |
 | `require_access_token` | Access token validation |

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1093,6 +1093,17 @@ fn test_pat_takes_precedence_over_oauth() {
     tests::oauth_login::test_pat_takes_precedence_over_oauth();
 }
 
+// --- OAuth Login Flow (real CLI + mock IdP, host-only) ---
+#[test]
+fn test_oauth_authorization_code_flow_persists_token() {
+    tests::oauth_login_flow::test_oauth_authorization_code_flow_persists_token();
+}
+
+#[test]
+fn test_oauth_flow_fails_when_routes_missing() {
+    tests::oauth_login_flow::test_oauth_flow_fails_when_routes_missing();
+}
+
 // --- Stress Test ---
 #[test]
 #[ignore] // Long-running; run with --ignored

--- a/tests/e2e/tests/fake_oauth_server.rs
+++ b/tests/e2e/tests/fake_oauth_server.rs
@@ -1,0 +1,342 @@
+//! Minimal CodeScene-shaped OAuth mock for host-only e2e tests.
+//!
+//! Implements the subset of the on-prem OAuth surface the embedded CLI uses:
+//! - empty `POST /oauth2/token` → OAuth error (route discovery)
+//! - `GET /oauth2/auth` → 302 to the CLI localhost callback with `code` + `state`
+//! - `POST /oauth2/token` with `grant_type=authorization_code` → access/refresh tokens
+//! - `POST /oauth2/token` with `grant_type=refresh_token` → refreshed access token
+//!
+//! Also stubs incidental API paths the CLI may hit after login.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use super::fake_server_bind_host;
+use super::fake_server_url_host;
+
+const ACCESS_TOKEN: &str = "oau_mock_e2e_access";
+const REFRESH_TOKEN: &str = "orr_mock_e2e_refresh";
+const REFRESHED_ACCESS_TOKEN: &str = "oau_mock_e2e_refreshed";
+
+#[derive(Clone, Debug, Default)]
+pub struct OAuthRequestLog {
+    pub discovery_posts: usize,
+    pub authorize_gets: usize,
+    pub auth_code_exchanges: usize,
+    pub refresh_grants: usize,
+}
+
+pub struct FakeOAuthServer {
+    port: u16,
+    log: Arc<Mutex<OAuthRequestLog>>,
+    shutdown: Arc<Mutex<bool>>,
+}
+
+pub struct FakeOAuthServerOptions {
+    /// When false, `/oauth2/*` routes return 404 so discovery fails.
+    pub oauth_enabled: bool,
+}
+
+impl Default for FakeOAuthServerOptions {
+    fn default() -> Self {
+        Self {
+            oauth_enabled: true,
+        }
+    }
+}
+
+struct ServerCtx {
+    log: Arc<Mutex<OAuthRequestLog>>,
+    shutdown: Arc<Mutex<bool>>,
+    base_url: String,
+    oauth_enabled: bool,
+}
+
+impl FakeOAuthServer {
+    pub fn start_with_options(options: FakeOAuthServerOptions) -> Self {
+        let bind_addr = format!("{}:0", fake_server_bind_host());
+        let listener = TcpListener::bind(&bind_addr).expect("bind OAuth mock");
+        let port = listener.local_addr().unwrap().port();
+        listener.set_nonblocking(true).unwrap();
+
+        let log = Arc::new(Mutex::new(OAuthRequestLog::default()));
+        let shutdown = Arc::new(Mutex::new(false));
+        let ctx = ServerCtx {
+            log: Arc::clone(&log),
+            shutdown: Arc::clone(&shutdown),
+            base_url: format!("http://{}:{}", fake_server_url_host(), port),
+            oauth_enabled: options.oauth_enabled,
+        };
+
+        thread::spawn(move || accept_loop(listener, ctx));
+        thread::sleep(Duration::from_millis(50));
+
+        FakeOAuthServer {
+            port,
+            log,
+            shutdown,
+        }
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://{}:{}", fake_server_url_host(), self.port)
+    }
+
+    pub fn access_token(&self) -> &'static str {
+        ACCESS_TOKEN
+    }
+
+    pub fn request_log(&self) -> OAuthRequestLog {
+        self.log.lock().unwrap().clone()
+    }
+
+    pub fn shutdown(&self) {
+        *self.shutdown.lock().unwrap() = true;
+    }
+}
+
+impl Drop for FakeOAuthServer {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+fn accept_loop(listener: TcpListener, ctx: ServerCtx) {
+    while !*ctx.shutdown.lock().unwrap() {
+        match listener.accept() {
+            Ok((mut stream, _)) => serve_connection(&mut stream, &ctx),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+fn serve_connection(stream: &mut TcpStream, ctx: &ServerCtx) {
+    if let Some(req) = read_http_request(stream) {
+        let response = dispatch_request(&req, ctx);
+        let _ = stream.write_all(response.as_bytes());
+        let _ = stream.flush();
+    }
+    let _ = stream.shutdown(std::net::Shutdown::Both);
+}
+
+struct HttpRequest {
+    method: String,
+    path: String,
+    body: String,
+}
+
+fn read_http_request(stream: &mut TcpStream) -> Option<HttpRequest> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .ok()?;
+
+    let buf = read_request_bytes(stream);
+    if buf.is_empty() {
+        return None;
+    }
+    parse_http_request(&buf)
+}
+
+fn read_request_bytes(stream: &mut TcpStream) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 4096];
+    for _ in 0..40 {
+        match stream.read(&mut tmp) {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&tmp[..n]);
+                if request_body_complete(&buf) {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    buf
+}
+
+fn request_body_complete(buf: &[u8]) -> bool {
+    let Ok(text) = std::str::from_utf8(buf) else {
+        return false;
+    };
+    let Some(header_end) = text.find("\r\n\r\n") else {
+        return false;
+    };
+    let content_length = content_length_from_headers(&text[..header_end]);
+    buf.len() >= header_end + 4 + content_length
+}
+
+fn content_length_from_headers(headers: &str) -> usize {
+    headers
+        .lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("content-length:"))
+        .and_then(|l| l.split(':').nth(1))
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+fn parse_http_request(buf: &[u8]) -> Option<HttpRequest> {
+    let text = String::from_utf8_lossy(buf);
+    let mut lines = text.split("\r\n");
+    let request_line = lines.next()?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next()?.to_string();
+    let path = parts.next()?.to_string();
+    let body = text
+        .find("\r\n\r\n")
+        .map(|i| text[i + 4..].to_string())
+        .unwrap_or_default();
+    Some(HttpRequest { method, path, body })
+}
+
+fn dispatch_request(req: &HttpRequest, ctx: &ServerCtx) -> String {
+    let path_only = req.path.split('?').next().unwrap_or(&req.path);
+
+    if let Some(response) = handle_oauth_auth(req, path_only, ctx) {
+        return response;
+    }
+    if let Some(response) = handle_oauth_token(req, path_only, ctx) {
+        return response;
+    }
+    api_stub_response(path_only)
+}
+
+fn handle_oauth_auth(req: &HttpRequest, path_only: &str, ctx: &ServerCtx) -> Option<String> {
+    if path_only != "/oauth2/auth" || req.method != "GET" {
+        return None;
+    }
+    if !ctx.oauth_enabled {
+        return Some(json_response(404, r#"{"error":"not_found"}"#));
+    }
+    ctx.log.lock().unwrap().authorize_gets += 1;
+    Some(authorize_redirect(&req.path))
+}
+
+fn handle_oauth_token(req: &HttpRequest, path_only: &str, ctx: &ServerCtx) -> Option<String> {
+    if path_only != "/oauth2/token" || req.method != "POST" {
+        return None;
+    }
+    if !ctx.oauth_enabled {
+        return Some(json_response(404, r#"{"error":"not_found"}"#));
+    }
+    if req.body.trim().is_empty() {
+        ctx.log.lock().unwrap().discovery_posts += 1;
+        return Some(json_response(
+            400,
+            r#"{"error":"invalid_request","error_description":"missing parameters"}"#,
+        ));
+    }
+    Some(token_grant_response(&req.body, &ctx.log, &ctx.base_url))
+}
+
+fn api_stub_response(path_only: &str) -> String {
+    if path_only.contains("/api/v2/tool-license/cli") {
+        return json_response(200, r#"{"valid":true}"#);
+    }
+    if path_only.contains("/api/v2/projects") {
+        return json_response(200, r#"[{"id":1,"name":"Test Project"}]"#);
+    }
+    json_response(200, "{}")
+}
+
+fn authorize_redirect(full_path: &str) -> String {
+    let query = full_path.split('?').nth(1).unwrap_or("");
+    let mut state = "missing-state".to_string();
+    let mut redirect_uri = "http://127.0.0.1:19876/callback".to_string();
+
+    for pair in query.split('&') {
+        let mut parts = pair.splitn(2, '=');
+        let key = parts.next().unwrap_or("");
+        let value = percent_decode(parts.next().unwrap_or(""));
+        match key {
+            "state" => state = value,
+            "redirect_uri" => redirect_uri = value,
+            _ => {}
+        }
+    }
+
+    let location = format!("{redirect_uri}?code=e2e-auth-code&state={state}");
+    format!(
+        "HTTP/1.1 302 Found\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    )
+}
+
+fn token_grant_response(
+    body: &str,
+    log: &Arc<Mutex<OAuthRequestLog>>,
+    base_url: &str,
+) -> String {
+    let grant = form_value(body, "grant_type").unwrap_or_default();
+    match grant.as_str() {
+        "authorization_code" => {
+            log.lock().unwrap().auth_code_exchanges += 1;
+            json_response(200, &token_payload(ACCESS_TOKEN, base_url))
+        }
+        "refresh_token" => {
+            log.lock().unwrap().refresh_grants += 1;
+            json_response(200, &token_payload(REFRESHED_ACCESS_TOKEN, base_url))
+        }
+        _ => json_response(400, r#"{"error":"unsupported_grant_type"}"#),
+    }
+}
+
+fn token_payload(access_token: &str, base_url: &str) -> String {
+    format!(
+        r#"{{"access_token":"{access_token}","refresh_token":"{REFRESH_TOKEN}","token_type":"Bearer","expires_in":3600,"scope":"cli.access mcpapi.read mcpapi.write mcp.event-tracking","api_url":"{base_url}/api"}}"#
+    )
+}
+
+fn json_response(status: u16, body: &str) -> String {
+    let reason = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        _ => "OK",
+    };
+    format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+fn form_value(body: &str, key: &str) -> Option<String> {
+    for pair in body.split('&') {
+        let mut parts = pair.splitn(2, '=');
+        let k = parts.next()?;
+        if k == key {
+            return Some(percent_decode(parts.next().unwrap_or("")));
+        }
+    }
+    None
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if let Some(decoded) = decode_percent_at(bytes, i) {
+            out.push(decoded.0);
+            i = decoded.1;
+            continue;
+        }
+        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn decode_percent_at(bytes: &[u8], i: usize) -> Option<(u8, usize)> {
+    if bytes[i] != b'%' || i + 2 >= bytes.len() {
+        return None;
+    }
+    let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).ok()?;
+    let byte = u8::from_str_radix(hex, 16).ok()?;
+    Some((byte, i + 3))
+}

--- a/tests/e2e/tests/mod.rs
+++ b/tests/e2e/tests/mod.rs
@@ -30,6 +30,7 @@ pub fn use_isolated_config_dir(
 #[allow(dead_code)]
 pub mod fake_http_server;
 pub mod fake_https_server;
+pub mod fake_oauth_server;
 
 pub mod analytics_environment_override;
 pub mod analytics_tracking;
@@ -44,6 +45,7 @@ pub mod error_logging;
 pub mod git_subtree;
 pub mod git_worktree;
 pub mod oauth_login;
+pub mod oauth_login_flow;
 pub mod platform_specific;
 pub mod relative_paths;
 pub mod require_access_token;

--- a/tests/e2e/tests/oauth_login_flow.rs
+++ b/tests/e2e/tests/oauth_login_flow.rs
@@ -1,0 +1,312 @@
+//! Host-only OAuth Authorization Code e2e against a mock CodeScene OAuth server.
+//!
+//! Unlike `oauth_login.rs` (which fakes the CLI JSON contract via `CS_CLI_PATH`),
+//! these tests drive the **real embedded CLI**:
+//!
+//! 1. MCP `login` → `cs auth login --client mcp`
+//! 2. CLI discovers OAuth via empty `POST /oauth2/token` on `CS_ONPREM_URL`
+//! 3. CLI opens a browser (our helper via `BROWSER`) to `/oauth2/auth`
+//! 4. Mock redirects to `http://127.0.0.1:19876/callback` with `code` + `state`
+//! 5. CLI exchanges the code (PKCE) and returns signed-in JSON
+//! 6. MCP persists `CS_OAUTH_*` into an isolated `CS_CONFIG_DIR`
+//!
+//! Docker is skipped: OAuth localhost callback is unsupported in containers.
+//! Keep `oauth_login.rs` for fast MCP-contract coverage with a fake CLI.
+
+use super::fake_oauth_server::{FakeOAuthServer, FakeOAuthServerOptions};
+use super::*;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const LOGIN_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Tiny HTTP client used as `BROWSER` so the CLI's authorize URL is fetched
+/// headlessly. Follows a single 302 to the localhost callback.
+const BROWSER_HELPER_RS: &str = r##"use std::env;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+fn main() {
+    let url = env::args().nth(1).expect("url argument required");
+    let url = url.trim().trim_matches(|c| c == '\'' || c == '"');
+    eprintln!("oauth-browser-helper opening {url}");
+    match fetch(url) {
+        Ok(resp) => {
+            eprintln!("oauth-browser-helper status {}", resp.lines().next().unwrap_or(""));
+            if let Some(loc) = resp.lines().find(|l| l.to_ascii_lowercase().starts_with("location:")) {
+                let loc = loc.splitn(2, ':').nth(1).unwrap_or("").trim();
+                if !loc.is_empty() {
+                    eprintln!("oauth-browser-helper follow {loc}");
+                    let _ = fetch(loc);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("oauth-browser-helper error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn fetch(url: &str) -> Result<String, String> {
+    let without = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .ok_or_else(|| format!("unsupported url: {url}"))?;
+    let (hostport, path) = match without.split_once('/') {
+        Some((h, p)) => (h, format!("/{p}")),
+        None => (without, "/".to_string()),
+    };
+    let (host, port) = match hostport.split_once(':') {
+        Some((h, p)) => (h, p.parse::<u16>().map_err(|e| e.to_string())?),
+        None => (hostport, 80u16),
+    };
+    let mut stream =
+        TcpStream::connect((host, port)).map_err(|e| format!("connect {hostport}: {e}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .ok();
+    stream
+        .set_write_timeout(Some(Duration::from_secs(10)))
+        .ok();
+    let req = format!("GET {path} HTTP/1.1\r\nHost: {hostport}\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(req.as_bytes())
+        .map_err(|e| format!("write: {e}"))?;
+    let mut buf = String::new();
+    stream
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("read: {e}"))?;
+    Ok(buf)
+}
+"##;
+
+struct OAuthFlowEnv {
+    command: Vec<String>,
+    env: Vec<(String, String)>,
+    repo_dir: PathBuf,
+    config_dir: PathBuf,
+    server: FakeOAuthServer,
+    _tmp: tempfile::TempDir,
+    _cli_home: tempfile::TempDir,
+}
+
+fn compile_browser_helper(dir: &Path) -> PathBuf {
+    let source = dir.join("oauth_browser_helper.rs");
+    std::fs::write(&source, BROWSER_HELPER_RS).expect("write browser helper source");
+
+    let binary_name = if cfg!(windows) {
+        "oauth_browser_helper.exe"
+    } else {
+        "oauth_browser_helper"
+    };
+    let output_path = dir.join(binary_name);
+
+    let result = Command::new("rustc")
+        .args([
+            source.to_str().expect("source path"),
+            "-O",
+            "-o",
+            output_path.to_str().expect("output path"),
+        ])
+        .output()
+        .expect("rustc should execute");
+
+    assert!(
+        result.status.success(),
+        "Failed to compile browser helper: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    #[cfg(windows)]
+    {
+        // The CLI launches BROWSER via the Windows shell; a .cmd wrapper is
+        // more reliable than pointing BROWSER at a raw .exe path with spaces.
+        let cmd_path = dir.join("oauth_browser_helper.cmd");
+        let script = format!("@echo off\r\n\"{}\" %*\r\n", output_path.display());
+        std::fs::write(&cmd_path, script).expect("write browser helper cmd");
+        return cmd_path;
+    }
+
+    #[cfg(not(windows))]
+    {
+        output_path
+    }
+}
+
+fn oauth_flow_setup(oauth_enabled: bool) -> OAuthFlowEnv {
+    let executable = find_or_build_executable();
+    let backend = create_backend(executable);
+
+    let temp_dir = create_temp_dir("cs_mcp_oauth_flow_").expect("create temp dir");
+    let sample_files = get_sample_files();
+    let repo_dir = create_git_repo(temp_dir.path(), &sample_files).expect("create git repo");
+
+    let config_dir = temp_dir.path().join(".cs_config_oauth_flow");
+    std::fs::create_dir_all(&config_dir).expect("create config dir");
+
+    let cli_home = tempfile::Builder::new()
+        .prefix("cs_mcp_oauth_cli_home_")
+        .tempdir()
+        .expect("create isolated CLI home");
+    // Windows CLI stores OAuth creds under %APPDATA%\Codescene\credentials.
+    // Unix CLI uses $HOME/.codescene (or similar under the user home).
+    let app_data = cli_home.path().join("AppData").join("Roaming");
+    std::fs::create_dir_all(&app_data).expect("create isolated APPDATA");
+    std::fs::create_dir_all(cli_home.path().join(".codescene")).expect("create .codescene");
+
+    let browser = compile_browser_helper(temp_dir.path());
+    let server = FakeOAuthServer::start_with_options(FakeOAuthServerOptions { oauth_enabled });
+
+    let base = base_env();
+    let env_map = backend.get_env(&base, &repo_dir);
+    let env: Vec<(String, String)> = env_map
+        .into_iter()
+        .filter(|(k, _)| {
+            k != "CS_ACCESS_TOKEN"
+                && k != "CS_CLI_PATH"
+                && k != "CS_CONFIG_DIR"
+                && k != "CS_ONPREM_URL"
+                && k != "BROWSER"
+                && k != "HOME"
+                && k != "APPDATA"
+        })
+        .chain(
+            [
+                (
+                    "CS_CONFIG_DIR",
+                    config_dir.to_string_lossy().into_owned(),
+                ),
+                ("CS_ONPREM_URL", server.url()),
+                ("CS_DISABLE_VERSION_CHECK", "1".to_string()),
+                ("CS_DISABLE_TRACKING", "1".to_string()),
+                ("BROWSER", browser.to_string_lossy().into_owned()),
+                ("HOME", cli_home.path().to_string_lossy().into_owned()),
+                ("APPDATA", app_data.to_string_lossy().into_owned()),
+            ]
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v)),
+        )
+        .collect();
+
+    let command = backend.get_command(&repo_dir);
+    OAuthFlowEnv {
+        command,
+        env,
+        repo_dir,
+        config_dir,
+        server,
+        _tmp: temp_dir,
+        _cli_home: cli_home,
+    }
+}
+
+fn start_client(t: &OAuthFlowEnv) -> MCPClient {
+    let mut client = make_client(&t.command, &t.env, &t.repo_dir);
+    assert!(client.start(), "Server should start");
+    client.initialize().expect("Initialize should succeed");
+    client
+}
+
+fn call_login(client: &mut MCPClient) -> String {
+    let response = client
+        .call_tool("login", json!({}), LOGIN_TIMEOUT)
+        .expect("login call should succeed");
+    extract_result_text(&response)
+}
+
+fn read_config(config_dir: &Path) -> serde_json::Value {
+    let path = config_dir.join("config.json");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    serde_json::from_str(&content).expect("parse config.json")
+}
+
+/// Real CLI + mock IdP happy path: authorize → callback → token → MCP persist.
+pub fn test_oauth_authorization_code_flow_persists_token() {
+    if is_docker() {
+        return skip_if_docker("OAuth localhost callback unsupported in Docker");
+    }
+
+    let t = oauth_flow_setup(true);
+    let mut client = start_client(&t);
+
+    let result = call_login(&mut client);
+    assert!(
+        result.contains("Successfully signed in"),
+        "expected successful OAuth login, got: {result}"
+    );
+
+    let config = read_config(&t.config_dir);
+    assert_eq!(
+        config["oauth_token"].as_str(),
+        Some(t.server.access_token()),
+        "MCP should persist the OAuth access token, got: {config}"
+    );
+    assert!(
+        config.get("oauth_expires_at").is_some(),
+        "expected oauth_expires_at in config, got: {config}"
+    );
+
+    let log = t.server.request_log();
+    assert!(
+        log.discovery_posts >= 1,
+        "CLI should probe /oauth2/token for discovery, log={log:?}"
+    );
+    assert_eq!(
+        log.authorize_gets, 1,
+        "expected one authorize redirect, log={log:?}"
+    );
+    assert_eq!(
+        log.auth_code_exchanges, 1,
+        "expected one authorization_code exchange, log={log:?}"
+    );
+
+    // Second login should reuse the CLI/MCP session without another authorize hit.
+    let result2 = call_login(&mut client);
+    assert!(
+        result2.contains("Already signed in"),
+        "expected session reuse, got: {result2}"
+    );
+    let log2 = t.server.request_log();
+    assert_eq!(
+        log2.authorize_gets, 1,
+        "reuse must not hit /oauth2/auth again, log={log2:?}"
+    );
+}
+
+/// When OAuth routes are missing, login must fail and not leave a usable token.
+pub fn test_oauth_flow_fails_when_routes_missing() {
+    if is_docker() {
+        return skip_if_docker("OAuth localhost callback unsupported in Docker");
+    }
+
+    let t = oauth_flow_setup(false);
+    let mut client = start_client(&t);
+
+    let result = call_login(&mut client);
+    assert!(
+        result.contains("Login failed") || result.contains("did not complete"),
+        "expected login failure when OAuth routes are missing, got: {result}"
+    );
+
+    if t.config_dir.join("config.json").is_file() {
+        let config = read_config(&t.config_dir);
+        let token = config.get("oauth_token").and_then(|v| v.as_str());
+        assert!(
+            token.is_none() || token == Some(""),
+            "failed login must not persist a usable oauth_token, got: {config}"
+        );
+    }
+
+    let log = t.server.request_log();
+    assert_eq!(
+        log.authorize_gets, 0,
+        "authorize must not run when discovery fails, log={log:?}"
+    );
+    assert_eq!(
+        log.auth_code_exchanges, 0,
+        "token exchange must not run when discovery fails, log={log:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add host-only e2e coverage for the real embedded CLI OAuth Authorization Code flow against a local mock CodeScene OAuth server (CS_ONPREM_URL + headless BROWSER helper).
- Assert MCP persists CS_OAUTH_* on success and fails cleanly when OAuth routes are missing; keep the existing fake-CLI oauth_login suite for MCP contract tests.
- Skip Docker for this suite (localhost callback unsupported); document the modules in the run-e2e-tests skill.

## Test plan
- [x] CS_MCP_BACKEND=static cargo test --test e2e test_oauth_authorization_code_flow
- [x] CS_MCP_BACKEND=static cargo test --test e2e test_oauth_flow_fails
- [x] Existing fake-CLI 	est_login_* oauth contract tests still pass
- [x] CodeScene pre-commit / change-set quality gates passed
- [ ] Confirm CI static e2e runs the new tests; Docker backend skips them