### PR TITLE
Fix flaky OAuth E2E socket reads

### DIFF
--- a/tests/e2e/tests/fake_oauth_server.rs
+++ b/tests/e2e/tests/fake_oauth_server.rs
@@ -107,7 +107,14 @@ impl Drop for FakeOAuthServer {
 fn accept_loop(listener: TcpListener, ctx: ServerCtx) {
     while !*ctx.shutdown.lock().unwrap() {
         match listener.accept() {
-            Ok((mut stream, _)) => serve_connection(&mut stream, &ctx),
+            Ok((mut stream, _)) => {
+                // Accepted sockets inherit the listener's nonblocking mode on Windows.
+                // Reads must block so a request arriving just after accept is not discarded.
+                stream
+                    .set_nonblocking(false)
+                    .expect("set OAuth connection blocking");
+                serve_connection(&mut stream, &ctx);
+            }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 thread::sleep(Duration::from_millis(20));
             }


### PR DESCRIPTION
## Problem

The fake OAuth server sets its listener to nonblocking mode. On Windows, accepted sockets inherit the listener properties, so an immediate read can return `WouldBlock`. The mock treated every read error as end-of-request and closed the connection without an HTTP response. This intermittently surfaced as `HTTP/1.1 header parser received no bytes`.

## Fix

Explicitly restore blocking mode on each accepted OAuth connection before applying the request read timeout.

## Verification

- isolated `test_oauth_authorization_code_flow_persists_token` passes
- Code Health safeguard passes