### PR TITLE
Add logout MCP tool, prompt, and VS Code Sign Out

### DIFF
--- a/claude-code-plugin/README.md
+++ b/claude-code-plugin/README.md
@@ -25,6 +25,8 @@ claude --plugin-dir ./claude-code-plugin
 - Invoke the `login` MCP prompt (slash command) if your client exposes MCP prompts
 - Or ask Claude: *Log me in to CodeScene* (calls the `login` tool and opens your browser)
 
+To sign out, use the `logout` prompt/tool, or ask Claude to log you out.
+
 **Multi-account Cloud:** If you belong to multiple CodeScene Cloud accounts, set your account/tenant ID first:
 
 > Set my CodeScene account ID to 123
@@ -68,6 +70,7 @@ The plugin registers the CodeScene MCP server, which provides the following tool
 | Tool | Description |
 |------|-------------|
 | `login` | Sign in to CodeScene with OAuth (opens browser) |
+| `logout` | Sign out of CodeScene OAuth and clear the stored session |
 | `get_config` | Read current MCP server configuration |
 | `set_config` | Write MCP server configuration values |
 

--- a/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/configuring-codescene-mcp/SKILL.md
@@ -7,11 +7,12 @@ description: Use when the user wants to view, set, or troubleshoot CodeScene MCP
 
 ## Overview
 
-Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `get_config` and `set_config` tools (and, outside Docker, `login`) that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose a `login` prompt (slash command) that instructs the assistant to call the `login` tool — except in Docker, where OAuth login is unavailable and a Personal Access Token (`CS_ACCESS_TOKEN`) is required.
+Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `get_config`, `set_config`, and `logout` tools (and, outside Docker, `login`) that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose `login` and `logout` prompts (slash commands) — except in Docker, where OAuth login is unavailable and a Personal Access Token (`CS_ACCESS_TOKEN`) is required.
 
 ## When to Use
 
 - The user wants to sign in to CodeScene (OAuth).
+- The user wants to sign out of CodeScene (clear the OAuth session).
 - The user wants to set or change their CodeScene access token (PAT / standalone).
 - The user belongs to multiple Cloud accounts and needs to pin an account ID.
 - The user needs to connect to a self-hosted CodeScene instance.
@@ -26,6 +27,7 @@ Do not use this skill for installing or registering the MCP server in an AI assi
 ## Quick Reference
 
 - `login`: Sign in with OAuth (opens browser). Preferred for interactive desktop use. Also available as the `login` MCP prompt (slash command). Not available in Docker — use a PAT instead.
+- `logout`: Sign out of OAuth (clears CLI credentials and MCP OAuth config). Does not remove `CS_ACCESS_TOKEN`. Also available as the `logout` MCP prompt.
 - `get_config`: List all configuration options and their current values (sensitive values are masked).
 - `get_config` with a key: Read a single option by name.
 - `set_config`: Set a configuration value persistently.
@@ -56,7 +58,7 @@ Environment variables set by the MCP client always override values in the config
 
 1. Run `get_config` to see the current state of all options.
 2. For interactive auth: if `access_token` is set and the user wants OAuth, clear it first (`set_config` with empty value or ask them to remove `CS_ACCESS_TOKEN` from client env). For multi-account Cloud, ensure `account_id` is set before calling `login`.
-3. Call `login` for OAuth (or have the user invoke the `login` MCP prompt), or `set_config` for PAT / other options.
+3. Call `login` for OAuth (or have the user invoke the `login` MCP prompt), or `set_config` for PAT / other options. To sign out, call `logout` (or the `logout` prompt).
 4. Run `get_config` with the relevant key to confirm the change took effect.
 5. If the user changed `access_token`, inform them that a server restart may be needed for tool registration changes to take effect.
 6. If `get_config` shows a value source of "client environment variable", explain that the env var in their editor's MCP configuration takes precedence and must be changed there instead.
@@ -82,4 +84,4 @@ For individual, interactive use, prefer `login` for auth and `set_config` for ot
 - Providing a CA bundle path that is not accessible to the MCP server process or Docker container.
 - Setting `enabled_tools` with misspelled tool names. The server warns about unknown names, but the misspelled tools are silently ignored. Use `get_config` with key `enabled_tools` to see the list of available tool names.
 - Forgetting that `enabled_tools` changes require a server restart. The tool list is built once at startup.
-- Trying to disable `get_config`, `set_config`, or `login` via `enabled_tools`. Outside Docker these tools are always enabled to prevent configuration lockout. In Docker, `login` is not registered at all (use PAT / `CS_ACCESS_TOKEN`).
+- Trying to disable `get_config`, `set_config`, `login`, or `logout` via `enabled_tools`. Outside Docker these tools are always enabled to prevent configuration lockout. In Docker, `login` is not registered at all (use PAT / `CS_ACCESS_TOKEN`); `logout` remains available.

--- a/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
+++ b/claude-code-plugin/skills/installing-and-activating-codescene-mcp/SKILL.md
@@ -25,7 +25,7 @@ Do not use this skill for configuring tokens, URLs, or other server options. Use
 - Register the server in the AI assistant so it launches `cs-mcp`.
 - Copy the appropriate agent guidance file into the repository: `docs/AGENTS-full.md` for CodeScene Core users, or `docs/AGENTS-standalone.md` for standalone license users. For Amazon Q, copy `.amazonq/rules` instead.
 - Copy any relevant skills from the CodeScene MCP skills catalogue at `https://github.com/codescene-oss/codescene-mcp-server/tree/main/skills`.
-- After installation, authenticate with OAuth via the `login` MCP prompt (slash command), by asking the assistant to log in (`login` tool), or with **CodeScene: Sign In** in the VS Code extension. Use a PAT only for CI/headless environments.
+- After installation, authenticate with OAuth via the `login` MCP prompt (slash command), by asking the assistant to log in (`login` tool), or with **CodeScene: Sign In** in the VS Code extension. Sign out with `logout` / **CodeScene: Sign Out**. Use a PAT only for CI/headless environments.
 
 ## Implementation
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -12,6 +12,16 @@ For interactive desktop use, no token needs to be manually obtained or configure
 
 The `login` tool opens your browser to complete the OAuth flow. Once done, the MCP server is authenticated for the session.
 
+### Sign out
+
+To clear a stored OAuth session:
+
+1. **MCP `logout` prompt (slash command)** — Invokes the `logout` tool.
+2. **Ask the assistant** — Say *"Log me out of CodeScene"* so the agent calls the `logout` tool.
+3. **VS Code command** — Run **CodeScene: Sign Out** from the Command Palette (VS Code extension only).
+
+Logout revokes/removes the CLI OAuth credentials and clears MCP OAuth config. It does **not** remove a Personal Access Token (`CS_ACCESS_TOKEN`); clear that separately via `set_config` or your MCP client settings.
+
 **For CodeScene Cloud:** no extra configuration needed for single-account users — just sign in.
 
 **Multi-account Cloud:** If you belong to more than one CodeScene Cloud account, set your account/tenant ID **before** logging in, and keep it set afterward (it selects the OAuth credential slot):

--- a/docs/configuration-options.md
+++ b/docs/configuration-options.md
@@ -352,7 +352,7 @@ Controls which MCP tools the server exposes to the AI assistant. When set, only 
 
 This is useful for reducing token usage by limiting the number of tool descriptions sent to the AI model. Each exposed tool adds to the prompt context, so disabling tools you don't need can lower costs and improve response times.
 
-The `get_config` and `set_config` tools are always enabled and cannot be disabled. This prevents accidental lockout from the configuration system. Outside Docker, the `login` tool is also always enabled. In Docker, OAuth is unsupported, so the `login` tool and `login` prompt are not registered — use `CS_ACCESS_TOKEN` or `set_config` with `access_token` instead.
+The `get_config`, `set_config`, and `logout` tools are always enabled and cannot be disabled. Outside Docker, the `login` tool is also always enabled. In Docker, OAuth is unsupported, so the `login` tool and `login` prompt are not registered — use `CS_ACCESS_TOKEN` or `set_config` with `access_token` instead.
 
 Changes to this setting require a server restart to take effect.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # Tools
 
-The CodeScene MCP Server provides 24 tools organized into four categories:
+The CodeScene MCP Server provides 25 tools organized into four categories:
 **Code Health Analysis**, **Code Health Rules Configuration**, **Technical Debt & Project Insights**, and **Server Management**.
 
 Tools marked **All Users** work with any valid license (standalone or API-connected).
@@ -118,6 +118,12 @@ These tools manage authentication, server configuration, installation verificati
 
 Sign in to CodeScene with OAuth. Opens a browser to complete the flow (waits up to two minutes). Prefer this for interactive desktop use. Not needed when `CS_ACCESS_TOKEN` is already set — a configured PAT blocks OAuth until cleared. Clients that support MCP prompts can start the same flow via the `login` prompt (slash command).
 
+### `logout`
+
+**Availability:** All Users
+
+Sign out of CodeScene OAuth. Calls the CLI logout and clears stored OAuth config (including a signed-out sentinel so the session cannot be silently refreshed). Does not remove `CS_ACCESS_TOKEN`; clear a PAT separately via `set_config` or your MCP client environment. Also available as the `logout` MCP prompt (slash command).
+
 ### `get_config`
 
 **Availability:** All Users
@@ -179,6 +185,7 @@ MCP prompts are short chat templates clients can expose as slash commands. They 
 | Prompt | Description |
 |--------|-------------|
 | `login` | Sign in to CodeScene with OAuth (calls the `login` tool) |
+| `logout` | Sign out of CodeScene OAuth (calls the `logout` tool) |
 | `review_code_health` | Review Code Health for the current open file |
 | `plan_code_health_refactoring` | Plan a prioritized, low-risk Code Health refactoring |
 
@@ -189,6 +196,7 @@ In VS Code Copilot Chat, invoke them from the slash-command / prompt picker (`mc
 | Tool | Availability |
 |------|-------------|
 | `login` | All Users |
+| `logout` | All Users |
 | `code_health_score` | All Users |
 | `code_health_review` | All Users |
 | `pre_commit_code_health_safeguard` | All Users |

--- a/skills/configuring-codescene-mcp/SKILL.md
+++ b/skills/configuring-codescene-mcp/SKILL.md
@@ -7,11 +7,12 @@ description: Use when the user wants to view, set, or troubleshoot CodeScene MCP
 
 ## Overview
 
-Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `get_config` and `set_config` tools (and, outside Docker, `login`) that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose a `login` prompt (slash command) that instructs the assistant to call the `login` tool — except in Docker, where OAuth login is unavailable and a Personal Access Token (`CS_ACCESS_TOKEN`) is required.
+Use this skill when the task is to configure the CodeScene MCP Server after it has been installed. The MCP server exposes `get_config`, `set_config`, and `logout` tools (and, outside Docker, `login`) that let the AI assistant authenticate and manage configuration on the user's behalf. Clients that support MCP prompts also expose `login` and `logout` prompts (slash commands) — except in Docker, where OAuth login is unavailable and a Personal Access Token (`CS_ACCESS_TOKEN`) is required.
 
 ## When to Use
 
 - The user wants to sign in to CodeScene (OAuth).
+- The user wants to sign out of CodeScene (clear the OAuth session).
 - The user wants to set or change their CodeScene access token (PAT / standalone).
 - The user belongs to multiple Cloud accounts and needs to pin an account ID.
 - The user needs to connect to a self-hosted CodeScene instance.
@@ -26,6 +27,7 @@ Do not use this skill for installing or registering the MCP server in an AI assi
 ## Quick Reference
 
 - `login`: Sign in with OAuth (opens browser). Preferred for interactive desktop use. Also available as the `login` MCP prompt (slash command). Not available in Docker — use a PAT instead.
+- `logout`: Sign out of OAuth (clears CLI credentials and MCP OAuth config). Does not remove `CS_ACCESS_TOKEN`. Also available as the `logout` MCP prompt.
 - `get_config`: List all configuration options and their current values (sensitive values are masked).
 - `get_config` with a key: Read a single option by name.
 - `set_config`: Set a configuration value persistently.
@@ -56,7 +58,7 @@ Environment variables set by the MCP client always override values in the config
 
 1. Run `get_config` to see the current state of all options.
 2. For interactive auth: if `access_token` is set and the user wants OAuth, clear it first (`set_config` with empty value or ask them to remove `CS_ACCESS_TOKEN` from client env). For multi-account Cloud, ensure `account_id` is set before calling `login`.
-3. Call `login` for OAuth (or have the user invoke the `login` MCP prompt), or `set_config` for PAT / other options.
+3. Call `login` for OAuth (or have the user invoke the `login` MCP prompt), or `set_config` for PAT / other options. To sign out, call `logout` (or the `logout` prompt).
 4. Run `get_config` with the relevant key to confirm the change took effect.
 5. If the user changed `access_token`, inform them that a server restart may be needed for tool registration changes to take effect.
 6. If `get_config` shows a value source of "client environment variable", explain that the env var in their editor's MCP configuration takes precedence and must be changed there instead.
@@ -82,4 +84,4 @@ For individual, interactive use, prefer `login` for auth and `set_config` for ot
 - Providing a CA bundle path that is not accessible to the MCP server process or Docker container.
 - Setting `enabled_tools` with misspelled tool names. The server warns about unknown names, but the misspelled tools are silently ignored. Use `get_config` with key `enabled_tools` to see the list of available tool names.
 - Forgetting that `enabled_tools` changes require a server restart. The tool list is built once at startup.
-- Trying to disable `get_config`, `set_config`, or `login` via `enabled_tools`. Outside Docker these tools are always enabled to prevent configuration lockout. In Docker, `login` is not registered at all (use PAT / `CS_ACCESS_TOKEN`).
+- Trying to disable `get_config`, `set_config`, `login`, or `logout` via `enabled_tools`. Outside Docker these tools are always enabled to prevent configuration lockout. In Docker, `login` is not registered at all (use PAT / `CS_ACCESS_TOKEN`); `logout` remains available.

--- a/skills/installing-and-activating-codescene-mcp/SKILL.md
+++ b/skills/installing-and-activating-codescene-mcp/SKILL.md
@@ -25,7 +25,7 @@ Do not use this skill for configuring tokens, URLs, or other server options. Use
 - Register the server in the AI assistant so it launches `cs-mcp`.
 - Copy the appropriate agent guidance file into the repository: `docs/AGENTS-full.md` for CodeScene Core users, or `docs/AGENTS-standalone.md` for standalone license users. For Amazon Q, copy `.amazonq/rules` instead.
 - Copy any relevant skills from the CodeScene MCP skills catalogue at `https://github.com/codescene-oss/codescene-mcp-server/tree/main/skills`.
-- After installation, authenticate with OAuth via the `login` MCP prompt (slash command), by asking the assistant to log in (`login` tool), or with **CodeScene: Sign In** in the VS Code extension. Use a PAT only for CI/headless environments.
+- After installation, authenticate with OAuth via the `login` MCP prompt (slash command), by asking the assistant to log in (`login` tool), or with **CodeScene: Sign In** in the VS Code extension. Sign out with `logout` / **CodeScene: Sign Out**. Use a PAT only for CI/headless environments.
 
 ## Implementation
 

--- a/src/auth/manager.rs
+++ b/src/auth/manager.rs
@@ -1,8 +1,8 @@
 use crate::cli::CliRunner;
 
 use super::{
-    configured_credential, credential_from_response, fetch_token, run_login, state, AuthCredential,
-    CliTokenResponse,
+    configured_credential, credential_from_response, fetch_token, run_login, run_logout, state,
+    AuthCredential, CliTokenResponse,
 };
 
 /// Manages OAuth token lifecycle using the config env RwLock for all state.
@@ -206,6 +206,32 @@ impl AuthManager {
                 Ok(None)
             }
         }
+    }
+
+    /// Sign out: run CLI logout and persist the signed-out sentinel.
+    ///
+    /// Always clears MCP OAuth config (even if the CLI call fails) so a later
+    /// `auth token` refresh cannot rehydrate the session. Returns `Err` when
+    /// the CLI logout fails; callers should still treat local state as signed out.
+    pub(crate) async fn logout(&self, cli_runner: &dyn CliRunner) -> Result<(), String> {
+        let guard = crate::config::acquire_write_lock().await;
+        let result = run_logout(cli_runner).await;
+        state::persist_signed_out(&guard);
+        match &result {
+            Ok(resp) => {
+                tracing::info!(
+                    status = %resp.status,
+                    "CLI logout completed; persisted signed-out sentinel"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "CLI logout failed; still persisted signed-out sentinel"
+                );
+            }
+        }
+        result.map(|_| ())
     }
 
     /// Synchronously try to read the OAuth token for tracking purposes.
@@ -653,6 +679,49 @@ mod tests {
             );
             assert!(!manager.login(&cli).await.unwrap().is_signed_in());
             std::env::remove_var("CS_CONFIG_DIR");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn logout_clears_oauth_and_sets_sentinel() {
+        with_clean_env(|| async {
+            std::env::set_var("CS_OAUTH_TOKEN", "oau-to-clear");
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
+            std::env::set_var("CS_OAUTH_REFRESH_EXPIRES_AT", "9999999999");
+            let manager = AuthManager::new();
+            let cli = MockCliRunner::with_ok(
+                r#"{"status":"signed_out","access-token":null,"api-url":null}"#,
+            );
+            manager.logout(&cli).await.unwrap();
+            assert!(std::env::var("CS_OAUTH_TOKEN").is_err());
+            assert_eq!(
+                std::env::var("CS_OAUTH_EXPIRES_AT").ok().as_deref(),
+                Some(SIGNED_OUT_SENTINEL)
+            );
+            assert!(std::env::var("CS_OAUTH_REFRESH_EXPIRES_AT").is_err());
+            let calls = cli.calls();
+            let args = calls.lock().unwrap()[0].clone();
+            assert_eq!(args[0], "auth");
+            assert_eq!(args[1], "logout");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn logout_persists_sentinel_even_when_cli_fails() {
+        with_clean_env(|| async {
+            std::env::set_var("CS_OAUTH_TOKEN", "oau-stale");
+            std::env::set_var("CS_OAUTH_EXPIRES_AT", (now_epoch_secs() + 3600).to_string());
+            let manager = AuthManager::new();
+            let cli = MockCliRunner::with_err(1, "logout failed");
+            let err = manager.logout(&cli).await.unwrap_err();
+            assert!(err.contains("logout") || err.contains("failed"), "got: {err}");
+            assert!(std::env::var("CS_OAUTH_TOKEN").is_err());
+            assert_eq!(
+                std::env::var("CS_OAUTH_EXPIRES_AT").ok().as_deref(),
+                Some(SIGNED_OUT_SENTINEL)
+            );
         })
         .await;
     }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -232,6 +232,14 @@ pub(crate) async fn fetch_token(
     Ok(Some(parsed))
 }
 
+/// Run `cs auth logout --client mcp --output-format json`.
+/// Returns the parsed response on success (typically `status: signed_out`).
+pub(crate) async fn run_logout(
+    cli_runner: &dyn CliRunner,
+) -> Result<CliTokenResponse, String> {
+    run_and_parse_auth(cli_runner, "logout").await
+}
+
 /// Run `cs auth login --client mcp --output-format json` (blocking until the
 /// browser flow completes or the CLI's built-in 2-minute timeout fires).
 /// Returns the parsed response on success.
@@ -516,6 +524,23 @@ mod tests {
     async fn fetch_token_returns_err_on_invalid_json() {
         let cli = MockCliRunner::with_ok("not json");
         assert!(fetch_token(&cli).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_logout_returns_signed_out_response() {
+        let json = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+        let cli = MockCliRunner::with_ok(json);
+        let result = run_logout(&cli).await.unwrap();
+        assert_eq!(result.status, "signed_out");
+        let calls = cli.calls();
+        let args = calls.lock().unwrap()[0].clone();
+        assert_eq!(args[..2], ["auth".to_string(), "logout".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn run_logout_returns_err_on_cli_failure() {
+        let cli = MockCliRunner::with_err(1, "connection refused");
+        assert!(run_logout(&cli).await.is_err());
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ pub(crate) fn display_version(raw_version: &str) -> &str {
 }
 
 pub(crate) fn help_text() -> &'static str {
-    "CodeScene MCP Server\n\nUsage: cs-mcp [OPTIONS]\n\nOptions:\n  -h, --help       Show this help message and exit\n  -v, --version    Show version and exit\n  --cli-version    Show embedded CLI version and exit\n  auth             Sign in to CodeScene via OAuth (opens browser)\n  logout           Sign out of CodeScene OAuth and clear the stored session\n\nEnvironment:\n  CS_ONPREM_URL    Base URL of self-hosted CodeScene instance (for auth subcommand)"
+    "CodeScene MCP Server\n\nUsage: cs-mcp [OPTIONS]\n\nOptions:\n  -h, --help       Show this help message and exit\n  -v, --version    Show version and exit\n  --cli-version    Show embedded CLI version and exit\n  auth             Sign in to CodeScene via OAuth (opens browser)\n  auth logout      Sign out of CodeScene OAuth and clear the stored session\n\nEnvironment:\n  CS_ONPREM_URL    Base URL of self-hosted CodeScene instance (for auth subcommand)"
 }
 
 async fn ensure_oauth_client_configured() {
@@ -140,6 +140,10 @@ pub(crate) fn parse_cli_args(args: &[String], raw_version: &str) -> Result<CliAc
             "logout" => Ok(CliAction::Logout),
             other => Err(format!("Unknown argument: {other}")),
         };
+    }
+
+    if args.len() == 2 && args[0] == "auth" && args[1] == "logout" {
+        return Ok(CliAction::Logout);
     }
 
     Err(format!("Unexpected arguments: {}", args.join(" ")))
@@ -188,7 +192,8 @@ async fn run_auth_flow() -> anyhow::Result<()> {
     }
 }
 
-/// Run OAuth logout as a standalone CLI command.
+/// Run OAuth logout as a standalone CLI command (`cs-mcp auth logout`).
+/// Delegates to `cs auth logout --client mcp`, then clears MCP OAuth config.
 /// Outputs JSON with the result to stdout for consumption by the VS Code extension.
 async fn run_logout_flow() -> anyhow::Result<()> {
     config::snapshot_client_env_vars();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ use crate::http::HttpClient;
 use crate::tools::validation::{ValidationError, Validator};
 use crate::tools::{
     ChangeSetParam, DownloadSkillParam, FilePathParam, GetConfigParam, GitRepoParam, LoginParam,
-    OptionalContext, OwnershipParam, ProjectFileParam, ProjectParam,
+    LogoutParam, OptionalContext, OwnershipParam, ProjectFileParam, ProjectParam,
     RulesConfigListThresholdsParam, RulesConfigSetRuleParam, RulesConfigSetThresholdParam,
     RulesConfigValidateParam, SetConfigParam, SkillNameParam, SyncSkillsParam,
 };
@@ -93,7 +93,8 @@ pub(crate) const API_ONLY_TOOLS: &[&str] = &[
 ];
 
 /// Tools that cannot be disabled via `enabled_tools` config.
-pub(crate) const ALWAYS_ENABLED_TOOLS: &[&str] = &["get_config", "set_config", "login"];
+pub(crate) const ALWAYS_ENABLED_TOOLS: &[&str] =
+    &["get_config", "set_config", "login", "logout"];
 
 #[derive(Debug)]
 pub(crate) enum CliAction {
@@ -102,6 +103,7 @@ pub(crate) enum CliAction {
     PrintVersion(String),
     PrintCliVersion,
     Auth,
+    Logout,
 }
 
 pub(crate) fn display_version(raw_version: &str) -> &str {
@@ -109,7 +111,7 @@ pub(crate) fn display_version(raw_version: &str) -> &str {
 }
 
 pub(crate) fn help_text() -> &'static str {
-    "CodeScene MCP Server\n\nUsage: cs-mcp [OPTIONS]\n\nOptions:\n  -h, --help       Show this help message and exit\n  -v, --version    Show version and exit\n  --cli-version    Show embedded CLI version and exit\n  auth             Sign in to CodeScene via OAuth (opens browser)\n\nEnvironment:\n  CS_ONPREM_URL    Base URL of self-hosted CodeScene instance (for auth subcommand)"
+    "CodeScene MCP Server\n\nUsage: cs-mcp [OPTIONS]\n\nOptions:\n  -h, --help       Show this help message and exit\n  -v, --version    Show version and exit\n  --cli-version    Show embedded CLI version and exit\n  auth             Sign in to CodeScene via OAuth (opens browser)\n  logout           Sign out of CodeScene OAuth and clear the stored session\n\nEnvironment:\n  CS_ONPREM_URL    Base URL of self-hosted CodeScene instance (for auth subcommand)"
 }
 
 async fn ensure_oauth_client_configured() {
@@ -135,6 +137,7 @@ pub(crate) fn parse_cli_args(args: &[String], raw_version: &str) -> Result<CliAc
             )),
             "--cli-version" => Ok(CliAction::PrintCliVersion),
             "auth" => Ok(CliAction::Auth),
+            "logout" => Ok(CliAction::Logout),
             other => Err(format!("Unknown argument: {other}")),
         };
     }
@@ -181,6 +184,32 @@ async fn run_auth_flow() -> anyhow::Result<()> {
             let result = serde_json::json!({"status": "error", "error": e});
             println!("{}", result);
             anyhow::bail!("Login failed: {e}");
+        }
+    }
+}
+
+/// Run OAuth logout as a standalone CLI command.
+/// Outputs JSON with the result to stdout for consumption by the VS Code extension.
+async fn run_logout_flow() -> anyhow::Result<()> {
+    config::snapshot_client_env_vars();
+    ensure_oauth_client_configured().await;
+    let config_data = config::load().unwrap_or_default();
+    config::apply_to_env(&config_data);
+
+    let cli_runner = cli::ProductionCliRunner;
+    let auth_manager = AuthManager::new();
+
+    match auth_manager.logout(&cli_runner).await {
+        Ok(()) => {
+            let result = serde_json::json!({"status": "signed_out"});
+            println!("{}", result);
+            Ok(())
+        }
+        Err(e) => {
+            // Local OAuth state is already cleared; still report the CLI error.
+            let result = serde_json::json!({"status": "error", "error": e});
+            println!("{}", result);
+            anyhow::bail!("Logout failed: {e}");
         }
     }
 }
@@ -638,6 +667,17 @@ impl CodeSceneServer {
     }
 
     #[tool(
+        description = "Sign out of CodeScene OAuth.\n\nWhen to use:\n    Use this tool to clear the stored OAuth session (CLI credentials and MCP OAuth config).\n\nLimitations:\n    - Does not remove CS_ACCESS_TOKEN / a Personal Access Token; clear that separately via set_config or your MCP client environment.\n    - Requires the embedded CLI to be available for a full CLI logout; local OAuth config is still cleared if the CLI call fails.\n\nReturns:\n    A success message when signed out, noting if a PAT remains configured.",
+        input_schema = inlined_schema_for::<LogoutParam>()
+    )]
+    async fn logout(
+        &self,
+        Parameters(params): Parameters<LogoutParam>,
+    ) -> Result<CallToolResult, ErrorData> {
+        tools::logout::handle(self, params).await
+    }
+
+    #[tool(
         description = "List all available skills embedded in this MCP server.\n\nWhen to use:\n    Use this tool to discover what skills are available for\n    download or inspection.\n\nLimitations:\n    - Returns only skills embedded at compile time.\n    - Does not scan external skill directories.\n\nReturns:\n    A formatted list of skill names with their descriptions.\n\nExample:\n    Call this tool to see all available skills, then use\n    download_skill or sync_skills to install them locally."
     )]
     async fn list_skills(&self) -> Result<CallToolResult, ErrorData> {
@@ -751,6 +791,10 @@ async fn main() -> anyhow::Result<()> {
         }
         Ok(CliAction::Auth) => {
             run_auth_flow().await?;
+            return Ok(());
+        }
+        Ok(CliAction::Logout) => {
+            run_logout_flow().await?;
             return Ok(());
         }
         Err(message) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,11 +142,18 @@ pub(crate) fn parse_cli_args(args: &[String], raw_version: &str) -> Result<CliAc
         };
     }
 
-    if args.len() == 2 && args[0] == "auth" && args[1] == "logout" {
+    if is_auth_logout_args(args) {
         return Ok(CliAction::Logout);
     }
 
     Err(format!("Unexpected arguments: {}", args.join(" ")))
+}
+
+fn is_auth_logout_args(args: &[String]) -> bool {
+    matches!(
+        args,
+        [cmd, sub] if cmd == "auth" && sub == "logout"
+    )
 }
 
 pub(crate) async fn fetch_cli_version(cli_runner: &dyn cli::CliRunner) -> anyhow::Result<String> {
@@ -196,15 +203,20 @@ async fn run_auth_flow() -> anyhow::Result<()> {
 /// Delegates to `cs auth logout --client mcp`, then clears MCP OAuth config.
 /// Outputs JSON with the result to stdout for consumption by the VS Code extension.
 async fn run_logout_flow() -> anyhow::Result<()> {
+    run_logout_flow_with(&cli::ProductionCliRunner).await
+}
+
+/// Testable logout CLI flow using an injected runner.
+pub(crate) async fn run_logout_flow_with(
+    cli_runner: &dyn cli::CliRunner,
+) -> anyhow::Result<()> {
     config::snapshot_client_env_vars();
     ensure_oauth_client_configured().await;
     let config_data = config::load().unwrap_or_default();
     config::apply_to_env(&config_data);
 
-    let cli_runner = cli::ProductionCliRunner;
     let auth_manager = AuthManager::new();
-
-    match auth_manager.logout(&cli_runner).await {
+    match auth_manager.logout(cli_runner).await {
         Ok(()) => {
             let result = serde_json::json!({"status": "signed_out"});
             println!("{}", result);

--- a/src/prompts/logout.rs
+++ b/src/prompts/logout.rs
@@ -1,0 +1,7 @@
+pub const TEXT: &str = "\
+Sign me out of CodeScene now. Call the logout tool immediately to clear the OAuth session. \
+Do not ask for confirmation first. \
+Logout clears the stored OAuth credentials; it does not remove a Personal Access Token \
+(CS_ACCESS_TOKEN). If logout reports that a PAT is still configured, explain how to clear \
+it with set_config or the MCP client environment. After a successful logout, briefly confirm \
+that I am signed out.";

--- a/src/prompts/logout.rs
+++ b/src/prompts/logout.rs
@@ -5,3 +5,15 @@ Logout clears the stored OAuth credentials; it does not remove a Personal Access
 (CS_ACCESS_TOKEN). If logout reports that a PAT is still configured, explain how to clear \
 it with set_config or the MCP client environment. After a successful logout, briefly confirm \
 that I am signed out.";
+
+#[cfg(test)]
+mod tests {
+    use super::TEXT;
+
+    #[test]
+    fn logout_prompt_instructs_immediate_tool_call() {
+        assert!(TEXT.contains("logout tool"));
+        assert!(TEXT.contains("CS_ACCESS_TOKEN"));
+        assert!(TEXT.contains("signed out"));
+    }
+}

--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -1,10 +1,12 @@
 pub mod login;
+pub mod logout;
 pub mod plan_code_health_refactoring;
 pub mod review_code_health;
 
 pub fn resolve_prompt_text(name: &str) -> Option<&'static str> {
     match name {
         "login" => Some(login::TEXT),
+        "logout" => Some(logout::TEXT),
         "review_code_health" => Some(review_code_health::TEXT),
         "plan_code_health_refactoring" => Some(plan_code_health_refactoring::TEXT),
         _ => None,
@@ -18,6 +20,11 @@ mod tests {
     #[test]
     fn resolve_login_prompt() {
         assert!(resolve_prompt_text("login").is_some());
+    }
+
+    #[test]
+    fn resolve_logout_prompt() {
+        assert!(resolve_prompt_text("logout").is_some());
     }
 
     #[test]

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -91,6 +91,13 @@ fn build_prompts_list(is_docker: bool) -> ListPromptsResult {
         ));
     }
     prompts_list.push(Prompt::new(
+        "logout",
+        Some("Sign out of CodeScene OAuth. Invokes the logout tool to clear the stored session."),
+        Some(vec![PromptArgument::new("context")
+            .with_description("Optional context string.")
+            .with_required(false)]),
+    ));
+    prompts_list.push(Prompt::new(
         "review_code_health",
         Some(
             "Review Code Health and assess code quality for the current open file. The file path needs to be sent to the code_health_review MCP tool when using this prompt.",
@@ -207,18 +214,22 @@ fn build_resource_templates() -> ListResourceTemplatesResult {
 
 fn login_tool_instruction_line(is_docker: bool) -> &'static str {
     if is_docker {
-        ""
+        "- logout: Sign out of CodeScene OAuth and clear the stored session. Does not remove CS_ACCESS_TOKEN.\n\
+         "
     } else {
         "- login: Sign in to CodeScene with OAuth. When authentication is missing, call this tool first.\n\
+         - logout: Sign out of CodeScene OAuth and clear the stored session. Does not remove CS_ACCESS_TOKEN.\n\
          "
     }
 }
 
 fn login_prompt_instruction_line(is_docker: bool) -> &'static str {
     if is_docker {
-        ""
+        "- logout: Sign out of CodeScene OAuth (calls the logout tool).\n\
+         "
     } else {
         "- login: Sign in to CodeScene with OAuth (calls the login tool).\n\
+         - logout: Sign out of CodeScene OAuth (calls the logout tool).\n\
          "
     }
 }
@@ -309,9 +320,10 @@ mod tests {
     #[test]
     fn prompts_list_contains_expected_prompts() {
         let result = build_prompts_list(false);
-        assert_eq!(result.prompts.len(), 3);
+        assert_eq!(result.prompts.len(), 4);
         let names: Vec<&str> = result.prompts.iter().map(|p| p.name.as_str()).collect();
         assert!(names.contains(&"login"));
+        assert!(names.contains(&"logout"));
         assert!(names.contains(&"review_code_health"));
         assert!(names.contains(&"plan_code_health_refactoring"));
     }
@@ -319,9 +331,10 @@ mod tests {
     #[test]
     fn prompts_list_omits_login_in_docker() {
         let result = build_prompts_list(true);
-        assert_eq!(result.prompts.len(), 2);
+        assert_eq!(result.prompts.len(), 3);
         let names: Vec<&str> = result.prompts.iter().map(|p| p.name.as_str()).collect();
         assert!(!names.contains(&"login"));
+        assert!(names.contains(&"logout"));
         assert!(names.contains(&"review_code_health"));
         assert!(names.contains(&"plan_code_health_refactoring"));
     }
@@ -355,6 +368,18 @@ mod tests {
     }
 
     #[test]
+    fn resolve_logout_prompt_succeeds() {
+        let result = resolve_prompt("logout", false);
+        assert!(result.is_ok());
+        let prompt = result.unwrap();
+        let text = match &prompt.messages[0].content {
+            rmcp::model::PromptMessageContent::Text { text } => text.as_str(),
+            _ => panic!("expected text content"),
+        };
+        assert!(text.contains("logout tool"));
+    }
+
+    #[test]
     fn resolve_unknown_prompt_returns_error() {
         let result = resolve_prompt("nonexistent_prompt", false);
         assert!(result.is_err());
@@ -366,6 +391,7 @@ mod tests {
     fn build_instructions_omits_login_in_docker() {
         let text = build_instructions(false, false, true);
         assert!(!text.contains("- login:"));
+        assert!(text.contains("- logout: Sign out of CodeScene OAuth"));
         assert!(text.contains("OAuth login is not available in Docker"));
         assert!(text.contains("CS_ACCESS_TOKEN"));
     }
@@ -374,6 +400,7 @@ mod tests {
     fn build_instructions_includes_login_outside_docker() {
         let text = build_instructions(false, false, false);
         assert!(text.contains("- login: Sign in to CodeScene with OAuth"));
+        assert!(text.contains("- logout: Sign out of CodeScene OAuth"));
         assert!(!text.contains("OAuth login is not available in Docker"));
     }
 

--- a/src/server_handler.rs
+++ b/src/server_handler.rs
@@ -347,16 +347,23 @@ mod tests {
         assert!(!prompt.messages.is_empty());
     }
 
-    #[test]
-    fn resolve_login_prompt_succeeds() {
-        let result = resolve_prompt("login", false);
+    fn assert_prompt_text_contains(name: &str, expected: &str) {
+        let result = resolve_prompt(name, false);
         assert!(result.is_ok());
         let prompt = result.unwrap();
         let text = match &prompt.messages[0].content {
             rmcp::model::PromptMessageContent::Text { text } => text.as_str(),
             _ => panic!("expected text content"),
         };
-        assert!(text.contains("login tool"));
+        assert!(
+            text.contains(expected),
+            "prompt {name} missing {expected:?}, got: {text}"
+        );
+    }
+
+    #[test]
+    fn resolve_login_prompt_succeeds() {
+        assert_prompt_text_contains("login", "login tool");
     }
 
     #[test]
@@ -369,14 +376,7 @@ mod tests {
 
     #[test]
     fn resolve_logout_prompt_succeeds() {
-        let result = resolve_prompt("logout", false);
-        assert!(result.is_ok());
-        let prompt = result.unwrap();
-        let text = match &prompt.messages[0].content {
-            rmcp::model::PromptMessageContent::Text { text } => text.as_str(),
-            _ => panic!("expected text content"),
-        };
-        assert!(text.contains("logout tool"));
+        assert_prompt_text_contains("logout", "logout tool");
     }
 
     #[test]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -486,6 +486,13 @@ mod tests {
         assert!(matches!(action, CliAction::Auth));
     }
 
+    #[test]
+    fn parse_cli_args_supports_logout() {
+        let args = vec!["logout".to_string()];
+        let action = parse_cli_args(&args, "MCP-1.2.3").unwrap();
+        assert!(matches!(action, CliAction::Logout));
+    }
+
     #[tokio::test]
     async fn fetch_cli_version_returns_cli_output() {
         let runner = MockCliRunner::with_ok("cs version 1.5.0\n");
@@ -714,6 +721,8 @@ mod tests {
         assert!(text.contains("Usage:"));
         assert!(text.contains("--help"));
         assert!(text.contains("--version"));
+        assert!(text.contains("auth"));
+        assert!(text.contains("logout"));
     }
 
     #[test]
@@ -789,6 +798,7 @@ mod tests {
             "missing set_config"
         );
         assert!(names.contains(&"login".to_string()), "missing login");
+        assert!(names.contains(&"logout".to_string()), "missing logout");
     }
 
     fn assert_tool_count_and_config(names: &[String], expected: usize) {
@@ -806,7 +816,7 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server(false);
         let names = tool_names(&server);
-        assert_tool_count_and_config(&names, 25);
+        assert_tool_count_and_config(&names, 26);
         assert!(names.contains(&"code_health_review".to_string()));
     }
 
@@ -816,8 +826,8 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server_with_enabled_tools(false, "code_health_review,code_health_score");
         let names = tool_names(&server);
-        // Should have the 2 enabled tools + 3 always-on = 5
-        assert_tool_count_and_config(&names, 5);
+        // Should have the 2 enabled tools + 4 always-on = 6
+        assert_tool_count_and_config(&names, 6);
         assert!(names.contains(&"code_health_review".to_string()));
         assert!(names.contains(&"code_health_score".to_string()));
     }
@@ -852,7 +862,7 @@ mod tests {
         std::env::remove_var("CS_ENABLED_TOOLS");
         let server = make_server_with_enabled_tools(false, "analyze_change_set");
         let names = tool_names(&server);
-        assert_tool_count_and_config(&names, 4);
+        assert_tool_count_and_config(&names, 5);
         assert!(names.contains(&"analyze_change_set".to_string()));
     }
 
@@ -947,6 +957,10 @@ mod tests {
         assert!(
             !names.contains(&"login".to_string()),
             "login must be absent in Docker mode"
+        );
+        assert!(
+            names.contains(&"logout".to_string()),
+            "logout must remain available in Docker"
         );
         assert!(names.contains(&"get_config".to_string()));
         assert!(names.contains(&"set_config".to_string()));

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -493,6 +493,13 @@ mod tests {
         assert!(matches!(action, CliAction::Logout));
     }
 
+    #[test]
+    fn parse_cli_args_supports_auth_logout() {
+        let args = vec!["auth".to_string(), "logout".to_string()];
+        let action = parse_cli_args(&args, "MCP-1.2.3").unwrap();
+        assert!(matches!(action, CliAction::Logout));
+    }
+
     #[tokio::test]
     async fn fetch_cli_version_returns_cli_output() {
         let runner = MockCliRunner::with_ok("cs version 1.5.0\n");
@@ -722,7 +729,7 @@ mod tests {
         assert!(text.contains("--help"));
         assert!(text.contains("--version"));
         assert!(text.contains("auth"));
-        assert!(text.contains("logout"));
+        assert!(text.contains("auth logout"));
     }
 
     #[test]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -287,7 +287,7 @@ mod tests {
     use crate::version_checker::VersionChecker;
     use crate::{
         display_version, fetch_cli_version, help_text, parse_cli_args, remove_docker_unsupported_tools,
-        token_missing_msg, CliAction, API_ONLY_TOOLS,
+        run_logout_flow_with, token_missing_msg, CliAction, API_ONLY_TOOLS,
     };
 
     #[derive(Clone)]
@@ -681,6 +681,90 @@ mod tests {
             "got: {}",
             result_text(&result)
         );
+    }
+
+    #[tokio::test]
+    async fn logout_dispatch_method_delegates_to_logout_handler() {
+        use rmcp::handler::server::wrapper::Parameters;
+
+        let _g = clear_token();
+        std::env::set_var("CS_OAUTH_TOKEN", "oau-dispatch");
+        std::env::set_var("CS_OAUTH_EXPIRES_AT", "9999999999");
+        let server = make_server_with_mocks(
+            false,
+            MockCliRunner::with_ok(
+                r#"{"status":"signed_out","access-token":null,"api-url":null}"#,
+            ),
+            MockHttpClient::new(vec![]),
+        );
+        let result = server
+            .logout(Parameters(crate::tools::LogoutParam {}))
+            .await
+            .unwrap();
+        assert!(
+            result_text(&result).contains("Successfully signed out"),
+            "got: {}",
+            result_text(&result)
+        );
+        std::env::remove_var("CS_OAUTH_TOKEN");
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+    }
+
+    /// Env setup for `run_logout_flow_with` tests. Keeps the tempdir alive until drop.
+    struct LogoutFlowEnv {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl LogoutFlowEnv {
+        fn new() -> Self {
+            let lock = config::lock_test_env();
+            let dir = tempfile::tempdir().unwrap();
+            std::env::set_var("CS_CONFIG_DIR", dir.path().as_os_str());
+            std::env::set_var("CS_OAUTH_CLIENT", "mcp");
+            std::env::remove_var("CS_ACCESS_TOKEN");
+            Self {
+                _lock: lock,
+                _dir: dir,
+            }
+        }
+
+        fn assert_signed_out_sentinel(&self) {
+            assert_eq!(
+                std::env::var("CS_OAUTH_EXPIRES_AT").ok().as_deref(),
+                Some("0")
+            );
+        }
+    }
+
+    impl Drop for LogoutFlowEnv {
+        fn drop(&mut self) {
+            std::env::remove_var("CS_OAUTH_CLIENT");
+            std::env::remove_var("CS_CONFIG_DIR");
+            std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+        }
+    }
+
+    #[tokio::test]
+    async fn run_logout_flow_with_succeeds() {
+        let env = LogoutFlowEnv::new();
+        let runner = MockCliRunner::with_ok(
+            r#"{"status":"signed_out","access-token":null,"api-url":null}"#,
+        );
+        run_logout_flow_with(&runner).await.unwrap();
+        env.assert_signed_out_sentinel();
+    }
+
+    #[tokio::test]
+    async fn run_logout_flow_with_reports_cli_error() {
+        let env = LogoutFlowEnv::new();
+        let runner = MockCliRunner::with_err(1, "connection refused");
+        let err = run_logout_flow_with(&runner).await.unwrap_err();
+        assert!(
+            err.to_string().contains("Logout failed"),
+            "got: {err}"
+        );
+        env.assert_signed_out_sentinel();
     }
 
     #[tokio::test]

--- a/src/tools/logout.rs
+++ b/src/tools/logout.rs
@@ -1,0 +1,112 @@
+use rmcp::model::{CallToolResult, Content};
+use rmcp::ErrorData;
+use serde_json::json;
+
+use crate::auth;
+use crate::tools::LogoutParam;
+use crate::CodeSceneServer;
+
+pub(crate) async fn handle(
+    server: &CodeSceneServer,
+    _params: LogoutParam,
+) -> Result<CallToolResult, ErrorData> {
+    tracing::info!("starting CodeScene logout");
+    let pat_configured = auth::configured_credential().is_some();
+    match server.auth_manager.logout(&*server.cli_runner).await {
+        Ok(()) => {
+            if pat_configured {
+                tracing::info!("OAuth session cleared; CS_ACCESS_TOKEN remains configured");
+                server.track(
+                    "auth-logout",
+                    json!({"result": "pat_still_configured"}),
+                );
+                Ok(CallToolResult::success(vec![Content::text(
+                    "Signed out of CodeScene OAuth. \
+                     CS_ACCESS_TOKEN is still configured, so API tools may continue to work \
+                     until you remove it via set_config or your MCP client environment.",
+                )]))
+            } else {
+                tracing::info!("CodeScene logout succeeded");
+                server.track("auth-logout", json!({"result": "success"}));
+                Ok(CallToolResult::success(vec![Content::text(
+                    "Successfully signed out of CodeScene.",
+                )]))
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "CodeScene logout CLI failed; local OAuth state cleared");
+            server.track("auth-logout", json!({"result": "error"}));
+            let mut message = format!(
+                "Local OAuth session cleared, but CLI logout reported an error: {e}\n\
+                 You may also run: cs auth logout"
+            );
+            if pat_configured {
+                message.push_str(
+                    "\n\nCS_ACCESS_TOKEN is still configured. Remove it to fully stop using that credential.",
+                );
+            }
+            Ok(CallToolResult::success(vec![Content::text(message)]))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::tests::MockHttpClient;
+    use crate::test_utils::MockCliRunner;
+    use crate::tests::{clear_token, make_server_with_mocks, result_text, set_token};
+
+    fn params() -> LogoutParam {
+        LogoutParam {}
+    }
+
+    const SIGNED_OUT_JSON: &str = r#"{"status":"signed_out","access-token":null,"api-url":null}"#;
+
+    #[tokio::test]
+    async fn logout_succeeds_and_clears_oauth() {
+        let _g = clear_token();
+        std::env::set_var("CS_OAUTH_TOKEN", "oau-test");
+        std::env::set_var("CS_OAUTH_EXPIRES_AT", "9999999999");
+        let cli = MockCliRunner::with_ok(SIGNED_OUT_JSON);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("Successfully signed out"), "got: {text}");
+        assert!(std::env::var("CS_OAUTH_TOKEN").is_err());
+        assert_eq!(
+            std::env::var("CS_OAUTH_EXPIRES_AT").ok().as_deref(),
+            Some("0")
+        );
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+    }
+
+    #[tokio::test]
+    async fn logout_notes_pat_when_still_configured() {
+        let _g = set_token("pat-still-here");
+        let cli = MockCliRunner::with_ok(SIGNED_OUT_JSON);
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("CS_ACCESS_TOKEN is still configured"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn logout_reports_cli_error_but_clears_local_state() {
+        let _g = clear_token();
+        std::env::set_var("CS_OAUTH_TOKEN", "oau-stale");
+        std::env::set_var("CS_OAUTH_EXPIRES_AT", "9999999999");
+        let cli = MockCliRunner::with_err(1, "connection refused");
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("CLI logout reported an error"), "got: {text}");
+        assert!(text.contains("cs auth logout"), "got: {text}");
+        assert!(std::env::var("CS_OAUTH_TOKEN").is_err());
+        assert_eq!(
+            std::env::var("CS_OAUTH_EXPIRES_AT").ok().as_deref(),
+            Some("0")
+        );
+        std::env::remove_var("CS_OAUTH_EXPIRES_AT");
+    }
+}

--- a/src/tools/logout.rs
+++ b/src/tools/logout.rs
@@ -109,4 +109,22 @@ mod tests {
         );
         std::env::remove_var("CS_OAUTH_EXPIRES_AT");
     }
+
+    #[tokio::test]
+    async fn logout_cli_error_notes_pat_when_still_configured() {
+        let _g = set_token("pat-still-here");
+        let cli = MockCliRunner::with_err(1, "connection refused");
+        let server = make_server_with_mocks(false, cli, MockHttpClient::new(vec![]));
+        let result = handle(&server, params()).await.unwrap();
+        let text = result_text(&result);
+        assert!(text.contains("CLI logout reported an error"), "got: {text}");
+        assert!(
+            text.contains("CS_ACCESS_TOKEN is still configured"),
+            "got: {text}"
+        );
+        assert!(
+            text.contains("Remove it to fully stop using that credential"),
+            "got: {text}"
+        );
+    }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -19,6 +19,7 @@ pub mod list_technical_debt_goals_for_project_file;
 pub mod list_technical_debt_hotspots_for_project;
 pub mod list_technical_debt_hotspots_for_project_file;
 pub mod login;
+pub mod logout;
 pub mod pre_commit_code_health_safeguard;
 pub mod rules_config;
 pub mod rules_config_list_thresholds;
@@ -34,6 +35,10 @@ pub mod verify_installation;
 /// Parameters for the `login` tool (currently accepts no arguments).
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct LoginParam {}
+
+/// Parameters for the `logout` tool (currently accepts no arguments).
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct LogoutParam {}
 
 /// Optional context parameter used by explain tools.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1093,6 +1093,16 @@ fn test_pat_takes_precedence_over_oauth() {
     tests::oauth_login::test_pat_takes_precedence_over_oauth();
 }
 
+#[test]
+fn test_logout_clears_oauth_after_login() {
+    tests::oauth_login::test_logout_clears_oauth_after_login();
+}
+
+#[test]
+fn test_logout_notes_pat_still_configured() {
+    tests::oauth_login::test_logout_notes_pat_still_configured();
+}
+
 // --- OAuth Login Flow (real CLI + mock IdP, host-only) ---
 #[test]
 fn test_oauth_authorization_code_flow_persists_token() {

--- a/tests/e2e/tests/enabled_tools.rs
+++ b/tests/e2e/tests/enabled_tools.rs
@@ -117,6 +117,10 @@ pub fn test_all_tools_without_filter() {
         assert!(names.contains("login"), "login should be listed outside Docker");
     }
     assert!(
+        names.contains("logout"),
+        "logout should be listed (including Docker)"
+    );
+    assert!(
         names.len() >= 10,
         "Expected >= 10 tools, found {}",
         names.len()
@@ -142,6 +146,10 @@ pub fn test_all_tools_without_filter() {
             "login prompt should be listed outside Docker"
         );
     }
+    assert!(
+        prompt_names.contains("logout"),
+        "logout prompt should be listed (including Docker)"
+    );
 }
 
 #[test]
@@ -166,6 +174,7 @@ pub fn test_filter_restricts_tools() {
     );
     assert!(names.contains("get_config"), "get_config always listed");
     assert!(names.contains("set_config"), "set_config always listed");
+    assert!(names.contains("logout"), "logout always listed (including Docker)");
     if is_docker() {
         assert!(
             !names.contains("login"),
@@ -173,8 +182,8 @@ pub fn test_filter_restricts_tools() {
         );
         assert_eq!(
             names.len(),
-            4,
-            "Expected exactly 4 tools in Docker, found {}: {:?}",
+            5,
+            "Expected exactly 5 tools in Docker, found {}: {:?}",
             names.len(),
             names
         );
@@ -182,8 +191,8 @@ pub fn test_filter_restricts_tools() {
         assert!(names.contains("login"), "login always listed outside Docker");
         assert_eq!(
             names.len(),
-            5,
-            "Expected exactly 5 tools, found {}: {:?}",
+            6,
+            "Expected exactly 6 tools, found {}: {:?}",
             names.len(),
             names
         );

--- a/tests/e2e/tests/oauth_login.rs
+++ b/tests/e2e/tests/oauth_login.rs
@@ -108,6 +108,13 @@ fn main() {
             println!("{resp}");
             process::exit(0);
         }
+        (Some("auth"), Some("logout")) => {
+            let resp = env::var("FAKE_AUTH_LOGOUT_RESPONSE").unwrap_or_else(|_| {
+                r#"{"status":"signed_out","access-token":null,"api-url":null}"#.to_string()
+            });
+            println!("{resp}");
+            process::exit(0);
+        }
         (Some("review"), _) => {
             println!(r#"{{"score":9.5,"review":[]}}"#);
             process::exit(0);
@@ -252,6 +259,13 @@ fn call_login(client: &mut MCPClient) -> String {
     let response = client
         .call_tool("login", json!({}), Duration::from_secs(30))
         .expect("login call should succeed");
+    extract_result_text(&response)
+}
+
+fn call_logout(client: &mut MCPClient) -> String {
+    let response = client
+        .call_tool("logout", json!({}), Duration::from_secs(30))
+        .expect("logout call should succeed");
     extract_result_text(&response)
 }
 
@@ -523,5 +537,93 @@ pub fn test_pat_takes_precedence_over_oauth() {
     assert!(
         log.is_empty(),
         "CLI auth endpoints should not be called when PAT is configured, got log: {log}"
+    );
+}
+
+/// After a successful login, `logout` must call CLI logout, clear OAuth config
+/// (with signed-out sentinel), and leave subsequent tools unauthenticated.
+pub fn test_logout_clears_oauth_after_login() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let login_resp = signed_in_json("logout-me-token", 3600);
+    let t = oauth_setup(&[
+        ("FAKE_AUTH_TOKEN_RESPONSE", SIGNED_OUT_JSON),
+        ("FAKE_AUTH_LOGIN_RESPONSE", login_resp.as_str()),
+    ]);
+    let mut client = start_client(&t);
+
+    let login_result = call_login(&mut client);
+    assert!(
+        login_result.contains("Successfully signed in"),
+        "got: {login_result}"
+    );
+    let config = read_config(&t.config_dir);
+    assert_eq!(config["oauth_token"].as_str(), Some("logout-me-token"));
+
+    let logout_result = call_logout(&mut client);
+    assert!(
+        logout_result.contains("Successfully signed out"),
+        "got: {logout_result}"
+    );
+
+    let config = read_config(&t.config_dir);
+    assert!(
+        config.get("oauth_token").is_none(),
+        "oauth_token should be cleared, got: {config}"
+    );
+    assert_eq!(
+        config["oauth_expires_at"].as_str(),
+        Some("0"),
+        "signed-out sentinel should be set, got: {config}"
+    );
+
+    let log = std::fs::read_to_string(&t.call_log_path).unwrap_or_default();
+    assert!(
+        log.contains("auth logout"),
+        "CLI auth logout should be called, got log: {log}"
+    );
+
+    let score = call_score(&mut client, &t.repo_dir);
+    assert!(
+        score.contains("No access token configured") || score.contains("login"),
+        "after logout, tools should report missing auth, got: {score}"
+    );
+}
+
+/// Logout with a PAT still configured clears OAuth state and notes that the
+/// PAT remains in effect.
+pub fn test_logout_notes_pat_still_configured() {
+    if is_docker() {
+        return skip_if_docker("fake CLI binary not available in container");
+    }
+    let t = oauth_setup(&[("CS_ACCESS_TOKEN", "pat-token")]);
+    seed_config(
+        &t.config_dir,
+        json!({
+            "instance_id": "test-instance-id",
+            "oauth_token": "stale-oauth-token",
+            "oauth_expires_at": (now_epoch() + 3600).to_string(),
+        }),
+    );
+    let mut client = start_client(&t);
+
+    let result = call_logout(&mut client);
+    assert!(
+        result.contains("CS_ACCESS_TOKEN is still configured"),
+        "got: {result}"
+    );
+
+    let config = read_config(&t.config_dir);
+    assert!(
+        config.get("oauth_token").is_none(),
+        "oauth_token should be cleared even when PAT is set, got: {config}"
+    );
+    assert_eq!(config["oauth_expires_at"].as_str(), Some("0"));
+
+    let log = std::fs::read_to_string(&t.call_log_path).unwrap_or_default();
+    assert!(
+        log.contains("auth logout"),
+        "CLI auth logout should still be called, got log: {log}"
     );
 }

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -19,6 +19,7 @@ Once installed, the following tools become available in VS Code's agent mode.
 | Tool | Description |
 |------|-------------|
 | `login` | Sign in to CodeScene with OAuth (opens browser) |
+| `logout` | Sign out of CodeScene OAuth and clear the stored session |
 | `get_config` | Read current server configuration |
 | `set_config` | Write a configuration value |
 | `verify_installation` | Diagnose setup issues |
@@ -67,9 +68,9 @@ These tools require OAuth or a CodeScene Personal Access Token and a CodeScene C
 
 ### Authentication
 
-**Recommended (interactive):** OAuth via the `login` MCP prompt / `login` tool, or **CodeScene: Sign In**. No token to copy or paste.
+**Recommended (interactive):** OAuth via the `login` MCP prompt / `login` tool, or **CodeScene: Sign In**. No token to copy or paste. Sign out with the `logout` prompt / tool, or **CodeScene: Sign Out**.
 
-**Optional (CI / headless):** Set a Personal Access Token or standalone license via `CodeScene: Configure Access Token (optional / CI)` or the `codescene.accessToken` setting. A saved PAT **blocks** OAuth until you clear it.
+**Optional (CI / headless):** Set a Personal Access Token or standalone license via `CodeScene: Configure Access Token (optional / CI)` or the `codescene.accessToken` setting. A saved PAT **blocks** OAuth until you clear it. Sign Out clears OAuth only — remove the PAT separately if needed.
 
 - **OAuth / Personal Access Token** — Full tool set, including project-level features.
 - **Standalone access token** — Local Code Health analysis only (scoring, review, refactoring).
@@ -96,6 +97,7 @@ See [Configuration Options](https://github.com/codescene-oss/codescene-mcp-serve
 | Prompt | Description |
 |--------|-------------|
 | `login` | Sign in to CodeScene with OAuth (instructs the agent to call the `login` tool) |
+| `logout` | Sign out of CodeScene OAuth (instructs the agent to call the `logout` tool) |
 | `review_code_health` | Review Code Health for the current file |
 | `plan_code_health_refactoring` | Plan a prioritized, low-risk Code Health refactoring |
 
@@ -104,6 +106,7 @@ In Copilot Chat, pick these from the slash-command / prompt picker (MCP prompts 
 ## Commands
 
 - `CodeScene: Sign In` — Start the OAuth browser login flow
+- `CodeScene: Sign Out` — Clear the stored OAuth session
 - `CodeScene: Configure Access Token (optional / CI)` — Set or clear a PAT/standalone token
 - `CodeScene: Restart MCP Server` — Restart the MCP server (after config changes)
 - `CodeScene: Show Server Status` — Display current server status and configuration

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -104,6 +104,10 @@
         "title": "CodeScene: Sign In"
       },
       {
+        "command": "codescene.signOut",
+        "title": "CodeScene: Sign Out"
+      },
+      {
         "command": "codescene.configure",
         "title": "CodeScene: Configure Access Token (optional / CI)"
       },

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -62,6 +62,11 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand('codescene.signIn', () => runSignIn(context, didChangeEmitter))
     );
 
+    // Command: Sign out of OAuth
+    context.subscriptions.push(
+        vscode.commands.registerCommand('codescene.signOut', () => runSignOut(context, didChangeEmitter))
+    );
+
     // Command: Configure access token (optional PAT / CI fallback)
     context.subscriptions.push(
         vscode.commands.registerCommand('codescene.configure', async () => {
@@ -219,6 +224,23 @@ function handleAuthResult(
 }
 
 /**
+ * Handles the JSON result from the logout subprocess.
+ */
+function handleLogoutResult(
+    stdout: string,
+    didChangeEmitter: vscode.EventEmitter<void>,
+): void {
+    const result = JSON.parse(stdout.trim());
+    if (result.status === 'signed_out') {
+        vscode.window.showInformationMessage('CodeScene: Successfully signed out!');
+        didChangeEmitter.fire();
+    } else {
+        vscode.window.showWarningMessage(`CodeScene: Sign out incomplete — ${result.error || result.status}`);
+        didChangeEmitter.fire();
+    }
+}
+
+/**
  * Runs the OAuth sign-in flow by spawning `cs-mcp auth`.
  */
 async function runSignIn(
@@ -257,6 +279,51 @@ async function runSignIn(
                         handleAuthResult(stdout, didChangeEmitter);
                     } catch {
                         vscode.window.showInformationMessage('CodeScene: Sign in completed.');
+                        didChangeEmitter.fire();
+                    }
+                }
+                resolve();
+            });
+        }),
+    );
+}
+
+/**
+ * Runs OAuth sign-out by spawning `cs-mcp logout`.
+ */
+async function runSignOut(
+    context: vscode.ExtensionContext,
+    didChangeEmitter: vscode.EventEmitter<void>,
+) {
+    const binaryPath = getBinaryPath(context);
+    if (!binaryPath) {
+        vscode.window.showErrorMessage('CodeScene: Binary not available for this platform.');
+        return;
+    }
+
+    const config = vscode.workspace.getConfiguration('codescene');
+    const onpremUrl = (config.get<string>('onpremUrl', '') || '').trim();
+    const accountId = optionalIdString(config.get<string>('accountId', ''));
+    const env = buildAuthEnv(onpremUrl, accountId);
+
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title: 'CodeScene: Signing out...',
+            cancellable: false,
+        },
+        () => new Promise<void>((resolve) => {
+            execFile(binaryPath, ['logout'], { env }, (error, stdout, stderr) => {
+                if (error) {
+                    vscode.window.showErrorMessage(
+                        `CodeScene: Sign out failed — ${stderr?.trim() || stdout?.trim() || error.message}`,
+                    );
+                    didChangeEmitter.fire();
+                } else {
+                    try {
+                        handleLogoutResult(stdout, didChangeEmitter);
+                    } catch {
+                        vscode.window.showInformationMessage('CodeScene: Sign out completed.');
                         didChangeEmitter.fire();
                     }
                 }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -226,7 +226,7 @@ function authFlowLabel(kind: AuthSubprocessKind): string {
 }
 
 /**
- * Handles JSON stdout from `cs-mcp auth` / `cs-mcp logout`.
+ * Handles JSON stdout from `cs-mcp auth` / `cs-mcp auth logout`.
  */
 function handleAuthSubprocessResult(
     stdout: string,
@@ -311,14 +311,15 @@ const AUTH_FLOWS: Record<AuthSubprocessKind, Omit<AuthFlowOptions, 'kind'>> = {
         successStatuses: ['signed_in', 'already_signed_in'],
     },
     'sign-out': {
-        args: ['logout'],
+        // Mirrors `cs auth logout` via the bundled binary: `cs-mcp auth logout`.
+        args: ['auth', 'logout'],
         resolveOnpremUrl: async (config) => (config.get<string>('onpremUrl', '') || '').trim(),
         alwaysRefresh: true,
         successStatuses: ['signed_out'],
     },
 };
 
-/** Runs `cs-mcp auth` or `cs-mcp logout` for the given flow kind. */
+/** Runs `cs-mcp auth` or `cs-mcp auth logout` for the given flow kind. */
 async function runAuthCommand(
     context: vscode.ExtensionContext,
     didChangeEmitter: vscode.EventEmitter<void>,

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -59,12 +59,14 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Command: Sign in via OAuth (opens browser)
     context.subscriptions.push(
-        vscode.commands.registerCommand('codescene.signIn', () => runSignIn(context, didChangeEmitter))
+        vscode.commands.registerCommand('codescene.signIn', () =>
+            runAuthCommand(context, didChangeEmitter, 'sign-in'))
     );
 
     // Command: Sign out of OAuth
     context.subscriptions.push(
-        vscode.commands.registerCommand('codescene.signOut', () => runSignOut(context, didChangeEmitter))
+        vscode.commands.registerCommand('codescene.signOut', () =>
+            runAuthCommand(context, didChangeEmitter, 'sign-out'))
     );
 
     // Command: Configure access token (optional PAT / CI fallback)
@@ -163,7 +165,7 @@ async function showFirstRunPrompt(
     await context.globalState.update(FIRST_RUN_KEY, true);
 
     if (choice === signIn) {
-        await runSignIn(context, didChangeEmitter);
+        await runAuthCommand(context, didChangeEmitter, 'sign-in');
     }
 }
 
@@ -207,48 +209,55 @@ function buildAuthEnv(onpremUrl: string, accountId: string): Record<string, stri
     return env;
 }
 
+type AuthSubprocessKind = 'sign-in' | 'sign-out';
+
+interface AuthFlowOptions {
+    kind: AuthSubprocessKind;
+    args: string[];
+    /** Return `undefined` to abort (e.g. user cancelled the on-prem prompt). */
+    resolveOnpremUrl: (config: vscode.WorkspaceConfiguration) => Promise<string | undefined>;
+    /** When true, always refresh MCP definitions after the subprocess finishes. */
+    alwaysRefresh: boolean;
+    successStatuses: string[];
+}
+
+function authFlowLabel(kind: AuthSubprocessKind): string {
+    return kind === 'sign-in' ? 'Sign in' : 'Sign out';
+}
+
 /**
- * Handles the JSON result from the auth subprocess.
+ * Handles JSON stdout from `cs-mcp auth` / `cs-mcp logout`.
  */
-function handleAuthResult(
+function handleAuthSubprocessResult(
     stdout: string,
     didChangeEmitter: vscode.EventEmitter<void>,
+    options: Pick<AuthFlowOptions, 'kind' | 'successStatuses' | 'alwaysRefresh'>,
 ): void {
     const result = JSON.parse(stdout.trim());
-    if (result.status === 'signed_in' || result.status === 'already_signed_in') {
-        vscode.window.showInformationMessage('CodeScene: Successfully signed in!');
+    if (options.successStatuses.includes(result.status)) {
+        const successVerb = options.kind === 'sign-in' ? 'signed in' : 'signed out';
+        vscode.window.showInformationMessage(`CodeScene: Successfully ${successVerb}!`);
         didChangeEmitter.fire();
-    } else {
-        vscode.window.showWarningMessage(`CodeScene: Sign in incomplete — ${result.error || result.status}`);
+        return;
+    }
+    vscode.window.showWarningMessage(
+        `CodeScene: ${authFlowLabel(options.kind)} incomplete — ${result.error || result.status}`,
+    );
+    if (options.alwaysRefresh) {
+        didChangeEmitter.fire();
     }
 }
 
 /**
- * Handles the JSON result from the logout subprocess.
+ * Resolves on-prem URL / account env, then spawns a bundled auth subcommand.
  */
-function handleLogoutResult(
-    stdout: string,
-    didChangeEmitter: vscode.EventEmitter<void>,
-): void {
-    const result = JSON.parse(stdout.trim());
-    if (result.status === 'signed_out') {
-        vscode.window.showInformationMessage('CodeScene: Successfully signed out!');
-        didChangeEmitter.fire();
-    } else {
-        vscode.window.showWarningMessage(`CodeScene: Sign out incomplete — ${result.error || result.status}`);
-        didChangeEmitter.fire();
-    }
-}
-
-/**
- * Runs the OAuth sign-in flow by spawning `cs-mcp auth`.
- */
-async function runSignIn(
+async function runAuthFlow(
     context: vscode.ExtensionContext,
     didChangeEmitter: vscode.EventEmitter<void>,
-) {
+    options: AuthFlowOptions,
+): Promise<void> {
     const config = vscode.workspace.getConfiguration('codescene');
-    const onpremUrl = await resolveOnpremUrl(config);
+    const onpremUrl = await options.resolveOnpremUrl(config);
     if (onpremUrl === undefined) {
         return;
     }
@@ -261,24 +270,30 @@ async function runSignIn(
 
     const accountId = optionalIdString(config.get<string>('accountId', ''));
     const env = buildAuthEnv(onpremUrl, accountId);
+    const label = authFlowLabel(options.kind);
+    const progressTitle = `CodeScene: ${options.kind === 'sign-in' ? 'Signing in' : 'Signing out'}...`;
+    const completedMessage = `CodeScene: ${label} completed.`;
 
     await vscode.window.withProgress(
         {
             location: vscode.ProgressLocation.Notification,
-            title: 'CodeScene: Signing in...',
+            title: progressTitle,
             cancellable: false,
         },
         () => new Promise<void>((resolve) => {
-            execFile(binaryPath, ['auth'], { env }, (error, stdout, stderr) => {
+            execFile(binaryPath, options.args, { env }, (error, stdout, stderr) => {
                 if (error) {
                     vscode.window.showErrorMessage(
-                        `CodeScene: Sign in failed — ${stderr?.trim() || stdout?.trim() || error.message}`,
+                        `CodeScene: ${label} failed — ${stderr?.trim() || stdout?.trim() || error.message}`,
                     );
+                    if (options.alwaysRefresh) {
+                        didChangeEmitter.fire();
+                    }
                 } else {
                     try {
-                        handleAuthResult(stdout, didChangeEmitter);
+                        handleAuthSubprocessResult(stdout, didChangeEmitter, options);
                     } catch {
-                        vscode.window.showInformationMessage('CodeScene: Sign in completed.');
+                        vscode.window.showInformationMessage(completedMessage);
                         didChangeEmitter.fire();
                     }
                 }
@@ -288,49 +303,28 @@ async function runSignIn(
     );
 }
 
-/**
- * Runs OAuth sign-out by spawning `cs-mcp logout`.
- */
-async function runSignOut(
+const AUTH_FLOWS: Record<AuthSubprocessKind, Omit<AuthFlowOptions, 'kind'>> = {
+    'sign-in': {
+        args: ['auth'],
+        resolveOnpremUrl,
+        alwaysRefresh: false,
+        successStatuses: ['signed_in', 'already_signed_in'],
+    },
+    'sign-out': {
+        args: ['logout'],
+        resolveOnpremUrl: async (config) => (config.get<string>('onpremUrl', '') || '').trim(),
+        alwaysRefresh: true,
+        successStatuses: ['signed_out'],
+    },
+};
+
+/** Runs `cs-mcp auth` or `cs-mcp logout` for the given flow kind. */
+async function runAuthCommand(
     context: vscode.ExtensionContext,
     didChangeEmitter: vscode.EventEmitter<void>,
+    kind: AuthSubprocessKind,
 ) {
-    const binaryPath = getBinaryPath(context);
-    if (!binaryPath) {
-        vscode.window.showErrorMessage('CodeScene: Binary not available for this platform.');
-        return;
-    }
-
-    const config = vscode.workspace.getConfiguration('codescene');
-    const onpremUrl = (config.get<string>('onpremUrl', '') || '').trim();
-    const accountId = optionalIdString(config.get<string>('accountId', ''));
-    const env = buildAuthEnv(onpremUrl, accountId);
-
-    await vscode.window.withProgress(
-        {
-            location: vscode.ProgressLocation.Notification,
-            title: 'CodeScene: Signing out...',
-            cancellable: false,
-        },
-        () => new Promise<void>((resolve) => {
-            execFile(binaryPath, ['logout'], { env }, (error, stdout, stderr) => {
-                if (error) {
-                    vscode.window.showErrorMessage(
-                        `CodeScene: Sign out failed — ${stderr?.trim() || stdout?.trim() || error.message}`,
-                    );
-                    didChangeEmitter.fire();
-                } else {
-                    try {
-                        handleLogoutResult(stdout, didChangeEmitter);
-                    } catch {
-                        vscode.window.showInformationMessage('CodeScene: Sign out completed.');
-                        didChangeEmitter.fire();
-                    }
-                }
-                resolve();
-            });
-        }),
-    );
+    await runAuthFlow(context, didChangeEmitter, { kind, ...AUTH_FLOWS[kind] });
 }
 
 /**

--- a/vscode/tests/extension.test.js
+++ b/vscode/tests/extension.test.js
@@ -71,8 +71,8 @@ describe('activate', () => {
         const ctx = makeContext();
         extension.activate(ctx);
 
-        // status bar + provider + 3 commands + config watcher = 6
-        assert.equal(ctx.subscriptions.length, 7);
+        // status bar + provider + 5 commands + config watcher = 8
+        assert.equal(ctx.subscriptions.length, 8);
     });
 
     it('registers MCP server definition provider with id codesceneMcp', () => {
@@ -83,11 +83,12 @@ describe('activate', () => {
         assert.equal(state.registeredProviders[0].id, 'codesceneMcp');
     });
 
-    it('registers four commands', () => {
+    it('registers five commands', () => {
         const ctx = makeContext();
         extension.activate(ctx);
 
         assert.ok(state.registeredCommands['codescene.signIn']);
+        assert.ok(state.registeredCommands['codescene.signOut']);
         assert.ok(state.registeredCommands['codescene.configure']);
         assert.ok(state.registeredCommands['codescene.restart']);
         assert.ok(state.registeredCommands['codescene.showStatus']);
@@ -550,5 +551,78 @@ describe('codescene.signIn command', () => {
         const { options } = state.execFileCalls[0];
         assert.equal(options.env['CS_ONPREM_URL'], 'https://cs.co');
         assert.equal(options.env['CS_ACCOUNT_ID'], '42');
+    });
+});
+
+describe('codescene.signOut command', () => {
+    beforeEach(() => { reset(); });
+    afterEach(() => {
+        if (existsSync(FAKE_EXT_PATH)) {
+            rmSync(FAKE_EXT_PATH, { recursive: true, force: true });
+        }
+    });
+
+    function setupBinary(ctx) {
+        const binDir = join(ctx.extensionPath, 'bin');
+        mkdirSync(binDir, { recursive: true });
+        const binaryName = process.platform === 'darwin' && process.arch === 'arm64'
+            ? 'cs-mcp-macos-aarch64'
+            : process.platform === 'linux' ? 'cs-mcp-linux-amd64' : 'cs-mcp-windows-amd64.exe';
+        writeFileSync(join(binDir, binaryName), '#!/bin/sh\necho {}');
+    }
+
+    async function invokeSignOut({ execResult, configOverrides } = {}) {
+        if (execResult) state.execFileResult = execResult;
+        if (configOverrides) Object.assign(state.configValues, configOverrides);
+        const ctx = makeContext();
+        setupBinary(ctx);
+        extension.activate(ctx);
+        const handler = findCommand('codescene.signOut');
+        await handler();
+    }
+
+    it('shows error when binary is not available', async () => {
+        const ctx = makeContext({ extensionPath: '/nonexistent' });
+        extension.activate(ctx);
+        const handler = findCommand('codescene.signOut');
+        await handler();
+
+        const errorMsg = state.shownErrors.find(m => m.message.includes('Binary not available'));
+        assert.ok(errorMsg, 'expected binary not available error');
+    });
+
+    it('shows success message on signed_out result', async () => {
+        await invokeSignOut({ execResult: { error: null, stdout: '{"status":"signed_out"}', stderr: '' } });
+
+        const msg = state.shownInfoMessages.find(m => m.message.includes('Successfully signed out'));
+        assert.ok(msg, 'expected success message');
+        assert.equal(state.execFileCalls.length, 1);
+        assert.deepEqual(state.execFileCalls[0].args, ['logout']);
+    });
+
+    it('shows warning on incomplete logout', async () => {
+        await invokeSignOut({
+            execResult: { error: null, stdout: '{"status":"error","error":"connection refused"}', stderr: '' },
+        });
+
+        const msg = state.shownWarnings.find(m => m.message.includes('Sign out incomplete'));
+        assert.ok(msg, 'expected warning message');
+    });
+
+    it('shows error message on execFile failure', async () => {
+        await invokeSignOut({
+            execResult: { error: new Error('spawn failed'), stdout: '', stderr: 'timeout' },
+        });
+
+        const msg = state.shownErrors.find(m => m.message.includes('Sign out failed'));
+        assert.ok(msg, 'expected error message');
+        assert.ok(msg.message.includes('timeout'), 'expected stderr in message');
+    });
+
+    it('handles unparseable stdout gracefully', async () => {
+        await invokeSignOut({ execResult: { error: null, stdout: 'not json', stderr: '' } });
+
+        const msg = state.shownInfoMessages.find(m => m.message.includes('Sign out completed'));
+        assert.ok(msg, 'expected fallback success message');
     });
 });

--- a/vscode/tests/extension.test.js
+++ b/vscode/tests/extension.test.js
@@ -597,7 +597,7 @@ describe('codescene.signOut command', () => {
         const msg = state.shownInfoMessages.find(m => m.message.includes('Successfully signed out'));
         assert.ok(msg, 'expected success message');
         assert.equal(state.execFileCalls.length, 1);
-        assert.deepEqual(state.execFileCalls[0].args, ['logout']);
+        assert.deepEqual(state.execFileCalls[0].args, ['auth', 'logout']);
     });
 
     it('shows warning on incomplete logout', async () => {


### PR DESCRIPTION
## Summary
- Add always-available `logout` MCP tool and `logout` prompt that run `cs auth logout` and persist the signed-out sentinel so OAuth cannot be silently refreshed
- Add `cs-mcp logout` CLI subcommand and VS Code **CodeScene: Sign Out** command (mirrors Sign In)
- Leave PAT / on-prem / account settings intact; document logout across auth docs, tools, skills, and the VS Code extension

## Test plan
- [x] Unit tests covering `AuthManager::logout`, logout tool, prompt listing, and always-enabled tool filtering
- [x] VS Code extension tests for `codescene.signOut`
- [x] E2E: login then logout clears `oauth_token` / sets `oauth_expires_at=0` and logs `auth logout`
- [x] E2E: logout with PAT notes that `CS_ACCESS_TOKEN` remains configured
- [x] Manual: Sign In then Sign Out from Command Palette; confirm agent `logout` tool clears session