### PR TITLE
CS-12053 Keep Copilot discovery fallback connection alive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,10 +289,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1928,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -1950,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [dependencies]
 # MCP SDK
-rmcp = { version = "1.4", features = ["server", "macros", "transport-io"] }
+rmcp = { version = "1.8", features = ["server", "macros", "transport-io"] }
 
 # Async runtime
 tokio = { version = "1", features = ["macros", "rt", "io-std", "sync", "time", "process", "fs"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ mod startup;
 mod test_utils;
 mod tools;
 mod tracking;
+mod transport;
 mod version_checker;
 
 #[cfg(test)]
@@ -45,6 +46,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content, Meta};
 use rmcp::schemars::{self, JsonSchema};
 use rmcp::service::ServerInitializeError;
+use rmcp::transport::IntoTransport;
 use rmcp::{tool, tool_router, ErrorData, ServiceExt};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -778,7 +780,9 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Covered by e2e test: test_shutdown_during_handshake.py
-    let Some(service) = serve_or_handle_disconnect(server, rmcp::transport::stdio()).await? else {
+    let stdio = rmcp::transport::stdio().into_transport();
+    let transport = transport::DiscoveryFallbackTransport::new(stdio);
+    let Some(service) = serve_or_handle_disconnect(server, transport).await? else {
         return Ok(());
     };
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -364,6 +364,16 @@ mod tests {
         .unwrap()
     }
 
+    fn server_discover_request_message() -> ClientJsonRpcMessage {
+        serde_json::from_value(json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "server/discover",
+            "params": {}
+        }))
+        .unwrap()
+    }
+
     fn initialized_notification_message() -> ClientJsonRpcMessage {
         serde_json::from_value(json!({
             "jsonrpc": "2.0",
@@ -1452,6 +1462,42 @@ mod tests {
 
         let close_result = service.close().await;
         assert!(close_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn server_discover_falls_back_to_initialize_on_same_connection() {
+        let transport = ScriptedTransport::from_messages(vec![
+            server_discover_request_message(),
+            initialize_request_message(),
+            initialized_notification_message(),
+        ]);
+        let sent = transport.sent.clone();
+        let server = make_server(false);
+
+        let mut service = crate::serve_or_handle_disconnect(
+            server,
+            crate::transport::DiscoveryFallbackTransport::new(transport),
+        )
+        .await
+        .unwrap()
+        .expect("expected initialized service");
+
+        let messages: Vec<serde_json::Value> = sent
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|message| serde_json::to_value(message).unwrap())
+            .collect();
+        assert_eq!(
+            (
+                &messages[0]["id"],
+                &messages[0]["error"]["code"],
+                messages.iter().any(|message| message.get("result").is_some()),
+            ),
+            (&json!(0), &json!(-32601), true)
+        );
+
+        service.close().await.unwrap();
     }
 
     #[test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,60 @@
+use rmcp::model::{ClientJsonRpcMessage, ErrorCode, ErrorData, ServerJsonRpcMessage};
+use rmcp::service::RoleServer;
+use rmcp::transport::Transport;
+
+const SERVER_DISCOVER_METHOD: &str = "server/discover";
+
+pub(crate) struct DiscoveryFallbackTransport<T> {
+    inner: T,
+    awaiting_initialize: bool,
+}
+
+impl<T> DiscoveryFallbackTransport<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
+            inner,
+            awaiting_initialize: true,
+        }
+    }
+}
+
+impl<T> Transport<RoleServer> for DiscoveryFallbackTransport<T>
+where
+    T: Transport<RoleServer>,
+{
+    type Error = T::Error;
+
+    fn send(
+        &mut self,
+        item: ServerJsonRpcMessage,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send + 'static {
+        self.inner.send(item)
+    }
+
+    async fn receive(&mut self) -> Option<ClientJsonRpcMessage> {
+        loop {
+            let message = self.inner.receive().await?;
+            let ClientJsonRpcMessage::Request(request) = &message else {
+                return Some(message);
+            };
+            if !self.awaiting_initialize || request.request.method() != SERVER_DISCOVER_METHOD {
+                self.awaiting_initialize &= request.request.method() != "initialize";
+                return Some(message);
+            }
+
+            let error = ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None);
+            if self
+                .inner
+                .send(ServerJsonRpcMessage::error(error, request.id.clone()))
+                .await
+                .is_err()
+            {
+                return Some(message);
+            }
+        }
+    }
+
+    fn close(&mut self) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.close()
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -45,7 +45,7 @@ where
             let error = ErrorData::new(ErrorCode::METHOD_NOT_FOUND, "Method not found", None);
             if self
                 .inner
-                .send(ServerJsonRpcMessage::error(error, request.id.clone()))
+                .send(ServerJsonRpcMessage::error(error, Some(request.id.clone())))
                 .await
                 .is_err()
             {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -701,6 +701,12 @@ fn test_mcp_usage_overview_tool_and_resource() {
     tests::mcp_usage_overview::test_usage_tool_and_resource();
 }
 
+// --- Discovery Fallback ---
+#[test]
+fn test_server_discover_falls_back_without_exiting() {
+    tests::discovery_fallback::test_server_discover_falls_back_without_exiting();
+}
+
 // --- Shutdown During Handshake ---
 #[test]
 fn test_stdin_closed_before_any_input() {

--- a/tests/e2e/tests/discovery_fallback.rs
+++ b/tests/e2e/tests/discovery_fallback.rs
@@ -1,0 +1,28 @@
+//! Integration test for clients that probe server capabilities before initialization.
+//!
+//! Validates that an unsupported `server/discover` request receives a standard
+//! JSON-RPC error without terminating the process, allowing initialization and
+//! subsequent tool requests to succeed on the same stdio connection.
+
+use super::*;
+
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub fn test_server_discover_falls_back_without_exiting() {
+    let (command, env, repo_dir, _tmp) = setup();
+    let mut client = make_client(&command, &env, &repo_dir);
+    assert!(client.start(), "Server should start");
+
+    let discovery = client
+        .send_request("server/discover", json!({}), RESPONSE_TIMEOUT)
+        .expect("server/discover should receive an error response");
+    assert_eq!(discovery["error"]["code"], json!(-32601));
+
+    client
+        .initialize()
+        .expect("Initialize should succeed after server/discover");
+    let tools = client
+        .send_request("tools/list", json!({}), RESPONSE_TIMEOUT)
+        .expect("Server should remain available after initialization");
+    assert!(tools["result"]["tools"].as_array().is_some_and(|tools| !tools.is_empty()));
+}

--- a/tests/e2e/tests/mod.rs
+++ b/tests/e2e/tests/mod.rs
@@ -39,6 +39,7 @@ pub mod bundled_docs;
 pub mod business_case;
 pub mod cloudfront_headers;
 pub mod configure;
+pub mod discovery_fallback;
 pub mod docker_path_translation;
 pub mod enabled_tools;
 pub mod error_logging;


### PR DESCRIPTION
## Summary
- intercept pre-initialization `server/discover` probes and return JSON-RPC `METHOD_NOT_FOUND`
- keep the stdio transport alive so GitHub Copilot CLI can fall back to `initialize`
- upgrade `rmcp` and `rmcp-macros` from 1.4/1.6 to 1.8
- add unit and process-level E2E regression coverage for the complete fallback flow

## Verification
- `cargo test` (823 unit tests and 168 E2E tests passed; existing stress test ignored)
- fresh release binary: `cargo clean --profile release && cargo test --test e2e` (168 passed; existing stress test ignored)
- real GitHub Copilot CLI 1.0.83 handshake reached `CodeScene MCP server ready` and `client initialized`
- CodeScene pre-commit safeguard passed
- CodeScene branch change-set quality gates passed

## Notes
- `cargo clippy --all-targets -- -D warnings` remains blocked by the pre-existing `build.rs:187` `needless_range_loop` warning.