### PR TITLE
CS-12003 Retry extension platforms independently

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -182,7 +182,15 @@ jobs:
           npm install -g @vscode/vsce
           for file in ./vsix-artifacts/*.vsix; do
             echo "Publishing ${file} to VS Code Marketplace"
-            vsce publish --skip-duplicate --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}"
+            if output=$(vsce publish --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}" 2>&1); then
+              echo "$output"
+            elif [[ "$output" == *"already exists"* ]]; then
+              echo "$output"
+              echo "Package already exists; continuing with remaining platforms."
+            else
+              echo "$output" >&2
+              exit 1
+            fi
           done
 
       - name: Publish to Open VSX

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -67,7 +67,15 @@ jobs:
           npm install -g @vscode/vsce
           for file in ./vsix-artifacts/*.vsix; do
             echo "Publishing ${file} to VS Code Marketplace"
-            vsce publish --skip-duplicate --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}"
+            if output=$(vsce publish --pat "$VSCODE_MARKETPLACE_PUBLISHING_TOKEN" --packagePath "${file}" 2>&1); then
+              echo "$output"
+            elif [[ "$output" == *"already exists"* ]]; then
+              echo "$output"
+              echo "Package already exists; continuing with remaining platforms."
+            else
+              echo "$output" >&2
+              exit 1
+            fi
           done
 
       - name: Publish to Open VSX


### PR DESCRIPTION
## Summary
- handle VS Code Marketplace duplicate errors per platform instead of using `--skip-duplicate`
- continue past existing macOS packages while still publishing missing Linux and Windows packages
- preserve hard failures for all non-duplicate Marketplace errors
- apply the same recovery behavior to automatic and manual publishing workflows

## Context
`vsce --skip-duplicate` treats an extension version as globally published. During the MCP-1.5.0 recovery it therefore skipped Linux and Windows after finding existing macOS packages.

## Verification
- validated the shell loop with `bash -n`
- `git diff --check`
- CodeScene safeguard passed (workflow YAML is not Code Health eligible)