### PR TITLE
Hide OAuth login tool and prompt in Docker

### DIFF
--- a/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user wants to view, set, or troubleshoot CodeScene MCP
 
 ## Overview
 
-Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `login`, `get_config`, and `set_config` tools that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose a `login` prompt (slash command) that instructs the assistant to call the `login` tool.
+Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `get_config` and `set_config` tools (and, outside Docker, `login`) that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose a `login` prompt (slash command) that instructs the assistant to call the `login` tool — except in Docker, where OAuth login is unavailable and a Personal Access Token (`CS_ACCESS_TOKEN`) is required.
 
 ## When to Use
 
@@ -25,7 +25,7 @@ Do not use this skill for installing or registering the MCP server in an AI assi
 
 ## Quick Reference
 
-- `login`: Sign in with OAuth (opens browser). Preferred for interactive desktop use. Also available as the `login` MCP prompt (slash command).
+- `login`: Sign in with OAuth (opens browser). Preferred for interactive desktop use. Also available as the `login` MCP prompt (slash command). Not available in Docker — use a PAT instead.
 - `get_config`: List all configuration options and their current values (sensitive values are masked).
 - `get_config` with a key: Read a single option by name.
 - `set_config`: Set a configuration value persistently.
@@ -82,4 +82,4 @@ For individual, interactive use, prefer `login` for auth and `set_config` for ot
 - Providing a CA bundle path that is not accessible to the MCP server process or Docker container.
 - Setting `enabled_tools` with misspelled tool names. The server warns about unknown names, but the misspelled tools are silently ignored. Use `get_config` with key `enabled_tools` to see the list of available tool names.
 - Forgetting that `enabled_tools` changes require a server restart. The tool list is built once at startup.
-- Trying to disable `get_config`, `set_config`, or `login` via `enabled_tools`. These tools are always enabled to prevent configuration lockout.
+- Trying to disable `get_config`, `set_config`, or `login` via `enabled_tools`. Outside Docker these tools are always enabled to prevent configuration lockout. In Docker, `login` is not registered at all (use PAT / `CS_ACCESS_TOKEN`).

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -352,7 +352,7 @@ Controls which MCP tools the server exposes to the AI assistant. When set, only 
 
 This is useful for reducing token usage by limiting the number of tool descriptions sent to the AI model. Each exposed tool adds to the prompt context, so disabling tools you don't need can lower costs and improve response times.
 
-The `get_config` and `set_config` tools are always enabled and cannot be disabled. This prevents accidental lockout from the configuration system.
+The `get_config` and `set_config` tools are always enabled and cannot be disabled. This prevents accidental lockout from the configuration system. Outside Docker, the `login` tool is also always enabled. In Docker, OAuth is unsupported, so the `login` tool and `login` prompt are not registered — use `CS_ACCESS_TOKEN` or `set_config` with `access_token` instead.
 
 Changes to this setting require a server restart to take effect.
 

--- a/skills/configuring-codescene-mcp/SKILL.md
+++ b/skills/configuring-codescene-mcp/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user wants to view, set, or troubleshoot CodeScene MCP
 
 ## Overview
 
-Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `login`, `get_config`, and `set_config` tools that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose a `login` prompt (slash command) that instructs the assistant to call the `login` tool.
+Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `get_config` and `set_config` tools (and, outside Docker, `login`) that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose a `login` prompt (slash command) that instructs the assistant to call the `login` tool — except in Docker, where OAuth login is unavailable and a Personal Access Token (`CS_ACCESS_TOKEN`) is required.
 
 ## When to Use
 
@@ -25,7 +25,7 @@ Do not use this skill for installing or registering the MCP server in an AI assi
 
 ## Quick Reference
 
-- `login`: Sign in with OAuth (opens browser). Preferred for interactive desktop use. Also available as the `login` MCP prompt (slash command).
+- `login`: Sign in with OAuth (opens browser). Preferred for interactive desktop use. Also available as the `login` MCP prompt (slash command). Not available in Docker — use a PAT instead.
 - `get_config`: List all configuration options and their current values (sensitive values are masked).
 - `get_config` with a key: Read a single option by name.
 - `set_config`: Set a configuration value persistently.
@@ -82,4 +82,4 @@ For individual, interactive use, prefer `login` for auth and `set_config` for ot
 - Providing a CA bundle path that is not accessible to the MCP server process or Docker container.
 - Setting `enabled_tools` with misspelled tool names. The server warns about unknown names, but the misspelled tools are silently ignored. Use `get_config` with key `enabled_tools` to see the list of available tool names.
 - Forgetting that `enabled_tools` changes require a server restart. The tool list is built once at startup.
-- Trying to disable `get_config`, `set_config`, or `login` via `enabled_tools`. These tools are always enabled to prevent configuration lockout.
+- Trying to disable `get_config`, `set_config`, or `login` via `enabled_tools`. Outside Docker these tools are always enabled to prevent configuration lockout. In Docker, `login` is not registered at all (use PAT / `CS_ACCESS_TOKEN`).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -829,6 +829,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn is_owned_by_current_user_rejects_world_writable_file() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();
@@ -852,6 +853,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn create_or_get_truststore_rejects_world_writable_existing_file() {
         use std::os::unix::fs::PermissionsExt;
         let _lock = TRUSTSTORE_TEST_MUTEX.lock().unwrap();
@@ -895,6 +897,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn atomic_write_sets_restricted_permissions() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -13,8 +13,42 @@ pub fn detect() -> &'static str {
 }
 
 pub fn is_docker() -> bool {
+    #[cfg(test)]
+    if let Some(forced) = test_override::docker_override() {
+        return forced;
+    }
     detect() == "docker"
 }
+
+#[cfg(test)]
+mod test_override {
+    use std::cell::Cell;
+
+    thread_local! {
+        static DOCKER_OVERRIDE: Cell<Option<bool>> = const { Cell::new(None) };
+    }
+
+    pub(super) fn docker_override() -> Option<bool> {
+        DOCKER_OVERRIDE.with(|c| c.get())
+    }
+
+    /// Force [`super::is_docker`] for the duration of the returned guard.
+    pub struct DockerOverrideGuard;
+
+    impl Drop for DockerOverrideGuard {
+        fn drop(&mut self) {
+            DOCKER_OVERRIDE.with(|c| c.set(None));
+        }
+    }
+
+    pub fn force_docker(is_docker: bool) -> DockerOverrideGuard {
+        DOCKER_OVERRIDE.with(|c| c.set(Some(is_docker)));
+        DockerOverrideGuard
+    }
+}
+
+#[cfg(test)]
+pub use test_override::force_docker;
 
 #[cfg(test)]
 mod tests {
@@ -37,5 +71,17 @@ mod tests {
         let first = detect();
         let second = detect();
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn force_docker_overrides_detect() {
+        let _guard = force_docker(true);
+        assert!(is_docker());
+    }
+
+    #[test]
+    fn force_docker_false_overrides_detect() {
+        let _guard = force_docker(false);
+        assert!(!is_docker());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,22 @@ If a token must be configured manually:\n\
 To get a Personal Access Token, see:\n\
 https://github.com/codescene-oss/codescene-mcp-server/blob/main/docs/authentication.md";
 
+const TOKEN_MISSING_MSG_DOCKER: &str = "\
+No access token configured.\n\n\
+OAuth login is not available in Docker. Configure a Personal Access Token:\n\
+1. Set the CS_ACCESS_TOKEN environment variable in your MCP client / Docker configuration\n\
+2. Or use the `set_config` tool: set_config(key=\"access_token\", value=\"your-token\")\n\n\
+To get a Personal Access Token, see:\n\
+https://github.com/codescene-oss/codescene-mcp-server/blob/main/docs/authentication.md";
+
+fn token_missing_msg() -> &'static str {
+    if environment::is_docker() {
+        TOKEN_MISSING_MSG_DOCKER
+    } else {
+        TOKEN_MISSING_MSG
+    }
+}
+
 const _VERSION_NOTICE_SUFFIX: &str = "\n\
 Note: If the result contains version update information (indicated by\n\
 \"VERSION UPDATE AVAILABLE\"), please inform the user about this update\n\
@@ -221,13 +237,13 @@ impl CodeSceneServer {
             Ok(None) => {
                 self.log_no_credential("token requirement failed: no usable credential resolved");
                 Some(CallToolResult::success(vec![Content::text(
-                    TOKEN_MISSING_MSG,
+                    token_missing_msg(),
                 )]))
             }
             Err(e) => {
                 tracing::warn!(error = %e, "auth token check failed");
                 Some(CallToolResult::success(vec![Content::text(
-                    TOKEN_MISSING_MSG,
+                    token_missing_msg(),
                 )]))
             }
         }
@@ -246,13 +262,13 @@ impl CodeSceneServer {
             Ok(None) => {
                 self.log_no_credential("failed to resolve auth credential for API tool");
                 Err(CallToolResult::success(vec![Content::text(
-                    TOKEN_MISSING_MSG,
+                    token_missing_msg(),
                 )]))
             }
             Err(e) => {
                 tracing::warn!(error = %e, "auth token check failed");
                 Err(CallToolResult::success(vec![Content::text(
-                    TOKEN_MISSING_MSG,
+                    token_missing_msg(),
                 )]))
             }
         }
@@ -358,6 +374,11 @@ fn remove_standalone_tools(router: &mut ToolRouter<CodeSceneServer>) {
     }
 }
 
+/// Tools that cannot work in Docker (OAuth browser callback is unsupported).
+fn remove_docker_unsupported_tools(router: &mut ToolRouter<CodeSceneServer>) {
+    router.remove_route("login");
+}
+
 fn apply_enabled_tools_filter(router: &mut ToolRouter<CodeSceneServer>, config_data: &ConfigData) {
     let enabled = match config::enabled_tools(config_data) {
         Some(set) => set,
@@ -381,6 +402,9 @@ impl CodeSceneServer {
         let mut router = Self::tool_router();
         if deps.is_standalone {
             remove_standalone_tools(&mut router);
+        }
+        if environment::is_docker() {
+            remove_docker_unsupported_tools(&mut router);
         }
         apply_enabled_tools_filter(&mut router, &deps.config_data);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ OAuth login is not available in Docker. Configure a Personal Access Token:\n\
 To get a Personal Access Token, see:\n\
 https://github.com/codescene-oss/codescene-mcp-server/blob/main/docs/authentication.md";
 
-fn token_missing_msg() -> &'static str {
+pub(crate) fn token_missing_msg() -> &'static str {
     if environment::is_docker() {
         TOKEN_MISSING_MSG_DOCKER
     } else {
@@ -375,7 +375,7 @@ fn remove_standalone_tools(router: &mut ToolRouter<CodeSceneServer>) {
 }
 
 /// Tools that cannot work in Docker (OAuth browser callback is unsupported).
-fn remove_docker_unsupported_tools(router: &mut ToolRouter<CodeSceneServer>) {
+pub(crate) fn remove_docker_unsupported_tools(router: &mut ToolRouter<CodeSceneServer>) {
     router.remove_route("login");
 }
 

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -8,7 +8,7 @@ use rmcp::model::{
 use rmcp::service::RequestContext;
 use rmcp::{tool_handler, ErrorData, RoleServer, ServerHandler};
 
-use crate::{config, prompts, skills, CodeSceneServer};
+use crate::{config, environment, prompts, skills, CodeSceneServer};
 
 #[tool_handler(router = "self.tool_router")]
 impl ServerHandler for CodeSceneServer {
@@ -28,6 +28,7 @@ impl ServerHandler for CodeSceneServer {
         .with_instructions(build_instructions(
             self.is_standalone,
             config::enabled_tools(&self.config_data).is_some(),
+            environment::is_docker(),
         ))
     }
 
@@ -36,7 +37,7 @@ impl ServerHandler for CodeSceneServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListPromptsResult, ErrorData> {
-        Ok(build_prompts_list())
+        Ok(build_prompts_list(environment::is_docker()))
     }
 
     async fn get_prompt(
@@ -44,7 +45,7 @@ impl ServerHandler for CodeSceneServer {
         request: GetPromptRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<GetPromptResult, ErrorData> {
-        resolve_prompt(&request.name)
+        resolve_prompt(&request.name, environment::is_docker())
     }
 
     async fn list_resources(
@@ -76,9 +77,10 @@ fn protocol_version_2025_11_25() -> rmcp::model::ProtocolVersion {
     serde_json::from_str("\"2025-11-25\"").expect("valid MCP protocol version literal")
 }
 
-fn build_prompts_list() -> ListPromptsResult {
-    let prompts_list = vec![
-        Prompt::new(
+fn build_prompts_list(is_docker: bool) -> ListPromptsResult {
+    let mut prompts_list = Vec::new();
+    if !is_docker {
+        prompts_list.push(Prompt::new(
             "login",
             Some(
                 "Sign in to CodeScene with OAuth. Invokes the login tool to open a browser and complete authentication.",
@@ -86,28 +88,35 @@ fn build_prompts_list() -> ListPromptsResult {
             Some(vec![PromptArgument::new("context")
                 .with_description("Optional context string.")
                 .with_required(false)]),
+        ));
+    }
+    prompts_list.push(Prompt::new(
+        "review_code_health",
+        Some(
+            "Review Code Health and assess code quality for the current open file. The file path needs to be sent to the code_health_review MCP tool when using this prompt.",
         ),
-        Prompt::new(
-            "review_code_health",
-            Some(
-                "Review Code Health and assess code quality for the current open file. The file path needs to be sent to the code_health_review MCP tool when using this prompt.",
-            ),
-            Some(vec![PromptArgument::new("context")
-                .with_description("Optional context string.")
-                .with_required(false)]),
-        ),
-        Prompt::new(
-            "plan_code_health_refactoring",
-            Some("Plan a prioritized, low-risk refactoring to remediate detected Code Health issues."),
-            Some(vec![PromptArgument::new("context")
-                .with_description("Optional context string.")
-                .with_required(false)]),
-        ),
-    ];
+        Some(vec![PromptArgument::new("context")
+            .with_description("Optional context string.")
+            .with_required(false)]),
+    ));
+    prompts_list.push(Prompt::new(
+        "plan_code_health_refactoring",
+        Some("Plan a prioritized, low-risk refactoring to remediate detected Code Health issues."),
+        Some(vec![PromptArgument::new("context")
+            .with_description("Optional context string.")
+            .with_required(false)]),
+    ));
     ListPromptsResult::with_all_items(prompts_list)
 }
 
-fn resolve_prompt(name: &str) -> Result<GetPromptResult, ErrorData> {
+fn resolve_prompt(name: &str, is_docker: bool) -> Result<GetPromptResult, ErrorData> {
+    if is_docker && name == "login" {
+        return Err(ErrorData::new(
+            rmcp::model::ErrorCode::INVALID_REQUEST,
+            format!("Unknown prompt: {name}"),
+            None,
+        ));
+    }
     let text = prompts::resolve_prompt_text(name).ok_or_else(|| {
         ErrorData::new(
             rmcp::model::ErrorCode::INVALID_REQUEST,
@@ -196,11 +205,67 @@ fn build_resource_templates() -> ListResourceTemplatesResult {
     }
 }
 
-pub(crate) fn build_instructions(is_standalone: bool, tools_filtered: bool) -> String {
-    let mut text = String::from(
+fn login_tool_instruction_line(is_docker: bool) -> &'static str {
+    if is_docker {
+        ""
+    } else {
+        "- login: Sign in to CodeScene with OAuth. When authentication is missing, call this tool first.\n\
+         "
+    }
+}
+
+fn login_prompt_instruction_line(is_docker: bool) -> &'static str {
+    if is_docker {
+        ""
+    } else {
+        "- login: Sign in to CodeScene with OAuth (calls the login tool).\n\
+         "
+    }
+}
+
+fn append_docker_auth_note(text: &mut String, is_docker: bool) {
+    if is_docker {
+        text.push_str(
+            "\nNote: OAuth login is not available in Docker. Authenticate with a Personal Access Token \
+             via CS_ACCESS_TOKEN or set_config(key=\"access_token\", value=\"...\").\n",
+        );
+    }
+}
+
+fn append_api_tools_section(text: &mut String, is_standalone: bool) {
+    if !is_standalone {
+        text.push_str(
+            "\nTOOLS (API-connected):\n\
+             - select_project: Choose a CodeScene project.\n\
+             - list_technical_debt_goals_for_project: View debt goals.\n\
+             - list_technical_debt_goals_for_project_file: File-level goals.\n\
+             - list_technical_debt_hotspots_for_project: View hotspots.\n\
+             - list_technical_debt_hotspots_for_project_file: File-level hotspots.\n\
+             - code_ownership_for_path: Find code owners.\n",
+        );
+    }
+}
+
+fn append_tools_filtered_note(text: &mut String, tools_filtered: bool) {
+    if tools_filtered {
+        text.push_str(
+            "\nNote: Tool availability is restricted by the 'enabled_tools' configuration. \
+             Use get_config with key 'enabled_tools' to see the current setting.\n",
+        );
+    }
+}
+
+pub(crate) fn build_instructions(
+    is_standalone: bool,
+    tools_filtered: bool,
+    is_docker: bool,
+) -> String {
+    let login_tool_line = login_tool_instruction_line(is_docker);
+    let login_prompt_line = login_prompt_instruction_line(is_docker);
+    let mut text = format!(
         "CodeScene MCP Server - Code Health analysis tools for AI-assisted development.\n\n\
          TOOLS (always available):\n\
-         - login: Sign in to CodeScene with OAuth. When authentication is missing, call this tool first.\n\
+         {login_tool_line}\
          - explain_code_health: Learn about the Code Health metric.\n\
          - explain_code_health_productivity: Business case for Code Health.\n\
          - code_health_review: Detailed review of a single file.\n\
@@ -215,34 +280,19 @@ pub(crate) fn build_instructions(is_standalone: bool, tools_filtered: bool) -> S
          - get_config / set_config: Manage server configuration.\n\
          \n\
          PROMPTS:\n\
-         - login: Sign in to CodeScene with OAuth (calls the login tool).\n\
+         {login_prompt_line}\
          - review_code_health: Review Code Health for the current file.\n\
          - plan_code_health_refactoring: Plan a low-risk Code Health refactoring.\n\
          \n\
          RESOURCES:\n\
          - skill://<name>/SKILL.md: Agent skill instructions for Code Health workflows.\n\
          - skill://<name>/_manifest: File listing for a skill.\n\
-         Use resources/list to discover available skills.\n",
+         Use resources/list to discover available skills.\n"
     );
 
-    if !is_standalone {
-        text.push_str(
-            "\nTOOLS (API-connected):\n\
-             - select_project: Choose a CodeScene project.\n\
-             - list_technical_debt_goals_for_project: View debt goals.\n\
-             - list_technical_debt_goals_for_project_file: File-level goals.\n\
-             - list_technical_debt_hotspots_for_project: View hotspots.\n\
-             - list_technical_debt_hotspots_for_project_file: File-level hotspots.\n\
-             - code_ownership_for_path: Find code owners.\n",
-        );
-    }
-
-    if tools_filtered {
-        text.push_str(
-            "\nNote: Tool availability is restricted by the 'enabled_tools' configuration. \
-             Use get_config with key 'enabled_tools' to see the current setting.\n",
-        );
-    }
+    append_docker_auth_note(&mut text, is_docker);
+    append_api_tools_section(&mut text, is_standalone);
+    append_tools_filtered_note(&mut text, tools_filtered);
 
     text
 }
@@ -258,7 +308,7 @@ mod tests {
 
     #[test]
     fn prompts_list_contains_expected_prompts() {
-        let result = build_prompts_list();
+        let result = build_prompts_list(false);
         assert_eq!(result.prompts.len(), 3);
         let names: Vec<&str> = result.prompts.iter().map(|p| p.name.as_str()).collect();
         assert!(names.contains(&"login"));
@@ -267,8 +317,18 @@ mod tests {
     }
 
     #[test]
+    fn prompts_list_omits_login_in_docker() {
+        let result = build_prompts_list(true);
+        assert_eq!(result.prompts.len(), 2);
+        let names: Vec<&str> = result.prompts.iter().map(|p| p.name.as_str()).collect();
+        assert!(!names.contains(&"login"));
+        assert!(names.contains(&"review_code_health"));
+        assert!(names.contains(&"plan_code_health_refactoring"));
+    }
+
+    #[test]
     fn resolve_known_prompt_succeeds() {
-        let result = resolve_prompt("review_code_health");
+        let result = resolve_prompt("review_code_health", false);
         assert!(result.is_ok());
         let prompt = result.unwrap();
         assert!(!prompt.messages.is_empty());
@@ -276,7 +336,7 @@ mod tests {
 
     #[test]
     fn resolve_login_prompt_succeeds() {
-        let result = resolve_prompt("login");
+        let result = resolve_prompt("login", false);
         assert!(result.is_ok());
         let prompt = result.unwrap();
         let text = match &prompt.messages[0].content {
@@ -287,11 +347,34 @@ mod tests {
     }
 
     #[test]
-    fn resolve_unknown_prompt_returns_error() {
-        let result = resolve_prompt("nonexistent_prompt");
+    fn resolve_login_prompt_fails_in_docker() {
+        let result = resolve_prompt("login", true);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.message.contains("Unknown prompt"));
+    }
+
+    #[test]
+    fn resolve_unknown_prompt_returns_error() {
+        let result = resolve_prompt("nonexistent_prompt", false);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unknown prompt"));
+    }
+
+    #[test]
+    fn build_instructions_omits_login_in_docker() {
+        let text = build_instructions(false, false, true);
+        assert!(!text.contains("- login:"));
+        assert!(text.contains("OAuth login is not available in Docker"));
+        assert!(text.contains("CS_ACCESS_TOKEN"));
+    }
+
+    #[test]
+    fn build_instructions_includes_login_outside_docker() {
+        let text = build_instructions(false, false, false);
+        assert!(text.contains("- login: Sign in to CodeScene with OAuth"));
+        assert!(!text.contains("OAuth login is not available in Docker"));
     }
 
     #[test]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -282,10 +282,12 @@ mod tests {
 
     use super::*;
     use crate::config::{self, ConfigData};
+    use crate::environment;
     use crate::server_handler::build_instructions;
     use crate::version_checker::VersionChecker;
     use crate::{
-        display_version, fetch_cli_version, help_text, parse_cli_args, CliAction, API_ONLY_TOOLS,
+        display_version, fetch_cli_version, help_text, parse_cli_args, remove_docker_unsupported_tools,
+        token_missing_msg, CliAction, API_ONLY_TOOLS,
     };
 
     #[derive(Clone)]
@@ -904,5 +906,115 @@ mod tests {
 
         let close_result = service.close().await;
         assert!(close_result.is_ok());
+    }
+
+    #[test]
+    fn token_missing_msg_uses_docker_copy_when_forced() {
+        let _docker = environment::force_docker(true);
+        let msg = token_missing_msg();
+        assert!(msg.contains("not available in Docker"));
+        assert!(msg.contains("CS_ACCESS_TOKEN"));
+        assert!(!msg.contains("Call the `login` tool"));
+    }
+
+    #[test]
+    fn token_missing_msg_uses_oauth_copy_outside_docker() {
+        let _docker = environment::force_docker(false);
+        let msg = token_missing_msg();
+        assert!(msg.contains("Call the `login` tool"));
+    }
+
+    #[test]
+    fn remove_docker_unsupported_tools_drops_login_route() {
+        let mut router = CodeSceneServer::tool_router();
+        assert!(
+            router.list_all().iter().any(|t| t.name == "login"),
+            "login should be present before removal"
+        );
+        remove_docker_unsupported_tools(&mut router);
+        assert!(
+            !router.list_all().iter().any(|t| t.name == "login"),
+            "login should be removed for Docker"
+        );
+    }
+
+    #[test]
+    fn docker_mode_removes_login_tool_at_construction() {
+        let _lock = config::lock_test_env();
+        let _docker = environment::force_docker(true);
+        let server = make_server(false);
+        let names = tool_names(&server);
+        assert!(
+            !names.contains(&"login".to_string()),
+            "login must be absent in Docker mode"
+        );
+        assert!(names.contains(&"get_config".to_string()));
+        assert!(names.contains(&"set_config".to_string()));
+    }
+
+    fn prompts_list_request_message() -> ClientJsonRpcMessage {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "prompts/list",
+            "params": {}
+        }))
+        .unwrap()
+    }
+
+    fn prompts_get_request_message(name: &str) -> ClientJsonRpcMessage {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "prompts/get",
+            "params": { "name": name }
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn list_prompts_and_get_prompt_handlers_work() {
+        use rmcp::ServiceExt;
+
+        let transport = ScriptedTransport::from_messages(vec![
+            initialize_request_message(),
+            initialized_notification_message(),
+            prompts_list_request_message(),
+            prompts_get_request_message("review_code_health"),
+        ]);
+        let sent = transport.sent.clone();
+        let server = make_server(false);
+
+        let service = server
+            .serve(transport)
+            .await
+            .expect("MCP handshake should succeed");
+
+        // Drain remaining client requests (prompts/list + prompts/get).
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), service.waiting()).await;
+
+        let messages = sent.lock().unwrap().clone();
+        let bodies: Vec<serde_json::Value> = messages
+            .iter()
+            .filter_map(|m| serde_json::to_value(m).ok())
+            .collect();
+
+        let list_ok = bodies.iter().any(|b| {
+            b.get("id") == Some(&json!(2))
+                && b.pointer("/result/prompts")
+                    .and_then(|p| p.as_array())
+                    .is_some_and(|prompts| {
+                        prompts.iter().any(|p| p.get("name") == Some(&json!("review_code_health")))
+                    })
+        });
+        assert!(list_ok, "prompts/list handler should return review_code_health; got {bodies:?}");
+
+        let get_ok = bodies.iter().any(|b| {
+            b.get("id") == Some(&json!(3))
+                && b.pointer("/result/messages")
+                    .and_then(|m| m.as_array())
+                    .is_some_and(|messages| !messages.is_empty())
+        });
+        assert!(get_ok, "prompts/get handler should return messages; got {bodies:?}");
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -722,14 +722,14 @@ mod tests {
 
     #[test]
     fn build_instructions_standalone_omits_api_tools() {
-        let text = build_instructions(true, false);
+        let text = build_instructions(true, false, false);
         assert!(text.contains("code_health_review"));
         assert!(!text.contains("select_project"));
     }
 
     #[test]
     fn build_instructions_api_mode_includes_all_tools() {
-        let text = build_instructions(false, false);
+        let text = build_instructions(false, false, false);
         assert!(text.contains("code_health_review"));
         assert!(text.contains("select_project"));
         assert!(text.contains("code_ownership_for_path"));
@@ -737,14 +737,14 @@ mod tests {
 
     #[test]
     fn build_instructions_tools_filtered_adds_note() {
-        let text = build_instructions(false, true);
+        let text = build_instructions(false, true, false);
         assert!(text.contains("enabled_tools"));
         assert!(text.contains("restricted"));
     }
 
     #[test]
     fn build_instructions_tools_not_filtered_no_note() {
-        let text = build_instructions(false, false);
+        let text = build_instructions(false, false, false);
         assert!(!text.contains("restricted"));
     }
 

--- a/tests/e2e/tests/enabled_tools.rs
+++ b/tests/e2e/tests/enabled_tools.rs
@@ -108,11 +108,40 @@ pub fn test_all_tools_without_filter() {
         names.contains("explain_code_health"),
         "explain_code_health should be listed"
     );
+    if is_docker() {
+        assert!(
+            !names.contains("login"),
+            "login must not be listed in Docker"
+        );
+    } else {
+        assert!(names.contains("login"), "login should be listed outside Docker");
+    }
     assert!(
         names.len() >= 10,
         "Expected >= 10 tools, found {}",
         names.len()
     );
+
+    let prompts_response = client
+        .send_request("prompts/list", json!({}), Duration::from_secs(15))
+        .expect("prompts/list should succeed");
+    let prompt_names: HashSet<String> = prompts_response["result"]["prompts"]
+        .as_array()
+        .expect("prompts should be an array")
+        .iter()
+        .map(|p| p["name"].as_str().expect("prompt name").to_string())
+        .collect();
+    if is_docker() {
+        assert!(
+            !prompt_names.contains("login"),
+            "login prompt must not be listed in Docker"
+        );
+    } else {
+        assert!(
+            prompt_names.contains("login"),
+            "login prompt should be listed outside Docker"
+        );
+    }
 }
 
 #[test]
@@ -137,17 +166,31 @@ pub fn test_filter_restricts_tools() {
     );
     assert!(names.contains("get_config"), "get_config always listed");
     assert!(names.contains("set_config"), "set_config always listed");
-    assert!(names.contains("login"), "login always listed");
+    if is_docker() {
+        assert!(
+            !names.contains("login"),
+            "login must not be listed in Docker"
+        );
+        assert_eq!(
+            names.len(),
+            4,
+            "Expected exactly 4 tools in Docker, found {}: {:?}",
+            names.len(),
+            names
+        );
+    } else {
+        assert!(names.contains("login"), "login always listed outside Docker");
+        assert_eq!(
+            names.len(),
+            5,
+            "Expected exactly 5 tools, found {}: {:?}",
+            names.len(),
+            names
+        );
+    }
     assert!(
         !names.contains("explain_code_health"),
         "explain_code_health should NOT be listed"
-    );
-    assert_eq!(
-        names.len(),
-        5,
-        "Expected exactly 5 tools, found {}: {:?}",
-        names.len(),
-        names
     );
 }
 


### PR DESCRIPTION
## Summary
- Remove the `login` MCP tool and `login` prompt when `CS_MOUNT_PATH` indicates Docker, since OAuth browser callbacks are unsupported
- Point agents at PAT / `CS_ACCESS_TOKEN` via Docker-specific auth messaging and server instructions
- Update configuring-skill docs and e2e assertions for Docker vs host behavior

## Test plan
- [ ] Unit tests for Docker vs non-Docker prompts/instructions pass on Linux CI
- [ ] E2E `enabled_tools` on Docker backend: `login` absent from `tools/list` and `prompts/list`
- [ ] E2E host/static backend: `login` tool and prompt still available
- [ ] Missing-token path in Docker mentions PAT / `CS_ACCESS_TOKEN`, not `login`