### PR TITLE
CS-12003 Make extension publishing retry-safe

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -182,7 +182,7 @@ jobs:
           npm install -g @vscode/vsce
           for file in ./vsix-artifacts/*.vsix; do
             echo "Publishing ${file} to VS Code Marketplace"
-            vsce publish --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}"
+            vsce publish --skip-duplicate --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}"
           done
 
       - name: Publish to Open VSX
@@ -193,5 +193,5 @@ jobs:
           npm install -g ovsx
           for file in ./vsix-artifacts/*.vsix; do
             echo "Publishing ${file} to Open VSX"
-            ovsx publish --pat "$OPEN_VSX_PUBLISHING_TOKEN" --packagePath "${file}"
+            ovsx publish --skip-duplicate --pat "$OPEN_VSX_PUBLISHING_TOKEN" --packagePath "${file}"
           done

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -67,7 +67,7 @@ jobs:
           npm install -g @vscode/vsce
           for file in ./vsix-artifacts/*.vsix; do
             echo "Publishing ${file} to VS Code Marketplace"
-            vsce publish --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}"
+            vsce publish --skip-duplicate --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}"
           done
 
       - name: Publish to Open VSX
@@ -78,5 +78,5 @@ jobs:
           npm install -g ovsx
           for file in ./vsix-artifacts/*.vsix; do
             echo "Publishing ${file} to Open VSX"
-            ovsx publish --pat "$OPEN_VSX_PUBLISHING_TOKEN" --packagePath "${file}"
+            ovsx publish --skip-duplicate --pat "$OPEN_VSX_PUBLISHING_TOKEN" --packagePath "${file}"
           done


### PR DESCRIPTION
## Summary
- make automatic VS Code Marketplace and Open VSX publication tolerate already-published platform packages
- apply the same retry behavior to the manual recovery workflow
- allow MCP-1.5.0 publication to continue past existing macOS packages and publish Windows/Linux/Open VSX artifacts

## Root cause
The MCP-1.5.0 extension workflow stopped on the first VS Code Marketplace duplicate (`darwin-arm64`), so later platform packages and the Open VSX step never ran.

## Verification
- confirmed `--skip-duplicate` support in both `vsce publish` and `ovsx publish`
- `git diff --check`
- CodeScene pre-commit safeguard: passed (workflow YAML is not Code Health eligible)